### PR TITLE
fix(optimiser): cstore shouldn't be eliminated when followed by sstore

### DIFF
--- a/libevmasm/CommonSubexpressionEliminator.cpp
+++ b/libevmasm/CommonSubexpressionEliminator.cpp
@@ -243,9 +243,22 @@ void CSECodeGenerator::addDependencies(Id _c)
 		// this loads an unknown value from storage or memory and thus, in addition to its
 		// arguments, depends on all store operations to addresses where we do not know that
 		// they are different that occur before this load
-		StoreOperation::Target target = (expr.item->instruction() == Instruction::SLOAD 
-		|| expr.item->instruction() == Instruction::CLOAD) ?
-			StoreOperation::Storage : StoreOperation::Memory;
+		StoreOperation::Target target;
+		switch (expr.item->instruction())
+		{
+		case Instruction::SLOAD:
+			target = StoreOperation::Storage;
+			break;
+		case Instruction::CLOAD:
+			target = StoreOperation::ShieldedStorage;
+			break;
+		case Instruction::MLOAD:
+		case Instruction::KECCAK256:
+			target = StoreOperation::Memory;
+			break;
+		default:
+			solAssert(false, "Unexpected load instruction in CSE dependency analysis");
+		}
 		Id slotToLoadFrom = expr.arguments.at(0);
 		for (auto const& p: m_storeOperations)
 		{

--- a/libevmasm/CommonSubexpressionEliminator.cpp
+++ b/libevmasm/CommonSubexpressionEliminator.cpp
@@ -247,10 +247,10 @@ void CSECodeGenerator::addDependencies(Id _c)
 		switch (expr.item->instruction())
 		{
 		case Instruction::SLOAD:
-			target = StoreOperation::Storage;
-			break;
+		// CLOAD can read both public and private storage, so its treated separately below.
+		// We still need it here however to avoid the default assert.
 		case Instruction::CLOAD:
-			target = StoreOperation::ShieldedStorage;
+			target = StoreOperation::Storage;
 			break;
 		case Instruction::MLOAD:
 		case Instruction::KECCAK256:
@@ -262,7 +262,12 @@ void CSECodeGenerator::addDependencies(Id _c)
 		Id slotToLoadFrom = expr.arguments.at(0);
 		for (auto const& p: m_storeOperations)
 		{
-			if (p.first.first != target)
+			// CLOAD can read both public and private storage, so check both domains
+			bool shouldCheckTarget
+				= (expr.item->instruction() == Instruction::CLOAD)
+					  ? (p.first.first == StoreOperation::Storage || p.first.first == StoreOperation::ShieldedStorage)
+					  : (p.first.first == target);
+			if (!shouldCheckTarget)
 				continue;
 			Id slot = p.first.second;
 			StoreOperations const& storeOps = p.second;

--- a/libevmasm/KnownState.cpp
+++ b/libevmasm/KnownState.cpp
@@ -179,7 +179,7 @@ KnownState::StoreOperation KnownState::feedItem(AssemblyItem const& _item, bool 
 					m_stackHeight + static_cast<int>(_item.deposit()),
 					loadFromStorage(arguments[0], _item.debugData())
 				);
-				break;	
+				break;
 			case Instruction::CLOAD:
 				setStackElement(
 					m_stackHeight + static_cast<int>(_item.deposit()),
@@ -391,12 +391,12 @@ KnownState::StoreOperation KnownState::storeInShieldedStorage(
 	// operation will not destroy the knowledge. Specifically, we copy storage locations we know
 	// are different from _slot or locations where we know that the stored value is equal to _value.
 	//
-	// Also preserve storage items from different storage domains (private vs public), as they
-	// cannot overwrite each other and accessing the same slot from different domains causes a runtime error.
+	// CSTORE can claim a public slot if its value is 0, so we cannot unconditionally preserve
+	// public storage knowledge about the same slot. We only preserve knowledge about different slots
+	// or if we're storing the exact same private value.
 	for (auto const& storageItem: m_storageContent)
 		if (m_expressionClasses->knownToBeDifferent(storageItem.first, _slot) ||
-		    storageItem.second.value == _value ||
-		    !storageItem.second.is_private)  // Private store cannot overwrite public storage
+		    storageItem.second == FlaggedStorage{_value, true})
 			storageContents.insert(storageItem);
 	m_storageContent = std::move(storageContents);
 
@@ -423,13 +423,16 @@ ExpressionClasses::Id KnownState::loadFromStorage(Id _slot, langutil::DebugData:
 
 ExpressionClasses::Id KnownState::loadFromShieldedStorage(Id _slot, langutil::DebugData::ConstPtr _debugData)
 {
-	if (m_storageContent.count(_slot) && m_storageContent.at(_slot).is_private)
+	// CLOAD can read both public and private storage
+	if (m_storageContent.count(_slot))
 		return m_storageContent.at(_slot).value;
 
+	// No prior knowledge about this slot - create a fresh CLOAD expression.
+	// Unlike loadFromStorage, we intentionally don't cache this result because we don't know whether
+	// the slot is public or private (since CLOAD can read both), and caching with the wrong domain flag
+	// could cause incorrect behavior in subsequent store operations.
 	AssemblyItem item(Instruction::CLOAD, std::move(_debugData));
-	Id value = m_expressionClasses->find(item, {_slot}, true, m_sequenceNumber);
-	m_storageContent[_slot] = {value, true};
-	return value;
+	return m_expressionClasses->find(item, {_slot}, true, m_sequenceNumber);
 }
 
 KnownState::StoreOperation KnownState::storeInMemory(Id _slot, Id _value, langutil::DebugData::ConstPtr _debugData)

--- a/libevmasm/KnownState.cpp
+++ b/libevmasm/KnownState.cpp
@@ -356,8 +356,13 @@ KnownState::StoreOperation KnownState::storeInStorage(
 	// Copy over all values (i.e. retain knowledge about them) where we know that this store
 	// operation will not destroy the knowledge. Specifically, we copy storage locations we know
 	// are different from _slot or locations where we know that the stored value is equal to _value.
+	//
+	// Also preserve storage items from different storage domains (private vs public), as they
+	// cannot overwrite each other and accessing the same slot from different domains causes a runtime error.
 	for (auto const& storageItem: m_storageContent)
-		if (m_expressionClasses->knownToBeDifferent(storageItem.first, _slot) || storageItem.second.value == _value)
+		if (m_expressionClasses->knownToBeDifferent(storageItem.first, _slot) ||
+		    storageItem.second.value == _value ||
+		    storageItem.second.is_private)  // Public store cannot overwrite private storage
 			storageContents.insert(storageItem);
 	m_storageContent = std::move(storageContents);
 
@@ -385,14 +390,19 @@ KnownState::StoreOperation KnownState::storeInShieldedStorage(
 	// Copy over all values (i.e. retain knowledge about them) where we know that this store
 	// operation will not destroy the knowledge. Specifically, we copy storage locations we know
 	// are different from _slot or locations where we know that the stored value is equal to _value.
+	//
+	// Also preserve storage items from different storage domains (private vs public), as they
+	// cannot overwrite each other and accessing the same slot from different domains causes a runtime error.
 	for (auto const& storageItem: m_storageContent)
-		if (m_expressionClasses->knownToBeDifferent(storageItem.first, _slot) || storageItem.second.value == _value)
+		if (m_expressionClasses->knownToBeDifferent(storageItem.first, _slot) ||
+		    storageItem.second.value == _value ||
+		    !storageItem.second.is_private)  // Private store cannot overwrite public storage
 			storageContents.insert(storageItem);
 	m_storageContent = std::move(storageContents);
 
 	AssemblyItem item(Instruction::CSTORE, std::move(_debugData));
 	Id id = m_expressionClasses->find(item, {_slot, _value}, true, m_sequenceNumber);
-	StoreOperation operation{StoreOperation::Storage, _slot, m_sequenceNumber, id};
+	StoreOperation operation{StoreOperation::ShieldedStorage, _slot, m_sequenceNumber, id};
 	m_storageContent[_slot] = {_value, true};
 	// increment a second time so that we get unique sequence numbers for writes
 	m_sequenceNumber++;

--- a/libevmasm/KnownState.h
+++ b/libevmasm/KnownState.h
@@ -84,7 +84,7 @@ public:
 	using Id = ExpressionClasses::Id;
 	struct StoreOperation
 	{
-		enum Target { Invalid, Memory, Storage };
+		enum Target { Invalid, Memory, Storage, ShieldedStorage };
 
 		bool isValid() const { return target != Invalid; }
 

--- a/libyul/optimiser/UnusedStoreEliminator.cpp
+++ b/libyul/optimiser/UnusedStoreEliminator.cpp
@@ -310,10 +310,15 @@ bool UnusedStoreEliminator::knownUnrelated(
 		return true;
 	if (_op1.location == Location::Storage)
 	{
-		// CSTORE/CLOAD and SSTORE/SLOAD operate on different storage domains
-		// and should never be considered related, even if targeting the same slot.
+		// Different storage domains (public vs shielded) are generally unrelated.
+		// However, CLOAD can read BOTH domains, so it's related to any storage store.
+		// Note: _op1 is always a store (from m_storeOperations), so we only check _op2.
 		if (_op1.isShieldedStorage != _op2.isShieldedStorage)
-			return true;
+		{
+			bool op2IsCload = (_op2.effect == Effect::Read && _op2.isShieldedStorage);
+			if (!op2IsCload)
+				return true;
+		}
 		if (_op1.start && _op2.start)
 		{
 			yulAssert(

--- a/libyul/optimiser/UnusedStoreEliminator.cpp
+++ b/libyul/optimiser/UnusedStoreEliminator.cpp
@@ -235,9 +235,9 @@ std::vector<UnusedStoreEliminator::Operation> UnusedStoreEliminator::operationsF
 		std::vector<Operation> result;
 		// Unknown read is worse than unknown write.
 		if (sideEffects.memory != SideEffects::Effect::None)
-			result.emplace_back(Operation{Location::Memory, Effect::Read, {}, {}});
+			result.emplace_back(Operation{Location::Memory, Effect::Read, {}, {}, false});
 		if (sideEffects.storage != SideEffects::Effect::None)
-			result.emplace_back(Operation{Location::Storage, Effect::Read, {}, {}});
+			result.emplace_back(Operation{Location::Storage, Effect::Read, {}, {}, false});
 		return result;
 	}
 
@@ -249,7 +249,7 @@ std::vector<UnusedStoreEliminator::Operation> UnusedStoreEliminator::operationsF
 		{
 			yulAssert(!(_op.lengthParameter && _op.lengthConstant));
 			yulAssert(_op.effect != Effect::None);
-			Operation ourOp{_op.location, _op.effect, {}, {}};
+			Operation ourOp{_op.location, _op.effect, {}, {}, false};
 			if (_op.startParameter)
 				ourOp.start = identifierNameIfSSA(_functionCall.arguments.at(*_op.startParameter));
 			if (_op.lengthParameter)
@@ -261,6 +261,9 @@ std::vector<UnusedStoreEliminator::Operation> UnusedStoreEliminator::operationsF
 				case 32: ourOp.length = u256(32); break;
 				default: yulAssert(false);
 				}
+			// Mark shielded/private storage operations
+			if (_op.location == Location::Storage)
+				ourOp.isShieldedStorage = (*instruction == Instruction::CSTORE || *instruction == Instruction::CLOAD);
 			return ourOp;
 		}
 	);
@@ -287,6 +290,12 @@ void UnusedStoreEliminator::applyOperation(UnusedStoreEliminator::Operation cons
 		else if (_operation.effect == Effect::Write && knownCovered(storeOperation, _operation))
 			// This store is overwritten before being read, remove it from the active set.
 			it = active.erase(it);
+		else if (_operation.effect == Effect::Write && hasStorageDomainConflict(storeOperation, _operation))
+		{
+			// Storage domain conflict: mark the first store as used since the second will cause runtime error.
+			m_usedStores.insert(statement);
+			it = active.erase(it);
+		}
 		else
 			++it;
 	}
@@ -301,6 +310,10 @@ bool UnusedStoreEliminator::knownUnrelated(
 		return true;
 	if (_op1.location == Location::Storage)
 	{
+		// CSTORE/CLOAD and SSTORE/SLOAD operate on different storage domains
+		// and should never be considered related, even if targeting the same slot.
+		if (_op1.isShieldedStorage != _op2.isShieldedStorage)
+			return true;
 		if (_op1.start && _op2.start)
 		{
 			yulAssert(
@@ -369,6 +382,10 @@ bool UnusedStoreEliminator::knownCovered(
 {
 	if (_covered.location != _covering.location)
 		return false;
+	// CSTORE/CLOAD and SSTORE/SLOAD operate on different storage domains.
+	// A public storage write (SSTORE) cannot cover a private storage write (CSTORE) and vice versa.
+	if (_covered.location == Location::Storage && _covered.isShieldedStorage != _covering.isShieldedStorage)
+		return false;
 	if (
 		(_covered.start && _covered.start == _covering.start) &&
 		(_covered.length && _covered.length == _covering.length)
@@ -404,6 +421,44 @@ bool UnusedStoreEliminator::knownCovered(
 		// i.start <= e.start && e.start + e.length <= i.start + i.length
 	}
 	return false;
+}
+
+/// Detects a storage domain conflict between two operations.
+///
+/// A storage domain conflict occurs when two operations (CSTORE/CLOAD vs SSTORE/SLOAD)
+/// target the same storage slot but operate on different storage domains:
+/// - Public storage domain: SSTORE/SLOAD operations
+/// - Shielded/private storage domain: CSTORE/CLOAD operations
+///
+/// These domains are separate and mutually exclusive. Attempting to access the same slot
+/// with operations from different domains (e.g., CSTORE followed by SSTORE on slot 0)
+/// will cause a runtime error, as the slot's privacy cannot be changed without first
+/// clearing it.
+///
+/// When such a conflict is detected, the optimizer must preserve both operations to
+/// allow the runtime error to occur, rather than incorrectly optimizing away one of them.
+///
+/// @param _op1 First operation to check
+/// @param _op2 Second operation to check
+/// @return true if the operations target the same slot in different storage domains
+bool UnusedStoreEliminator::hasStorageDomainConflict(
+	UnusedStoreEliminator::Operation const& _op1,
+	UnusedStoreEliminator::Operation const& _op2
+) const
+{
+	// Only applies to storage operations
+	if (_op1.location != Location::Storage || _op2.location != Location::Storage)
+		return false;
+
+	// Check if they operate on different storage domains (public vs shielded)
+	if (_op1.isShieldedStorage == _op2.isShieldedStorage)
+		return false;
+
+	// Check if they target the same slot (or we can't prove they're different)
+	if (!_op1.start || !_op2.start)
+		return false;
+
+	return !m_knowledgeBase.knownToBeDifferent(*_op1.start, *_op2.start);
 }
 
 void UnusedStoreEliminator::markActiveAsUsed(

--- a/libyul/optimiser/UnusedStoreEliminator.h
+++ b/libyul/optimiser/UnusedStoreEliminator.h
@@ -88,6 +88,9 @@ public:
 		/// Length of affected area, unknown if not provided.
 		/// Unused for storage.
 		std::optional<OperationLength> length;
+		/// Whether this is a shielded/private storage operation (CSTORE/CLOAD).
+		/// Only meaningful when location == Storage.
+		bool isShieldedStorage = false;
 	};
 
 private:
@@ -115,6 +118,9 @@ private:
 	void applyOperation(Operation const& _operation);
 	bool knownUnrelated(Operation const& _op1, Operation const& _op2) const;
 	bool knownCovered(Operation const& _covered, Operation const& _covering) const;
+	/// Returns true if two operations target the same storage slot but different domains (public vs shielded).
+	/// This will cause a runtime error, so both operations must be preserved.
+	bool hasStorageDomainConflict(Operation const& _op1, Operation const& _op2) const;
 
 	void markActiveAsUsed(std::optional<Location> _onlyLocation = std::nullopt);
 	void clearActive(std::optional<Location> _onlyLocation = std::nullopt);

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -2521,7 +2521,7 @@ BOOST_AUTO_TEST_CASE(inliner_invalid)
 }
 
 
-BOOST_AUTO_TEST_CASE(cse_sstore_then_cload_no_optimization)
+BOOST_AUTO_TEST_CASE(cse_sstore_then_cload_can_optimize)
 {
 	AssemblyItems input{
 		u256(0x42),
@@ -2530,14 +2530,13 @@ BOOST_AUTO_TEST_CASE(cse_sstore_then_cload_no_optimization)
 		u256(0),
 		Instruction::CLOAD
 	};
-	// Optimizer does stack manipulation but keeps CLOAD (doesn't replace with SSTORE value)
+	// CLOAD can read from public storage, so optimizer eliminates CLOAD and keeps 0x42 on stack
 	checkCSE(input, {
 		u256(0x42),
 		u256(0),
-		Instruction::SWAP1,
 		Instruction::DUP2,
-		Instruction::SSTORE,
-		Instruction::CLOAD
+		Instruction::SWAP1,
+		Instruction::SSTORE
 	});
 }
 

--- a/test/libsolidity/semanticTests/inlineAssembly/cstore_then_sstore_should_fail.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/cstore_then_sstore_should_fail.sol
@@ -1,0 +1,10 @@
+contract C {
+    function test() external {
+        assembly {
+            cstore(0, 1)
+            sstore(0, 0x1337)
+        }
+    }
+}
+// ----
+// test() -> FAILURE

--- a/test/libsolidity/semanticTests/inlineAssembly/cstore_then_sstore_should_fail.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/cstore_then_sstore_should_fail.sol
@@ -2,6 +2,12 @@ contract C {
     function test() external {
         assembly {
             cstore(0, 1)
+        }
+        // We put the following in a separate assembly block since the TypeChecker prevents
+        // mixing sstore and cstore in the same block. Eventually our typechecker should get smarter
+        // and also prevent mixing them across blocks when they access the same slot, but for now we
+        // at least make sure that SSTORE results in runtime failure.
+        assembly {
             sstore(0, 0x1337)
         }
     }

--- a/test/libsolidity/semanticTests/inlineAssembly/sstore_zero_then_cstore.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/sstore_zero_then_cstore.sol
@@ -1,0 +1,21 @@
+contract C {
+    function test() external returns (uint256) {
+        assembly {
+            sstore(5, 0)      // Clear slot 5 (public, value = 0)
+            cstore(5, 100)    // Claim slot 5 for private use
+        }
+        // We put the following in a separate assembly block since the TypeChecker prevents
+        // mixing sstore and cstore in the same block. Eventually our typechecker should get smarter
+        // and also prevent mixing them across blocks when they access the same slot,
+        // but for now we use this test to test the CSE eliminator and make sure SLOAD is left as is
+        // to fail at runtime.
+        assembly {
+            let x := sload(5) // Should FAIL - slot is now private
+            // Below is only there to make sure sload is not dropped as dead code
+            mstore(0, x)
+            return(0, 32)
+        }
+    }
+}
+// ----
+// test() -> FAILURE


### PR DESCRIPTION
Fixes https://github.com/SeismicSystems/internal/issues/177.

Now that https://github.com/SeismicSystems/seismic-solidity/pull/136 had been merged, simple intra-block cstore/store semantics are prevented. However more complex cstore/sstore (such as in different assembly blocks) are not caught by the type checker. So we still want to make sure the optimizer doesn't remove SLOADs that could possibly revert at runtime.

This PR achives (at least I think...) that in both:
1. the evmasm optimiser (when solc run without --via-ir)
2. libyul optimiser (when run with --via-ir)