### PR TITLE
Fix `boost` link

### DIFF
--- a/scripts/install_deps.ps1
+++ b/scripts/install_deps.ps1
@@ -16,7 +16,7 @@ if ( -not (Test-Path "$PSScriptRoot\..\deps\boost") ) {
 
   # FIXME: The default user agent results in Artifactory treating Invoke-WebRequest as a browser
   # and serving it a page that requires JavaScript.
-  Invoke-WebRequest -URI "https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.zip" -OutFile boost.zip -UserAgent ""
+  Invoke-WebRequest -URI "https://archives.boost.io/release/1.83.0/source/boost_1_83_0.zip" -OutFile boost.zip -UserAgent ""
   if ((Get-FileHash boost.zip).Hash -ne "c86bd9d9eef795b4b0d3802279419fde5221922805b073b9bd822edecb1ca28e") {
     throw 'Downloaded Boost source package has wrong checksum.'
   }


### PR DESCRIPTION
This PR introduces the following:
1. Since the earlier link for downloading the `boost` dependencies for Windows has been deprecated according to [this](https://github.com/boostorg/boost/issues/996) discussion, this PR replaces the old/deprecated link with the [new](https://archives.boost.io/release/1.83.0/source/boost_1_83_0.zip) link.