### PR TITLE
fix: make binary releases work on the repo itself

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - seismic
+            - ameya/fix-release
 
 jobs:
     build-and-release:
@@ -103,15 +104,17 @@ jobs:
         needs: build-and-release
         runs-on: ubuntu-latest
         permissions:
-            contents: write # Needed for creating releases in the same repo
+            contents: write 
 
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
             - name: Download All Artifacts
               uses: actions/download-artifact@v4
               with:
                   path: artifacts/
 
-            # Create release using built-in GITHUB_TOKEN
             - name: Create Release
               env:
                   GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - seismic
-            - ameya/fix-release
 
 jobs:
     build-and-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         needs: build-and-release
         runs-on: ubuntu-latest
         permissions:
-            contents: write 
+            contents: write
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
This PR introduces the following:
1. Fixes to successfully build and push binary releases in the repo.