### PR TITLE
feat: shielded array .length method should always return uint

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2137,10 +2137,7 @@ MemberList::MemberMap ArrayType::nativeMembers(ASTNode const*) const
 	MemberList::MemberMap members;
 	if (!isString())
 	{
-		if (containsShieldedType())
-			members.emplace_back("length", TypeProvider::shieldedUint256());
-		else
-			members.emplace_back("length", TypeProvider::uint256());
+		members.emplace_back("length", TypeProvider::uint256());
 		if (isDynamicallySized() && location() == DataLocation::Storage)
 		{
 			Type const* thisAsPointer = TypeProvider::withLocation(this, location(), true);

--- a/test/libsolidity/semanticTests/array/shielded_array_length_type.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_length_type.sol
@@ -1,0 +1,71 @@
+contract C {
+    uint[2] array1;
+
+    suint[2] array2;
+    sint[2] array3;
+
+    suint8[2] array4;
+    sint8[2] array5;
+
+    suint16[2] array6;
+    sint16[2] array7;
+
+    function test_uint_length_type() public returns (uint)
+    {
+        array1[0] = 10;
+        array1[1] = 20;
+        return array1.length;
+    }
+
+    function test_suint_length_type() public returns (uint)
+    {
+        array2[0] = suint(10);
+        array2[1] = suint(20);
+        return array2.length;
+    }
+
+    function test_sint_length_type() public returns (uint)
+    {
+        array3[0] = sint(10);
+        array3[1] = sint(20);
+        return array3.length;
+    }
+
+    function test_suint8_length_type() public returns (uint)
+    {
+        array4[0] = suint8(10);
+        array4[1] = suint8(20);
+        return array4.length;
+    }
+
+    function test_sint8_length_type() public returns (uint)
+    {
+        array5[0] = sint8(10);
+        array5[1] = sint8(20);
+        return array5.length;
+    }
+
+    function test_suint16_length_type() public returns (uint)
+    {
+        array6[0] = suint16(10);
+        array6[1] = suint16(20);
+        return array6.length;
+    }
+
+    function test_sint16_length_type() public returns (uint)
+    {
+        array7[0] = sint16(10);
+        array7[1] = sint16(20);
+        return array7.length;
+    }
+}
+// ----
+// test_uint_length_type(): -> 2
+// test_suint_length_type(): -> 2
+// test_sint_length_type(): -> 2
+// test_suint8_length_type(): -> 2
+// test_sint8_length_type(): -> 2
+// test_suint16_length_type(): -> 2
+// test_sint16_length_type(): -> 2
+
+

--- a/test/libsolidity/semanticTests/array/shielded_array_storage_boundary_test.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_storage_boundary_test.sol
@@ -2,9 +2,9 @@ contract C {
     suint[] storageArray;
     function test_boundary_check(uint256 len, uint256 access) public returns (uint256)
     {
-        while(storageArray.length < suint(len))
+        while(storageArray.length < len)
             storageArray.push();
-        while(storageArray.length > suint(len))
+        while(storageArray.length > len)
             storageArray.pop();
         return uint(storageArray[access]);
     }

--- a/test/libsolidity/semanticTests/array/shielded_array_storage_index_access.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_storage_index_access.sol
@@ -2,9 +2,9 @@ contract C {
     suint[] storageArray;
     function test_indices(uint256 len) public
     {
-        while (storageArray.length < suint(len))
+        while (storageArray.length < len)
             storageArray.push();
-        while (storageArray.length > suint(len))
+        while (storageArray.length > len)
             storageArray.pop();
         for (uint i = 0; i < len; i++)
             storageArray[i] = suint(i) + suint(1);

--- a/test/libsolidity/semanticTests/array/shielded_array_storage_index_zeroed_test.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_storage_index_zeroed_test.sol
@@ -2,9 +2,9 @@ contract C {
     suint[] storageArray;
     function test_zeroed_indices(uint256 len) public
     {
-        while(storageArray.length < suint(len))
+        while(storageArray.length < len)
             storageArray.push();
-        while(storageArray.length > suint(len))
+        while(storageArray.length > len)
             storageArray.pop();
 
         for (uint i = 0; i < len; i++)
@@ -12,9 +12,9 @@ contract C {
 
         if (suint(len) > suint(3))
         {
-            while(storageArray.length > suint(0))
+            while(storageArray.length > 0)
                 storageArray.pop();
-            while(storageArray.length < suint(3))
+            while(storageArray.length < 3)
                 storageArray.push();
 
             for (uint i = 3; i < len; i++)
@@ -31,9 +31,9 @@ contract C {
 
         }
 
-        while(storageArray.length > suint(0))
+        while(storageArray.length > 0)
             storageArray.pop();
-        while(storageArray.length < suint(len))
+        while(storageArray.length < len)
             storageArray.push();
 
         for (uint i = 0; i < len; i++)

--- a/test/libsolidity/semanticTests/array/shielded_array_storage_length_access.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_storage_length_access.sol
@@ -1,22 +1,22 @@
 contract C {
     suint[] storageArray;
-    function set_get_length(suint256 len) public returns (uint256) {
+    function set_get_length(uint256 len) public returns (uint256) {
         while(storageArray.length < len)
             storageArray.push();
         return uint(storageArray.length);
     }
 }
 // ----
-// set_get_length(suint256): 0 -> 0
-// set_get_length(suint256): 1 -> 1
-// set_get_length(suint256): 10 -> 10
-// set_get_length(suint256): 20 -> 20
-// set_get_length(suint256): 0xFF -> 0xFF
+// set_get_length(uint256): 0 -> 0
+// set_get_length(uint256): 1 -> 1
+// set_get_length(uint256): 10 -> 10
+// set_get_length(uint256): 20 -> 20
+// set_get_length(uint256): 0xFF -> 0xFF
 // gas irOptimized: 96690
 // gas legacy: 128571
 // gas legacyOptimized: 110143
-// set_get_length(suint256): 0xFFF -> 0xFFF
+// set_get_length(uint256): 0xFFF -> 0xFFF
 // gas irOptimized: 1209116
 // gas legacy: 1689548
 // gas legacyOptimized: 1393535
-// set_get_length(suint256): 0xFFFFF -> FAILURE # Out-of-gas #
+// set_get_length(uint256): 0xFFFFF -> FAILURE # Out-of-gas #

--- a/test/libsolidity/semanticTests/array/shielded_array_storage_push_empty.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_storage_push_empty.sol
@@ -1,7 +1,7 @@
 contract C {
     suint256[] storageArray;
     function pushEmpty(uint256 len) public {
-        while(storageArray.length < suint(len))
+        while(storageArray.length < len)
             storageArray.push();
 
         for (uint i = 0; i < len; i++)

--- a/test/libsolidity/semanticTests/array/shielded_array_storage_push_empty_length_address.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_storage_push_empty_length_address.sol
@@ -1,6 +1,6 @@
 contract C {
     saddress[] addressArray;
-    function set_get_length(suint256 len) public returns (uint256)
+    function set_get_length(uint256 len) public returns (uint256)
     {
         while(addressArray.length < len)
             addressArray.push();
@@ -12,22 +12,22 @@ contract C {
 // ====
 // EVMVersion: >=Mercury
 // ----
-// set_get_length(suint256): 0 -> 0
-// set_get_length(suint256): 1 -> 1
-// set_get_length(suint256): 10 -> 10
-// set_get_length(suint256): 20 -> 20
-// set_get_length(suint256): 0 -> 0
+// set_get_length(uint256): 0 -> 0
+// set_get_length(uint256): 1 -> 1
+// set_get_length(uint256): 10 -> 10
+// set_get_length(uint256): 20 -> 20
+// set_get_length(uint256): 0 -> 0
 // gas irOptimized: 77628
 // gas legacy: 77730
 // gas legacyOptimized: 77162
-// set_get_length(suint256): 0xFF -> 0xFF
+// set_get_length(uint256): 0xFF -> 0xFF
 // gas irOptimized: 168565
 // gas legacy: 696850
 // gas legacyOptimized: 134488
-// set_get_length(suint256): 0xFFF -> 0xFFF
+// set_get_length(uint256): 0xFFF -> 0xFFF
 // gas irOptimized: 1908127
 // gas legacy: 9857362
 // gas legacyOptimized: 1393660
-// set_get_length(suint256): 0xFFFFF -> FAILURE # Out-of-gas #
+// set_get_length(uint256): 0xFFFFF -> FAILURE # Out-of-gas #
 // gas irOptimized: 100000000
 // gas legacyOptimized: 100000000

--- a/test/libsolidity/semanticTests/array/shielded_array_storage_push_pop.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_storage_push_pop.sol
@@ -1,27 +1,27 @@
 contract C {
     suint[] storageArray;
-    function set_get_length(suint256 len) public returns (uint256) {
+    function set_get_length(uint256 len) public returns (uint256) {
         while(storageArray.length < len)
             storageArray.push();
-        while(storageArray.length > suint(0))
+        while(storageArray.length > 0)
             storageArray.pop();
         return uint(storageArray.length);
     }
 }
 // ----
-// set_get_length(suint256): 0 -> 0
-// set_get_length(suint256): 1 -> 0
-// set_get_length(suint256): 10 -> 0
-// set_get_length(suint256): 20 -> 0
+// set_get_length(uint256): 0 -> 0
+// set_get_length(uint256): 1 -> 0
+// set_get_length(uint256): 10 -> 0
+// set_get_length(uint256): 20 -> 0
 // gas irOptimized: 106222
 // gas legacy: 105722
 // gas legacyOptimized: 103508
-// set_get_length(suint256): 0xFF -> 0
+// set_get_length(uint256): 0xFF -> 0
 // gas irOptimized: 833586
 // gas legacy: 807764
 // gas legacyOptimized: 784467
-// set_get_length(suint256): 0xFFF -> 0
+// set_get_length(uint256): 0xFFF -> FAILURE # Out-of-gas #
 // gas irOptimized: 13029438
 // gas legacy: 12608096
 // gas legacyOptimized: 12239199
-// set_get_length(suint256): 0xFFFF -> FAILURE # Out-of-gas #
+// set_get_length(uint256): 0xFFFF -> FAILURE # Out-of-gas #

--- a/test/libsolidity/semanticTests/array/shielded_array_various_types.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_various_types.sol
@@ -26,7 +26,7 @@ contract ShieldedArrayTest {
 
     // GetShieldedUint in normal Solidity
     function getShieldedUint(uint256 index) external view returns (uint) {
-        require(suint(index) < shieldedUints.length, "Index out of bounds");
+        require(index < shieldedUints.length, "Index out of bounds");
         return uint(shieldedUints[index]);
     }
 
@@ -61,7 +61,7 @@ contract ShieldedArrayTest {
 
     // GetShieldedAddress in normal Solidity
     function getShieldedAddress(uint256 index) external view returns (address) {
-        require(suint(index) < shieldedAddresses.length, "Index out of bounds");
+        require(index < shieldedAddresses.length, "Index out of bounds");
         return address(shieldedAddresses[index]);
     }
 
@@ -89,7 +89,7 @@ contract ShieldedArrayTest {
 
     // GetShieldedBool in normal Solidity
     function getShieldedBool(uint256 index) external view returns (bool) {
-        require(suint(index) < shieldedBools.length, "Index out of bounds");
+        require(index < shieldedBools.length, "Index out of bounds");
         return bool(shieldedBools[index]);
     }
 


### PR DESCRIPTION
Changes:
- The .length method on shielded arrays (suint and sint) will now return uint.
- Adds a test to verify this behavior
- Updates existing tests that expected the length of shielded arrays to be of type suint