### PR TITLE
feat: change type of shielded array constructor length from suint to uint

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3123,10 +3123,9 @@ void TypeChecker::endVisit(NewExpression const& _newExpression)
 				_newExpression.typeName().location(),
 				"Length has to be placed in parentheses after the array type for new expression."
 			);
-		auto lengthType = type->containsShieldedType() ? TypeProvider::shieldedUint256() : TypeProvider::uint256();
 		type = TypeProvider::withLocationIfReference(DataLocation::Memory, type);
 		_newExpression.annotation().type = TypeProvider::function(
-			TypePointers{lengthType},
+			TypePointers{TypeProvider::uint256()},
 			TypePointers{type},
 			strings(1, ""),
 			strings(1, ""),

--- a/test/libsolidity/semanticTests/array/copying/shielded_array_cleanup_uint128.sol
+++ b/test/libsolidity/semanticTests/array/copying/shielded_array_cleanup_uint128.sol
@@ -3,7 +3,7 @@ contract C {
     suint128[] x;
     function f() public returns(bool) {
         x.push(suint128(42)); x.push(suint128(42)); x.push(suint128(42)); x.push(suint128(42));
-        suint128[] memory y = new suint128[](suint(1));
+        suint128[] memory y = new suint128[](1);
         y[0] = suint128(23);
         x = y;
         assembly { sstore(x.slot, 4) }

--- a/test/libsolidity/semanticTests/array/copying/shielded_array_clear_storage_packed.sol
+++ b/test/libsolidity/semanticTests/array/copying/shielded_array_clear_storage_packed.sol
@@ -4,7 +4,7 @@ contract C {
     suint120[] x2;
     function f() public returns(uint128) {
         x.push(suint128(42)); x.push(suint128(42)); x.push(suint128(42)); x.push(suint128(42));
-        suint128[] memory y = new suint128[](suint(1));
+        suint128[] memory y = new suint128[](1);
         y[0] = suint128(23);
         x = y;
         assembly { sstore(x.slot, 4) }
@@ -16,7 +16,7 @@ contract C {
 
     function g() public returns(uint64) {
         x1.push(suint64(42)); x1.push(suint64(42)); x1.push(suint64(42)); x1.push(suint64(42));
-        suint64[] memory y = new suint64[](suint(1));
+        suint64[] memory y = new suint64[](1);
         y[0] = suint64(23);
         x1 = y;
         assembly { sstore(x1.slot, 4) }
@@ -28,7 +28,7 @@ contract C {
 
     function h() public returns(uint120) {
         x2.push(suint120(42)); x2.push(suint120(42)); x2.push(suint120(42)); x2.push(suint120(42));
-        suint120[] memory y = new suint120[](suint(1));
+        suint120[] memory y = new suint120[](1);
         y[0] = suint120(23);
         x2 = y;
         assembly { sstore(x2.slot, 4) }

--- a/test/libsolidity/semanticTests/array/copying/shielded_array_copy_clear_storage.sol
+++ b/test/libsolidity/semanticTests/array/copying/shielded_array_copy_clear_storage.sol
@@ -2,7 +2,7 @@ contract C {
     suint256[] x;
     function f() public returns(uint256) {
         x.push(suint(42)); x.push(suint(42)); x.push(suint(42)); x.push(suint(42));
-        suint256[] memory y = new suint256[](suint(1));
+        suint256[] memory y = new suint256[](1);
         y[0] = suint(23);
         x = y;
         assembly { sstore(x.slot, 4) }

--- a/test/libsolidity/semanticTests/array/delete/shielded_delete_memory_array.sol
+++ b/test/libsolidity/semanticTests/array/delete/shielded_delete_memory_array.sol
@@ -1,6 +1,6 @@
 contract C {
     function len() public returns (uint ret) {
-        suint[] memory data = new suint[](suint(2));
+        suint[] memory data = new suint[](2);
         data[0] = suint(234);
         data[1] = suint(123);
         delete data;

--- a/test/libsolidity/semanticTests/structs/shielded_struct_double_nested_array.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_double_nested_array.sol
@@ -8,7 +8,7 @@ contract C {
     S data;
 
     constructor() {
-        suint length = suint(2);
+        uint length = 2;
         suint8[] memory d = new suint8[](length);
         d[0] = suint8(3);
         d[1] = suint8(4);

--- a/test/libsolidity/semanticTests/types/mapping/shielded_copy_from_mapping_to_mapping.sol
+++ b/test/libsolidity/semanticTests/types/mapping/shielded_copy_from_mapping_to_mapping.sol
@@ -11,11 +11,11 @@ contract C {
     mapping (uint8 => S) dst;
 
     constructor() {
-        suint8[] memory d = new suint8[](suint(2));
+        suint8[] memory d = new suint8[](2);
         d[0] = suint8(3);
         d[1] = suint8(4);
 
-        suint8[][] memory y = new suint8[][](suint(2));
+        suint8[][] memory y = new suint8[][](2);
         y[0] = d;
         y[1] = d;
 

--- a/test/libsolidity/semanticTests/types/mapping/shielded_mapping_nested_array_in_struct.sol
+++ b/test/libsolidity/semanticTests/types/mapping/shielded_mapping_nested_array_in_struct.sol
@@ -8,11 +8,11 @@ contract C {
     mapping (uint8 => S) src;
 
     constructor() {
-        suint8[] memory d = new suint8[](suint(2));
+        suint8[] memory d = new suint8[](2);
         d[0] = suint8(3);
         d[1] = suint8(4);
 
-        suint8[][] memory y = new suint8[][](suint(2));
+        suint8[][] memory y = new suint8[][](2);
         y[0] = d;
         y[1] = d;
 

--- a/test/libsolidity/syntaxTests/array/shielded_array_constructor_length_suint.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_array_constructor_length_suint.sol
@@ -1,0 +1,8 @@
+contract C {
+
+    function test() public pure {
+        suint256[] memory arr = new suint256[](suint(2));
+    }
+}
+// ----
+// TypeError 9553: (95-103): Invalid type for argument in function call. Invalid implicit conversion from suint256 to uint256 requested.

--- a/test/libsolidity/syntaxTests/array/shielded_array_constructor_length_uint.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_array_constructor_length_uint.sol
@@ -1,0 +1,12 @@
+contract C {
+
+    function test() public pure {
+        suint256[] memory arr1 = new suint256[](2);
+        suint[] memory arr2 = new suint[](2);
+        suint[] memory arr3 = new suint[](uint(2));
+    }
+}
+// ----
+// Warning 2072: (56-78): Unused local variable.
+// Warning 2072: (108-127): Unused local variable.
+// Warning 2072: (154-173): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/address/shielded_address_payable_memory_array_conversion.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_address_payable_memory_array_conversion.sol
@@ -1,5 +1,5 @@
 contract C {
-    function f(suint length) public pure {
+    function f(uint length) public pure {
         saddress payable[] memory a = new saddress payable[](length);
         saddress[] memory b = new saddress[](length);
         a = b;
@@ -7,5 +7,5 @@ contract C {
     }
 }
 // ----
-// TypeError 7407: (192-193): Type saddress[] memory is not implicitly convertible to expected type saddress payable[] memory.
-// TypeError 7407: (207-208): Type saddress payable[] memory is not implicitly convertible to expected type saddress[] memory.
+// TypeError 7407: (191-192): Type saddress[] memory is not implicitly convertible to expected type saddress payable[] memory.
+// TypeError 7407: (206-207): Type saddress payable[] memory is not implicitly convertible to expected type saddress[] memory.

--- a/test/libsolidity/syntaxTests/types/sbytes_arrays.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_arrays.sol
@@ -16,9 +16,9 @@ contract C {
         sbytes32 val32 = arr32[0];
 
         // Test dynamic arrays
-        sbytes1[] memory dynArr1 = new sbytes1[](suint256(0));
-        sbytes8[] memory dynArr8 = new sbytes8[](suint256(2));
-        //sbytes32[] memory dynArr32 = new sbytes32[](suint256(1));
+        sbytes1[] memory dynArr1 = new sbytes1[](0);
+        sbytes8[] memory dynArr8 = new sbytes8[](2);
+        //sbytes32[] memory dynArr32 = new sbytes32[](1);
         //
         //dynArr1[0] = sbytes1(0xFF);
         //dynArr8[0] = sbytes8(0xFFFFFFFFFFFFFFFF);
@@ -30,4 +30,4 @@ contract C {
 // Warning 2072: (467-479): Unused local variable.
 // Warning 2072: (499-513): Unused local variable.
 // Warning 2072: (566-590): Unused local variable.
-// Warning 2072: (629-653): Unused local variable.
+// Warning 2072: (619-643): Unused local variable.


### PR DESCRIPTION
When we construct a shielded array like this
```
suint256[] memory arr = new suint256[](length);
```
the type of `length` should be `uint`, instead of `suint`.

This change is in line with https://github.com/SeismicSystems/seismic-solidity/pull/87