### PR TITLE
feat: add support for shielded fixed-size byte arrays (#32)

### DIFF
--- a/docs/grammar/SolidityLexer.g4
+++ b/docs/grammar/SolidityLexer.g4
@@ -77,6 +77,14 @@ Returns: 'returns';
 Revert: 'revert'; // not a real keyword
 ShieldedAddress: 'saddress';
 /**
+ * Shielded bytes types of fixed length.
+ */
+ShieldedFixedBytes:
+	'sbytes1' | 'sbytes2' | 'sbytes3' | 'sbytes4' | 'sbytes5' | 'sbytes6' | 'sbytes7' | 'sbytes8' |
+	'sbytes9' | 'sbytes10' | 'sbytes11' | 'sbytes12' | 'sbytes13' | 'sbytes14' | 'sbytes15' | 'sbytes16' |
+	'sbytes17' | 'sbytes18' | 'sbytes19' | 'sbytes20' | 'sbytes21' | 'sbytes22' | 'sbytes23' | 'sbytes24' |
+	'sbytes25' | 'sbytes26' | 'sbytes27' | 'sbytes28' | 'sbytes29' | 'sbytes30' | 'sbytes31' | 'sbytes32';
+/**
  * Sized shieled unsigned integer types.
  * suint is an alias of suint256.
  */

--- a/liblangutil/Token.cpp
+++ b/liblangutil/Token.cpp
@@ -75,6 +75,11 @@ void ElementaryTypeNameToken::assertDetails(Token _baseType, unsigned const& _fi
 		solAssert(_second == 0, "There should not be a second size argument to type bytesM.");
 		solAssert(_first <= 32, "No elementary type bytes" + std::to_string(_first) + ".");
 	}
+	else if (_baseType == Token::SBytesM)
+	{
+		solAssert(_second == 0, "There should not be a second size argument to type sbytesM.");
+		solAssert(_first <= 32, "No elementary type sbytes" + std::to_string(_first) + ".");
+	}
 	else if (_baseType == Token::UIntM || _baseType == Token::IntM || _baseType == Token::SUIntM || _baseType == Token::SIntM)
 	{
 		solAssert(_second == 0, "There should not be a second size argument to type " + std::string(TokenTraits::toString(_baseType)) + ".");
@@ -191,6 +196,11 @@ std::tuple<Token, unsigned int, unsigned int> fromIdentifierOrKeyword(std::strin
 		{
 			if (0 < m && m <= 32 && positionX == _literal.end())
 				return std::make_tuple(Token::BytesM, m, 0);
+		}
+		else if (keyword == Token::SBytes)
+		{
+			if (0 < m && m <= 32 && positionX == _literal.end())
+				return std::make_tuple(Token::SBytesM, m, 0);
 		}
 		else if (keyword == Token::UInt || keyword == Token::Int || keyword == Token::SUInt || keyword == Token::SInt)
 		{

--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -211,6 +211,7 @@ namespace solidity::langutil
 	K(SUInt, "suint", 0)											   \
 	K(SInt, "sint", 0)                                                 \
 	K(Bytes, "bytes", 0)                                               \
+	K(SBytes, "sbytes", 0)                                             \
 	K(String, "string", 0)                                             \
 	K(Address, "address", 0)                                           \
 	K(SAddress, "saddress", 0)                                  \
@@ -223,6 +224,7 @@ namespace solidity::langutil
 	T(SIntM, "sintM", 0)                                               \
 	T(SUIntM, "suintM", 0)                                             \
 	T(BytesM, "bytesM", 0)                                             \
+	T(SBytesM, "sbytesM", 0)                                           \
 	T(FixedMxN, "fixedMxN", 0)                                         \
 	T(UFixedMxN, "ufixedMxN", 0)                                       \
 	T(TypesEnd, nullptr, 0) /* used as type enum end marker */         \

--- a/libsolidity/ast/TypeProvider.cpp
+++ b/libsolidity/ast/TypeProvider.cpp
@@ -220,6 +220,41 @@ std::array<std::unique_ptr<ShieldedIntegerType>, 32> const TypeProvider::m_suint
 	{std::make_unique<ShieldedIntegerType>(8 * 32, ShieldedIntegerType::Modifier::Unsigned)}
 }};
 
+std::array<std::unique_ptr<ShieldedFixedBytesType>, 32> const TypeProvider::m_sbytesM{{
+	{std::make_unique<ShieldedFixedBytesType>(1)},
+	{std::make_unique<ShieldedFixedBytesType>(2)},
+	{std::make_unique<ShieldedFixedBytesType>(3)},
+	{std::make_unique<ShieldedFixedBytesType>(4)},
+	{std::make_unique<ShieldedFixedBytesType>(5)},
+	{std::make_unique<ShieldedFixedBytesType>(6)},
+	{std::make_unique<ShieldedFixedBytesType>(7)},
+	{std::make_unique<ShieldedFixedBytesType>(8)},
+	{std::make_unique<ShieldedFixedBytesType>(9)},
+	{std::make_unique<ShieldedFixedBytesType>(10)},
+	{std::make_unique<ShieldedFixedBytesType>(11)},
+	{std::make_unique<ShieldedFixedBytesType>(12)},
+	{std::make_unique<ShieldedFixedBytesType>(13)},
+	{std::make_unique<ShieldedFixedBytesType>(14)},
+	{std::make_unique<ShieldedFixedBytesType>(15)},
+	{std::make_unique<ShieldedFixedBytesType>(16)},
+	{std::make_unique<ShieldedFixedBytesType>(17)},
+	{std::make_unique<ShieldedFixedBytesType>(18)},
+	{std::make_unique<ShieldedFixedBytesType>(19)},
+	{std::make_unique<ShieldedFixedBytesType>(20)},
+	{std::make_unique<ShieldedFixedBytesType>(21)},
+	{std::make_unique<ShieldedFixedBytesType>(22)},
+	{std::make_unique<ShieldedFixedBytesType>(23)},
+	{std::make_unique<ShieldedFixedBytesType>(24)},
+	{std::make_unique<ShieldedFixedBytesType>(25)},
+	{std::make_unique<ShieldedFixedBytesType>(26)},
+	{std::make_unique<ShieldedFixedBytesType>(27)},
+	{std::make_unique<ShieldedFixedBytesType>(28)},
+	{std::make_unique<ShieldedFixedBytesType>(29)},
+	{std::make_unique<ShieldedFixedBytesType>(30)},
+	{std::make_unique<ShieldedFixedBytesType>(31)},
+	{std::make_unique<ShieldedFixedBytesType>(32)}
+}};
+
 std::array<std::unique_ptr<MagicType>, 5> const TypeProvider::m_magics{{
 	{std::make_unique<MagicType>(MagicType::Kind::Block)},
 	{std::make_unique<MagicType>(MagicType::Kind::Message)},
@@ -268,6 +303,7 @@ void TypeProvider::reset()
 	clearCaches(instance().m_suintM);
 	clearCaches(instance().m_sintM);
 	clearCaches(instance().m_bytesM);
+	clearCaches(instance().m_sbytesM);
 	clearCaches(instance().m_magics);
 	instance().m_generalTypes.clear();
 	instance().m_stringLiteralTypes.clear();
@@ -302,6 +338,8 @@ Type const* TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken const& 
 		return shieldedInteger(m, ShieldedIntegerType::Modifier::Unsigned);
 	case Token::SIntM:
 		return shieldedInteger(m, ShieldedIntegerType::Modifier::Signed);
+	case Token::SBytesM:
+		return shieldedFixedBytes(m);
 	case Token::Byte:
 		return byte();
 	case Token::BytesM:

--- a/libsolidity/ast/TypeProvider.h
+++ b/libsolidity/ast/TypeProvider.h
@@ -68,6 +68,9 @@ public:
 
 	static FixedBytesType const* byte() { return fixedBytes(1); }
 	static FixedBytesType const* fixedBytes(unsigned m) { return m_bytesM.at(m - 1).get(); }
+	
+	static ShieldedFixedBytesType const* shieldedByte() { return shieldedFixedBytes(1); }
+	static ShieldedFixedBytesType const* shieldedFixedBytes(unsigned m) { return m_sbytesM.at(m - 1).get(); }
 
 	static ArrayType const* bytesStorage();
 	static ArrayType const* bytesMemory();
@@ -247,6 +250,7 @@ private:
 	static std::array<std::unique_ptr<ShieldedIntegerType>, 32> const m_suintM;
 	static std::array<std::unique_ptr<ShieldedIntegerType>, 32> const m_sintM;
 	static std::array<std::unique_ptr<FixedBytesType>, 32> const m_bytesM;
+	static std::array<std::unique_ptr<ShieldedFixedBytesType>, 32> const m_sbytesM;
 	static std::array<std::unique_ptr<MagicType>, 5> const m_magics;        ///< MagicType's except MetaType
 
 	std::map<std::pair<unsigned, unsigned>, std::unique_ptr<FixedPointType>> m_ufixedMxN{};

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1160,6 +1160,13 @@ BoolResult RationalNumberType::isExplicitlyConvertibleTo(Type const& _convertTo)
 	auto category = _convertTo.category();
 	if (category == Category::FixedBytes)
 		return false;
+	else if (category == Category::ShieldedFixedBytes)
+	{
+		if (isFractional())
+			return false;
+		ShieldedFixedBytesType const& targetType = dynamic_cast<ShieldedFixedBytesType const&>(_convertTo);
+		return (m_value == 0) || (!isNegative() && integerType() && (integerType()->numBits() <= targetType.numBytes() * 8));
+	}
 	else if (auto addressType = dynamic_cast<AddressType const*>(&_convertTo))
 		return (m_value == 0) ||
 			((addressType->stateMutability() != StateMutability::Payable) &&

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -838,6 +838,39 @@ BoolResult ShieldedIntegerType::isExplicitlyConvertibleTo(Type const& _convertTo
 	return false;
 }
 
+BoolResult ShieldedFixedBytesType::isImplicitlyConvertibleTo(Type const& _convertTo) const
+{
+	if (_convertTo.category() != category())
+		return false;
+	ShieldedFixedBytesType const& convertTo = dynamic_cast<ShieldedFixedBytesType const&>(_convertTo);
+	return convertTo.m_bytes >= m_bytes;
+}
+
+BoolResult ShieldedFixedBytesType::isExplicitlyConvertibleTo(Type const& _convertTo) const
+{
+	if (_convertTo.category() == category())
+		return true;
+	else if (auto integerType = dynamic_cast<ShieldedIntegerType const*>(&_convertTo))
+		return (!integerType->isSigned() && integerType->numBits() == numBytes() * 8);
+	else if (auto addressType = dynamic_cast<ShieldedAddressType const*>(&_convertTo))
+		return
+			(addressType->stateMutability() != StateMutability::Payable) &&
+			(numBytes() == 20);
+	else if (auto fixedBytesType = dynamic_cast<FixedBytesType const*>(&_convertTo))
+		return true;
+	return false;
+}
+
+std::string ShieldedFixedBytesType::richIdentifier() const
+{
+	return "t_sbytes" + std::to_string(m_bytes);
+}
+
+std::string ShieldedFixedBytesType::toString(bool) const
+{
+	return "sbytes" + util::toString(m_bytes);
+}
+
 
 FixedPointType::FixedPointType(unsigned _totalBits, unsigned _fractionalDigits, FixedPointType::Modifier _modifier):
 	m_totalBits(_totalBits), m_fractionalDigits(_fractionalDigits), m_modifier(_modifier)

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -857,7 +857,7 @@ BoolResult ShieldedFixedBytesType::isExplicitlyConvertibleTo(Type const& _conver
 			(addressType->stateMutability() != StateMutability::Payable) &&
 			(numBytes() == 20);
 	else if (auto fixedBytesType = dynamic_cast<FixedBytesType const*>(&_convertTo))
-		return true;
+		return numBytes() == fixedBytesType->numBytes();
 	return false;
 }
 
@@ -1494,6 +1494,8 @@ BoolResult FixedBytesType::isExplicitlyConvertibleTo(Type const& _convertTo) con
 			(numBytes() == 20);
 	else if (auto fixedPointType = dynamic_cast<FixedPointType const*>(&_convertTo))
 		return fixedPointType->numBits() == numBytes() * 8;
+	else if (auto shieldedFixedBytesType = dynamic_cast<ShieldedFixedBytesType const*>(&_convertTo))
+		return numBytes() == shieldedFixedBytesType->numBytes();
 
 	return false;
 }

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -190,6 +190,7 @@ public:
 		Array,
 		ArraySlice,
 		FixedBytes,
+		ShieldedFixedBytes,
 		Contract,
 		Struct,
 		Function,
@@ -782,6 +783,39 @@ public:
 
 private:
 	unsigned m_bytes;
+};
+
+/**
+ * A shielded fixed-size byte array type.
+ */
+class ShieldedFixedBytesType: public FixedBytesType
+{
+public:
+	explicit ShieldedFixedBytesType(unsigned _bytes): FixedBytesType(_bytes), m_bytes(_bytes)
+	{
+		solAssert(
+			m_bytes > 0 && m_bytes <= 32,
+			"Invalid byte number for shielded fixed bytes type: " + util::toString(m_bytes)
+		);
+	}
+
+	virtual unsigned storageBytes() const override { return 32; }
+	bool isShielded() const override { return true; }
+	Category category() const override { return Category::ShieldedFixedBytes; }
+
+	virtual BoolResult isImplicitlyConvertibleTo(Type const& _convertTo) const override;
+	virtual BoolResult isExplicitlyConvertibleTo(Type const& _convertTo) const override;
+	
+	std::string richIdentifier() const override;
+	std::string toString(bool _withoutDataLocation) const override;
+	
+	unsigned numBytes() const { return m_bytes; }
+	
+	Type const* encodingType() const override { return this; }
+	TypeResult interfaceType(bool) const override { return this; }
+
+private:
+	unsigned const m_bytes;
 };
 
 /**

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -835,8 +835,45 @@ void CompilerUtils::convertType(
 		else
 		{
 			// clear for conversion to longer bytes
-			solAssert(targetTypeCategory == Type::Category::FixedBytes, "Invalid type conversion requested.");
-			FixedBytesType const& targetType = dynamic_cast<FixedBytesType const&>(_targetType);
+			solAssert(targetTypeCategory == Type::Category::FixedBytes || targetTypeCategory == Type::Category::ShieldedFixedBytes, "Invalid type conversion requested.");
+			FixedBytesType const& targetType = (targetTypeCategory == Type::Category::FixedBytes) ?
+				dynamic_cast<FixedBytesType const&>(_targetType) :
+				dynamic_cast<ShieldedFixedBytesType const&>(_targetType);
+			if (typeOnStack.numBytes() == 0 || targetType.numBytes() == 0)
+				m_context << Instruction::POP << u256(0);
+			else if (targetType.numBytes() > typeOnStack.numBytes() || _cleanupNeeded)
+			{
+				unsigned bytes = std::min(typeOnStack.numBytes(), targetType.numBytes());
+				m_context << ((u256(1) << (256 - bytes * 8)) - 1);
+				m_context << Instruction::NOT << Instruction::AND;
+			}
+		}
+		break;
+	}
+	case Type::Category::ShieldedFixedBytes:
+	{
+		ShieldedFixedBytesType const& typeOnStack = dynamic_cast<ShieldedFixedBytesType const&>(_typeOnStack);
+		if (targetTypeCategory == Type::Category::Integer || targetTypeCategory==Type::Category::ShieldedInteger)
+		{
+			// conversion from bytes to integer. no need to clean the high bit
+			// only to shift right because of opposite alignment
+			IntegerType const& targetIntegerType = dynamic_cast<IntegerType const&>(_targetType);
+			rightShiftNumberOnStack(256 - typeOnStack.numBytes() * 8);
+			if (targetIntegerType.numBits() < typeOnStack.numBytes() * 8)
+				convertType(IntegerType(typeOnStack.numBytes() * 8), _targetType, _cleanupNeeded);
+		}
+		else if (targetTypeCategory == Type::Category::Address || targetTypeCategory == Type::Category::ShieldedAddress)
+		{
+			solAssert(typeOnStack.numBytes() * 8 == 160);
+			rightShiftNumberOnStack(256 - 160);
+		}
+		else
+		{
+			// clear for conversion to longer bytes
+			solAssert(targetTypeCategory == Type::Category::FixedBytes || targetTypeCategory == Type::Category::ShieldedFixedBytes, "Invalid type conversion requested.");
+			FixedBytesType const& targetType = (targetTypeCategory == Type::Category::FixedBytes) ?
+				dynamic_cast<FixedBytesType const&>(_targetType) :
+				dynamic_cast<ShieldedFixedBytesType const&>(_targetType);
 			if (typeOnStack.numBytes() == 0 || targetType.numBytes() == 0)
 				m_context << Instruction::POP << u256(0);
 			else if (targetType.numBytes() > typeOnStack.numBytes() || _cleanupNeeded)
@@ -870,7 +907,7 @@ void CompilerUtils::convertType(
 	case Type::Category::Contract:
 	case Type::Category::RationalNumber:
 	case Type::Category::ShieldedInteger:
-		if (targetTypeCategory == Type::Category::FixedBytes)
+		if (targetTypeCategory == Type::Category::FixedBytes || targetTypeCategory == Type::Category::ShieldedFixedBytes)
 		{
 			solAssert(
 				(stackTypeCategory == Type::Category::Address ||
@@ -882,7 +919,9 @@ void CompilerUtils::convertType(
 			);
 			// conversion from bytes to string. no need to clean the high bit
 			// only to shift left because of opposite alignment
-			FixedBytesType const& targetBytesType = dynamic_cast<FixedBytesType const&>(_targetType);
+			FixedBytesType const& targetBytesType = (targetTypeCategory == Type::Category::FixedBytes) ?
+				dynamic_cast<FixedBytesType const&>(_targetType) :
+				dynamic_cast<ShieldedFixedBytesType const&>(_targetType);
 			if (auto typeOnStack = dynamic_cast<IntegerType const*>(&_typeOnStack))
 			{
 				if (targetBytesType.numBytes() * 8 > typeOnStack->numBits())
@@ -926,7 +965,8 @@ void CompilerUtils::convertType(
 				targetTypeCategory == Type::Category::Integer ||
 				targetTypeCategory == Type::Category::Contract ||
 				targetTypeCategory == Type::Category::Address || targetTypeCategory == Type::Category::ShieldedAddress ||
-				targetTypeCategory == Type::Category::ShieldedInteger,
+				targetTypeCategory == Type::Category::ShieldedInteger ||
+				targetTypeCategory == Type::Category::FixedBytes || targetTypeCategory == Type::Category::ShieldedFixedBytes,
 				""
 			);
 			IntegerType addressType(160);

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -4034,6 +4034,22 @@ std::string YulUtilFunctions::cleanupFunction(Type const& _type)
 			}
 			break;
 		}
+		case Type::Category::ShieldedFixedBytes:
+		{
+			ShieldedFixedBytesType const& type = dynamic_cast<ShieldedFixedBytesType const&>(_type);
+			if (type.numBytes() == 32)
+				templ("body", "cleaned := value");
+			else if (type.numBytes() == 0)
+				// This is disallowed in the type system.
+				solAssert(false, "");
+			else
+			{
+				size_t numBits = type.numBytes() * 8;
+				u256 mask = ((u256(1) << numBits) - 1) << (256 - numBits);
+				templ("body", "cleaned := and(value, " + toCompactHexWithPrefix(mask) + ")");
+			}
+			break;
+		}
 		case Type::Category::Contract:
 		{
 			AddressType addressType(dynamic_cast<ContractType const&>(_type).isPayable() ?

--- a/test/libsolidity/semanticTests/types/basic.sol
+++ b/test/libsolidity/semanticTests/types/basic.sol
@@ -3,6 +3,6 @@ contract C {
 
         return true;
     }
-
+}
 // ----
 // basic() -> true

--- a/test/libsolidity/semanticTests/types/sbytes_basic.sol
+++ b/test/libsolidity/semanticTests/types/sbytes_basic.sol
@@ -1,0 +1,36 @@
+contract C {
+    function basic() public pure returns(bool) {
+        // Test basic sbytes declarations and assignments
+        sbytes1 sb1 = sbytes1(0x01);
+        require(sb1 == sbytes1(0x01));
+        
+        sbytes8 sb8 = sbytes8(0x0102030405060708);
+        require(sb8 == sbytes8(0x0102030405060708));
+        
+        sbytes32 sb32 = sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+        require(sb32 == sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132));
+        
+        return true;
+    }
+    
+    function conversions() public pure returns(bool) {
+        // Test conversions between sbytes and bytes
+        sbytes1 sb1 = sbytes1(0x01);
+        bytes1 b1 = bytes1(sb1);
+        require(b1 == bytes1(0x01));
+        
+        sbytes8 sb8 = sbytes8(0x0102030405060708);
+        bytes8 b8 = bytes8(sb8);
+        require(b8 == bytes8(0x0102030405060708));
+        
+        // Test conversions from bytes to sbytes
+        bytes1 b1_orig = bytes1(0xFF);
+        sbytes1 sb1_conv = sbytes1(b1_orig);
+        require(sb1_conv == sbytes1(0xFF));
+        
+        return true;
+    }
+}
+// ----
+// basic() -> true
+// conversions() -> true

--- a/test/libsolidity/semanticTests/types/sbytes_storage.sol
+++ b/test/libsolidity/semanticTests/types/sbytes_storage.sol
@@ -1,0 +1,28 @@
+contract C {
+    sbytes1 stored_sb1;
+    sbytes8 stored_sb8;
+    sbytes32 stored_sb32;
+    
+    function set_values() public {
+        stored_sb1 = sbytes1(0x01);
+        stored_sb8 = sbytes8(0x0102030405060708);
+        stored_sb32 = sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+    }
+    
+    function get_values() public view returns(sbytes1, sbytes8, sbytes32) {
+        return (stored_sb1, stored_sb8, stored_sb32);
+    }
+    
+    function test_storage() public returns(bool) {
+        set_values();
+        (sbytes1 sb1, sbytes8 sb8, sbytes32 sb32) = get_values();
+        
+        require(sb1 == sbytes1(0x01));
+        require(sb8 == sbytes8(0x0102030405060708));
+        require(sb32 == sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132));
+        
+        return true;
+    }
+}
+// ----
+// test_storage() -> true

--- a/test/libsolidity/semanticTests/types/suint.sol
+++ b/test/libsolidity/semanticTests/types/suint.sol
@@ -1,0 +1,8 @@
+contract C {
+    function basic() public pure returns(bool) {
+
+        return true;
+    }
+
+// ----
+// basic() -> true

--- a/test/libsolidity/syntaxTests/types/sbytes_arrays.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_arrays.sol
@@ -1,0 +1,33 @@
+contract C {
+    function test() internal pure {
+        // Test sbytes arrays
+        sbytes1[3] memory arr1;
+        sbytes8[5] memory arr8;
+        sbytes32[2] memory arr32;
+        
+        // Test array assignments
+        arr1[suint256(0)] = sbytes1(0x01);
+        arr8[suint256(1)] = sbytes8(0x0102030405060708);
+        arr32[suint256(0)] = sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+
+        // Test array access
+        sbytes1 val1 = arr1[suint256(0)];
+        sbytes8 val8 = arr8[suint256(1)];
+        sbytes32 val32 = arr32[suint256(0)];
+
+        // Test dynamic arrays
+        sbytes1[] memory dynArr1 = new sbytes1[](suint256(0));
+        sbytes8[] memory dynArr8 = new sbytes8[](suint256(2));
+        //sbytes32[] memory dynArr32 = new sbytes32[](suint256(1));
+        //
+        //dynArr1[0] = sbytes1(0xFF);
+        //dynArr8[0] = sbytes8(0xFFFFFFFFFFFFFFFF);
+        //dynArr32[0] = sbytes32(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+    }
+}
+// ----
+// Warning 2072: (465-477): Unused local variable.
+// Warning 2072: (507-519): Unused local variable.
+// Warning 2072: (549-563): Unused local variable.
+// Warning 2072: (626-650): Unused local variable.
+// Warning 2072: (689-713): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/sbytes_basic_declarations.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_basic_declarations.sol
@@ -1,0 +1,20 @@
+contract C {
+    sbytes1 sb1;
+    sbytes2 sb2;
+    sbytes3 sb3;
+    sbytes4 sb4;
+    sbytes8 sb8;
+    sbytes16 sb16;
+    sbytes20 sb20;
+    sbytes32 sb32;
+    
+    function test() internal pure {
+        sbytes1 local1;
+        sbytes2 local2;
+        sbytes32 local32;
+        local1 = sbytes1(0x01);
+        local2 = sbytes2(0x0102);
+        local32 = sbytes32(0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20);
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/types/sbytes_events_errors.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_events_errors.sol
@@ -1,0 +1,23 @@
+contract C {
+    event DataEvent(sbytes1 id, sbytes8 hash, sbytes32 signature);
+    
+    error DataError(sbytes1 id, sbytes8 hash, sbytes32 signature);
+    
+    function test() internal pure {
+        // Test event emission with sbytes
+        emit DataEvent(
+            sbytes1(0x01),
+            sbytes8(0x0102030405060708),
+            sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132)
+        );
+        
+        // Test error revert with sbytes
+        revert DataError(
+            sbytes1(0xFF),
+            sbytes8(0xFFFFFFFFFFFFFFFF),
+            sbytes32(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+        );
+    }
+}
+// ----
+// TypeError 4626: (33-43): Shielded Types are not allowed as event parameter type.

--- a/test/libsolidity/syntaxTests/types/sbytes_explicit_conversions.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_explicit_conversions.sol
@@ -1,0 +1,22 @@
+
+contract C {
+    function test() internal pure {
+        sbytes1 sb1 = sbytes1(0x01);
+        sbytes8 sb8 = sbytes8(0x0102030405060708);
+        sbytes32 sb32 = sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+        
+        bytes1 b1 = bytes1(0x01);
+        bytes8 b8 = bytes8(0x0102030405060708);
+        bytes32 b32 = bytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+        
+        // Test conversions from sbytes to bytes (explicit conversion allowed)
+        b1 = bytes1(sb1);
+        b8 = bytes8(sb8);
+        b32 = bytes32(sb32);
+        
+        // Test conversions from bytes to sbytes (explicit conversion allowed)
+        sb1 = sbytes1(b1);
+        sb8 = sbytes8(b8);
+        sb32 = sbytes32(b32);
+    }
+}

--- a/test/libsolidity/syntaxTests/types/sbytes_external_function_returns.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_external_function_returns.sol
@@ -1,0 +1,27 @@
+contract C {
+    // Test that sbytes cannot be returned from external functions
+    function externalSbytes1() external pure returns (sbytes1) {
+        return sbytes1(0x01);
+    }
+    
+    function externalSbytes8() external pure returns (sbytes8) {
+        return sbytes8(0x0102030405060708);
+    }
+    
+    function externalSbytes32() external pure returns (sbytes32) {
+        return sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+    }
+    
+    // Test that sbytes cannot be returned from public functions
+    function publicSbytes1() public pure returns (sbytes1) {
+        return sbytes1(0x01);
+    }
+    
+    function publicSbytes8() public pure returns (sbytes8) {
+        return sbytes8(0x0102030405060708);
+    }
+    
+    function publicSbytes32() public pure returns (sbytes32) {
+        return sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+    }
+}

--- a/test/libsolidity/syntaxTests/types/sbytes_function_returns.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_function_returns.sol
@@ -1,0 +1,30 @@
+contract C {
+    function returnSbytes1() internal pure returns (sbytes1) {
+        return sbytes1(0x01);
+    }
+    
+    function returnSbytes8() internal pure returns (sbytes8) {
+        return sbytes8(0x0102030405060708);
+    }
+    
+    function returnSbytes32() internal pure returns (sbytes32) {
+        return sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+    }
+    
+    function test() internal pure {
+        sbytes1 sb1 = returnSbytes1();
+        sbytes8 sb8 = returnSbytes8();
+        sbytes32 sb32 = returnSbytes32();
+        
+        // Test chaining function calls
+        sbytes1 chained = sbytes1(returnSbytes8());
+        sbytes32 expanded = sbytes32(returnSbytes1());
+    }
+}
+
+// ----
+// Warning 2072: (448-459): Unused local variable.
+// Warning 2072: (487-498): Unused local variable.
+// Warning 2072: (526-539): Unused local variable.
+// Warning 2072: (617-632): Unused local variable.
+// Warning 2072: (669-686): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/sbytes_implicit_conversions_fail.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_implicit_conversions_fail.sol
@@ -1,0 +1,28 @@
+contract C {
+    function test() internal pure {
+        sbytes1 sb1 = sbytes1(0x01);
+        sbytes8 sb8 = sbytes8(0x0102030405060708);
+        sbytes32 sb32 = sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+        
+        bytes1 b1 = bytes1(0x01);
+        bytes8 b8 = bytes8(0x0102030405060708);
+        bytes32 b32 = bytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+        
+        // Test implicit conversions from sbytes to bytes (should fail)
+        b1 = sb1;
+        b8 = sb8;
+        b32 = sb32;
+        
+        // Test implicit conversions from bytes to sbytes (should fail)
+        sb1 = b1;
+        sb8 = b8;
+        sb32 = b32;
+    }
+}
+// ----
+// TypeError 7407: (523-526): Type sbytes1 is not implicitly convertible to expected type bytes1.
+// TypeError 7407: (541-544): Type sbytes8 is not implicitly convertible to expected type bytes8.
+// TypeError 7407: (560-564): Type sbytes32 is not implicitly convertible to expected type bytes32.
+// TypeError 7407: (661-663): Type bytes1 is not implicitly convertible to expected type sbytes1.
+// TypeError 7407: (679-681): Type bytes8 is not implicitly convertible to expected type sbytes8.
+// TypeError 7407: (698-701): Type bytes32 is not implicitly convertible to expected type sbytes32.

--- a/test/libsolidity/syntaxTests/types/sbytes_invalid_sizes.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_invalid_sizes.sol
@@ -1,0 +1,6 @@
+contract C {
+    sbytes0 sb0;
+    sbytes1 sb33;
+}
+// ----
+// DeclarationError 7920: (17-24): Identifier not found or not unique.

--- a/test/libsolidity/syntaxTests/types/sbytes_operations.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_operations.sol
@@ -1,0 +1,38 @@
+contract C {
+    function test() internal pure {
+        sbytes1 sb1 = sbytes1(0x01);
+        sbytes8 sb8 = sbytes8(0x0102030405060708);
+        sbytes32 sb32 = sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+        
+        // Test bitwise operations
+        sbytes1 result1 = sb1 & sbytes1(0xFF);
+        sbytes8 result8 = sb8 | sbytes8(0x0F0F0F0F0F0F0F0F);
+        sbytes32 result32 = sb32 ^ sbytes32(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+
+        // Test bitwise NOT
+        sbytes1 not1 = ~sb1;
+        sbytes8 not8 = ~sb8;
+        sbytes32 not32 = ~sb32;
+
+        // Test comparisons
+        bool eq = sb1 == sbytes1(0x01);
+        bool neq = sb8 != sbytes8(0x0000000000000000);
+        bool lt = sb1 < sbytes1(0xFF);
+        bool lte = sb8 <= sbytes8(0xFFFFFFFFFFFFFFFF);
+        bool gt = sb32 > sbytes32(0x0000000000000000000000000000000000000000000000000000000000000000);
+        bool gte = sb32 >= sbytes32(0x0000000000000000000000000000000000000000000000000000000000000000);
+    }
+}
+// ----
+// Warning 2072: (291-306): Unused local variable.
+// Warning 2072: (338-353): Unused local variable.
+// Warning 2072: (399-416): Unused local variable.
+// Warning 2072: (541-553): Unused local variable.
+// Warning 2072: (570-582): Unused local variable.
+// Warning 2072: (599-613): Unused local variable.
+// Warning 2072: (660-667): Unused local variable.
+// Warning 2072: (700-708): Unused local variable.
+// Warning 2072: (755-762): Unused local variable.
+// Warning 2072: (794-802): Unused local variable.
+// Warning 2072: (849-856): Unused local variable.
+// Warning 2072: (952-960): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/sbytes_public_variables.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_public_variables.sol
@@ -1,0 +1,17 @@
+contract C {
+    // Test public sbytes variables - should generate getter functions
+    sbytes1 public sb1;
+    sbytes8 public sb8;
+    sbytes32 public sb32;
+    
+    constructor() {
+        sb1 = sbytes1(0x01);
+        sb8 = sbytes8(0x0102030405060708);
+        sb32 = sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+    }
+}
+
+// ----
+// TypeError 7091: (88-106): Shielded Types are not supported for public state variables.
+// TypeError 7091: (112-130): Shielded Types are not supported for public state variables.
+// TypeError 7091: (136-156): Shielded Types are not supported for public state variables.

--- a/test/libsolidity/syntaxTests/types/sbytes_size_conversions.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_size_conversions.sol
@@ -1,0 +1,21 @@
+contract C {
+    function test() internal pure {
+        sbytes1 sb1 = sbytes1(0x01);
+        sbytes8 sb8 = sbytes8(0x0102030405060708);
+        sbytes32 sb32 = sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+        
+        // Test implicit conversions between sbytes sizes (smaller to larger should work)
+        sb8 = sb1;   // sbytes1 -> sbytes8 (implicit allowed)
+        sb32 = sb1;  // sbytes1 -> sbytes32 (implicit allowed)
+        sb32 = sb8;  // sbytes8 -> sbytes32 (implicit allowed)
+        
+        // Test implicit conversions between sbytes sizes (larger to smaller should fail)
+        sb1 = sb8;   // sbytes8 -> sbytes1 (implicit not allowed)
+        sb1 = sb32;  // sbytes32 -> sbytes1 (implicit not allowed)
+        sb8 = sb32;  // sbytes32 -> sbytes8 (implicit not allowed)
+    }
+}
+// ----
+// TypeError 7407: (639-642): Type sbytes8 is not implicitly convertible to expected type sbytes1.
+// TypeError 7407: (705-709): Type sbytes32 is not implicitly convertible to expected type sbytes1.
+// TypeError 7407: (772-776): Type sbytes32 is not implicitly convertible to expected type sbytes8.

--- a/test/libsolidity/syntaxTests/types/sbytes_storage_locations.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_storage_locations.sol
@@ -1,0 +1,29 @@
+contract C {
+    sbytes1 sb1_storage;
+    sbytes8 sb8_storage;
+    sbytes32 sb32_storage;
+    
+    function test() internal pure {
+        sbytes1 sb1_local;
+        sbytes8 sb8_local;
+        sbytes32 sb32_local;
+        
+        // Type conversions between different sbytes sizes
+        sb1_local = sbytes1(sb8_local);
+        sb8_local = sbytes8(sb32_local);
+        sb32_local = sbytes32(sb1_local);
+        
+        // Function parameters
+        testParams(sb1_local, sb8_local, sb32_local);
+    }
+    
+    function testParams(sbytes1 sb1_param, sbytes8 sb8_param, sbytes32 sb32_param) internal pure {
+        sbytes1 local1 = sb1_param;
+        sbytes8 local8 = sb8_param;
+        sbytes32 local32 = sb32_param;
+    }
+}
+// ----
+// Warning 2072: (617-631): Unused local variable.
+// Warning 2072: (653-667): Unused local variable.
+// Warning 2072: (689-705): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/sbytes_struct.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_struct.sol
@@ -1,0 +1,34 @@
+contract C {
+    struct Data {
+        sbytes1 id;
+        sbytes8 hash;
+        sbytes32 signature;
+        uint256 timestamp;
+    }
+    
+    function test() internal pure {
+        // Test struct with sbytes fields
+        Data memory data;
+        data.id = sbytes1(0x01);
+        data.hash = sbytes8(0x0102030405060708);
+        data.signature = sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+        data.timestamp = 123456789;
+        
+        // Test struct initialization
+        Data memory data2 = Data({
+            id: sbytes1(0xFF),
+            hash: sbytes8(0xFFFFFFFFFFFFFFFF),
+            signature: sbytes32(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF),
+            timestamp: 987654321
+        });
+        
+        // Test struct field access
+        sbytes1 readId = data2.id;
+        sbytes8 readHash = data2.hash;
+        sbytes32 readSig = data2.signature;
+    }
+}
+// ----
+// Warning 2072: (823-837): Unused local variable.
+// Warning 2072: (858-874): Unused local variable.
+// Warning 2072: (897-913): Unused local variable.


### PR DESCRIPTION
This adds support for shielded fixed-size byte arrays `bytes1, bytes2, bytes3, …, bytes32` (#32).

Internally a new type `ShieldedFixedBytesType` is added to the type system, which inherits from `FixedBytesType`.
This is similar to how `ShieldedIntegerType` inherits from `IntegerType`.

Shielded fixed-size byte arrays follow the characteristics of other shielded types:
- they consume an entire storage slot (even if the size is < 32)
- they can't be public
- they can't be returned from a public/external function

Casting behavior:
- `sbytesM` can be explicitly casted to `bytesN` iff `M == N`
- `bytesM` can be explicitly casted to `sbytesN` iff `M == N`
- no implicit casts

