### PR TITLE
fix: change terminal message from `solc` to `ssolc`

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -823,7 +823,7 @@ void CommandLineInterface::processInput()
 
 void CommandLineInterface::printVersion()
 {
-	sout() << "solc, the solidity compiler commandline interface" << std::endl;
+	sout() << "ssolc, the seismic solidity compiler commandline interface" << std::endl;
 	sout() << "Version: " << solidity::frontend::VersionString << std::endl;
 }
 


### PR DESCRIPTION
This PR introduces the following:
1. Changes the terminal/CLI message when `ssolc --version` is run from `solc, the solidity compiler commandline interface` to `ssolc, the seismic solidity compiler commandline interface`