### PR TITLE
Revert "CI/release: mac-osx should build with -DBoost_NO_BOOST_CMAKE=ON"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,7 @@ jobs:
           if [[ "${{ matrix.os }}" == "macos-latest" || "${{ matrix.os }}" == "macos-13" ]]; then
             cmake .. -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
-              -DPEDANTIC=OFF \
-              -DBoost_NO_BOOST_CMAKE=ON
+              -DPEDANTIC=OFF
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" || "${{ matrix.os }}" == "ubuntu-22.04" ]]; then
             cmake .. -DCMAKE_BUILD_TYPE=Release \
               -DPEDANTIC=OFF


### PR DESCRIPTION
Reverts SeismicSystems/seismic-solidity#78