### PR TITLE
fix(tstore): transient s-types should use tstore/tload

### DIFF
--- a/libsolidity/codegen/LValue.cpp
+++ b/libsolidity/codegen/LValue.cpp
@@ -235,7 +235,7 @@ void GenericStorageItem<IsTransient>::retrieveValue(langutil::SourceLocation con
 	if (!_remove)
 		CompilerUtils(m_context).copyToStackTop(sizeOnStack(), sizeOnStack());
 	if (m_dataType->isShielded() && m_dataType->storageBytes() == 32)
-		m_context << Instruction::POP << Instruction::CLOAD;
+		m_context << Instruction::POP << (IsTransient ? s_loadInstruction : Instruction::CLOAD);
 	else if (m_dataType->storageBytes() == 32)
 		m_context << Instruction::POP << s_loadInstruction;
 	else
@@ -317,7 +317,7 @@ void GenericStorageItem<IsTransient>::storeValue(Type const& _sourceType, langut
 			utils.convertType(_sourceType, *m_dataType, true);
 			m_context << Instruction::SWAP1;
 
-			m_context << Instruction::CSTORE;
+			m_context << (IsTransient ? s_storeInstruction : Instruction::CSTORE);
 		}
 		else if (m_dataType->storageBytes() == 32)
 		{
@@ -516,7 +516,7 @@ void GenericStorageItem<IsTransient>::setToZero(langutil::SourceLocation const&,
 			// offset should be zero. remember, shielded types have to be 32 bytes!!
 			m_context
 				<< Instruction::POP << u256(0)
-				<< Instruction::SWAP1 << Instruction::CSTORE;
+				<< Instruction::SWAP1 << (IsTransient ? s_storeInstruction : Instruction::CSTORE);
 		}
 		else if (m_dataType->isShielded())
 		{

--- a/libsolidity/codegen/LValue.h
+++ b/libsolidity/codegen/LValue.h
@@ -174,6 +174,10 @@ public:
 		bool _removeReference = true
 	) const override;
 private:
+	// NOTE: when using s_sload/s_storeInstruction on shielded types,
+	//       we instead use CLOAD/CSTORE when the type is not transient.
+	// IMPORTANT to use similar pattern on any future usage these instructions.
+	// Be especially cautious about merging in upstream code that uses these
 	static constexpr evmasm::Instruction s_storeInstruction = IsTransient ? evmasm::Instruction::TSTORE : evmasm::Instruction::SSTORE;
 	static constexpr evmasm::Instruction s_loadInstruction = IsTransient ? evmasm::Instruction::TLOAD : evmasm::Instruction::SLOAD;
 };

--- a/test/cmdlineTests/evmasm_transient_storage_delete_shielded/args
+++ b/test/cmdlineTests/evmasm_transient_storage_delete_shielded/args
@@ -1,0 +1,1 @@
+--no-cbor-metadata --optimize --asm --debug-info none

--- a/test/cmdlineTests/evmasm_transient_storage_delete_shielded/input.sol
+++ b/test/cmdlineTests/evmasm_transient_storage_delete_shielded/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0.0;
+
+contract C {
+    suint256 transient x;
+    function set(suint256 v) external {
+        x = v;
+    }
+    function clr() external {
+        delete x;
+    }
+}

--- a/test/cmdlineTests/evmasm_transient_storage_delete_shielded/output
+++ b/test/cmdlineTests/evmasm_transient_storage_delete_shielded/output
@@ -1,5 +1,3 @@
-Warning: This is a pre-release compiler version, please do not use it in production.
-
 
 ======= input.sol:C =======
 EVM assembly:
@@ -39,7 +37,7 @@ sub_0: assembly {
       tag_3
       jumpi
       dup1
-      0x6d4ce63c
+      0xa00dddbd
       eq
       tag_4
       jumpi
@@ -52,26 +50,47 @@ sub_0: assembly {
     tag_5:
       stop
     tag_4:
-      tag_7
-      calldataload(0x04)
+      tag_5
       tag_8
+      calldatasize
+      0x04
+      tag_9
       jump	// in
-    tag_7:
-      stop
+    tag_8:
+      tag_10
+      jump	// in
     tag_6:
       0x00
       dup1
-      swap1
       tstore
       jump	// out
-    tag_8:
+    tag_10:
+      dup1
+      dup1
       0x00
-      dup2
-      swap1
       tstore
+      pop
+      pop
+      jump	// out
+    tag_9:
+      0x00
+      0x20
+      dup3
+      dup5
+      sub
+      slt
+      iszero
+      tag_15
+      jumpi
+      0x00
+      0x00
+      revert
+    tag_15:
+      pop
+      calldataload
+      swap2
+      swap1
       pop
       jump	// out
 }
 
-Opcodes:
-PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH1 0x11 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x66 DUP1 PUSH1 0x1F PUSH1 0x0 CODECOPY PUSH1 0x0 RETURN INVALID PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH1 0x11 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x4 CALLDATASIZE LT PUSH1 0x2E JUMPI PUSH1 0x0 CALLDATALOAD PUSH1 0xE0 SHR DUP1 PUSH4 0x0EF1346A EQ PUSH1 0x33 JUMPI DUP1 PUSH4 0x6D4CE63C EQ PUSH1 0x3D JUMPI JUMPDEST PUSH1 0x0 DUP1 REVERT JUMPDEST PUSH1 0x3B PUSH1 0x45 JUMP JUMPDEST STOP JUMPDEST PUSH1 0x43 PUSH1 0x4 CALLDATALOAD PUSH1 0x4F JUMP JUMPDEST STOP JUMPDEST PUSH1 0x0 DUP1 SWAP1 TSTORE JUMP JUMPDEST PUSH1 0x0 DUP2 SWAP1 TSTORE POP JUMP INVALID

--- a/test/cmdlineTests/evmasm_transient_storage_delete_shielded/output
+++ b/test/cmdlineTests/evmasm_transient_storage_delete_shielded/output
@@ -1,0 +1,77 @@
+Warning: This is a pre-release compiler version, please do not use it in production.
+
+
+======= input.sol:C =======
+EVM assembly:
+  mstore(0x40, 0x80)
+  callvalue
+  dup1
+  iszero
+  tag_1
+  jumpi
+  revert(0x00, 0x00)
+tag_1:
+  pop
+  dataSize(sub_0)
+  dup1
+  dataOffset(sub_0)
+  0x00
+  codecopy
+  0x00
+  return
+stop
+
+sub_0: assembly {
+      mstore(0x40, 0x80)
+      callvalue
+      dup1
+      iszero
+      tag_1
+      jumpi
+      revert(0x00, 0x00)
+    tag_1:
+      pop
+      jumpi(tag_2, lt(calldatasize, 0x04))
+      shr(0xe0, calldataload(0x00))
+      dup1
+      0x0ef1346a
+      eq
+      tag_3
+      jumpi
+      dup1
+      0x6d4ce63c
+      eq
+      tag_4
+      jumpi
+    tag_2:
+      revert(0x00, 0x00)
+    tag_3:
+      tag_5
+      tag_6
+      jump	// in
+    tag_5:
+      stop
+    tag_4:
+      tag_7
+      calldataload(0x04)
+      tag_8
+      jump	// in
+    tag_7:
+      stop
+    tag_6:
+      0x00
+      dup1
+      swap1
+      tstore
+      jump	// out
+    tag_8:
+      0x00
+      dup2
+      swap1
+      tstore
+      pop
+      jump	// out
+}
+
+Opcodes:
+PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH1 0x11 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x66 DUP1 PUSH1 0x1F PUSH1 0x0 CODECOPY PUSH1 0x0 RETURN INVALID PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH1 0x11 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x4 CALLDATASIZE LT PUSH1 0x2E JUMPI PUSH1 0x0 CALLDATALOAD PUSH1 0xE0 SHR DUP1 PUSH4 0x0EF1346A EQ PUSH1 0x33 JUMPI DUP1 PUSH4 0x6D4CE63C EQ PUSH1 0x3D JUMPI JUMPDEST PUSH1 0x0 DUP1 REVERT JUMPDEST PUSH1 0x3B PUSH1 0x45 JUMP JUMPDEST STOP JUMPDEST PUSH1 0x43 PUSH1 0x4 CALLDATALOAD PUSH1 0x4F JUMP JUMPDEST STOP JUMPDEST PUSH1 0x0 DUP1 SWAP1 TSTORE JUMP JUMPDEST PUSH1 0x0 DUP2 SWAP1 TSTORE POP JUMP INVALID

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/args
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/args
@@ -1,0 +1,1 @@
+--no-cbor-metadata --optimize --asm --debug-info none

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/input.sol
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/input.sol
@@ -6,7 +6,7 @@ contract C {
     function set(sint256 v) external {
         x = v;
     }
-    function get() external {
-        sint256 y = x;
+    function get() external view {
+        x;
     }
 }

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/input.sol
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0.0;
+
+contract C {
+    sint256 transient x;
+    function set(sint256 v) external {
+        x = v;
+    }
+    function get() external {
+        sint256 y = x;
+    }
+}

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/output
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/output
@@ -1,5 +1,3 @@
-Warning: This is a pre-release compiler version, please do not use it in production.
-
 
 ======= input.sol:C =======
 EVM assembly:
@@ -34,43 +32,53 @@ sub_0: assembly {
       jumpi(tag_2, lt(calldatasize, 0x04))
       shr(0xe0, calldataload(0x00))
       dup1
-      0x198d5ca4
+      0x6d4ce63c
       eq
       tag_3
       jumpi
       dup1
-      0xa00dddbd
+      0xf9e5def4
       eq
       tag_4
       jumpi
     tag_2:
       revert(0x00, 0x00)
     tag_3:
-      tag_5
-      calldataload(0x04)
-      tag_6
-      jump	// in
-    tag_5:
       stop
     tag_4:
-      tag_7
+      tag_3
       tag_8
+      calldatasize
+      0x04
+      tag_9
       jump	// in
-    tag_7:
-      stop
-    tag_6:
+    tag_8:
+      dup1
+      dup1
       0x00
-      dup2
-      swap1
       tstore
       pop
+      pop
       jump	// out
-    tag_8:
+    tag_9:
       0x00
-      tload
+      0x20
+      dup3
+      dup5
+      sub
+      slt
+      iszero
+      tag_15
+      jumpi
+      0x00
+      0x00
+      revert
+    tag_15:
+      pop
+      calldataload
+      swap2
+      swap1
       pop
       jump	// out
 }
 
-Opcodes:
-PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH1 0x11 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x66 DUP1 PUSH1 0x1F PUSH1 0x0 CODECOPY PUSH1 0x0 RETURN INVALID PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH1 0x11 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x4 CALLDATASIZE LT PUSH1 0x2E JUMPI PUSH1 0x0 CALLDATALOAD PUSH1 0xE0 SHR DUP1 PUSH4 0x198D5CA4 EQ PUSH1 0x33 JUMPI DUP1 PUSH4 0xA00DDDBD EQ PUSH1 0x3D JUMPI JUMPDEST PUSH1 0x0 DUP1 REVERT JUMPDEST PUSH1 0x3B PUSH1 0x4 CALLDATALOAD PUSH1 0x47 JUMP JUMPDEST STOP JUMPDEST PUSH1 0x45 PUSH1 0x50 JUMP JUMPDEST STOP JUMPDEST PUSH1 0x0 DUP2 SWAP1 TSTORE POP JUMP JUMPDEST PUSH1 0x0 TLOAD POP JUMP INVALID

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/output
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/output
@@ -1,0 +1,76 @@
+Warning: This is a pre-release compiler version, please do not use it in production.
+
+
+======= input.sol:C =======
+EVM assembly:
+  mstore(0x40, 0x80)
+  callvalue
+  dup1
+  iszero
+  tag_1
+  jumpi
+  revert(0x00, 0x00)
+tag_1:
+  pop
+  dataSize(sub_0)
+  dup1
+  dataOffset(sub_0)
+  0x00
+  codecopy
+  0x00
+  return
+stop
+
+sub_0: assembly {
+      mstore(0x40, 0x80)
+      callvalue
+      dup1
+      iszero
+      tag_1
+      jumpi
+      revert(0x00, 0x00)
+    tag_1:
+      pop
+      jumpi(tag_2, lt(calldatasize, 0x04))
+      shr(0xe0, calldataload(0x00))
+      dup1
+      0x198d5ca4
+      eq
+      tag_3
+      jumpi
+      dup1
+      0xa00dddbd
+      eq
+      tag_4
+      jumpi
+    tag_2:
+      revert(0x00, 0x00)
+    tag_3:
+      tag_5
+      calldataload(0x04)
+      tag_6
+      jump	// in
+    tag_5:
+      stop
+    tag_4:
+      tag_7
+      tag_8
+      jump	// in
+    tag_7:
+      stop
+    tag_6:
+      0x00
+      dup2
+      swap1
+      tstore
+      pop
+      jump	// out
+    tag_8:
+      0x00
+      tload
+      pop
+      jump	// out
+}
+
+Opcodes:
+PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH1 0x11 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x66 DUP1 PUSH1 0x1F PUSH1 0x0 CODECOPY PUSH1 0x0 RETURN INVALID PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH1 0x11 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x4 CALLDATASIZE LT PUSH1 0x2E JUMPI PUSH1 0x0 CALLDATALOAD PUSH1 0xE0 SHR DUP1 PUSH4 0x198D5CA4 EQ PUSH1 0x33 JUMPI DUP1 PUSH4 0xA00DDDBD EQ PUSH1 0x3D JUMPI JUMPDEST PUSH1 0x0 DUP1 REVERT JUMPDEST PUSH1 0x3B PUSH1 0x4 CALLDATALOAD PUSH1 0x47 JUMP JUMPDEST STOP JUMPDEST PUSH1 0x45 PUSH1 0x50 JUMP JUMPDEST STOP JUMPDEST PUSH1 0x0 DUP2 SWAP1 TSTORE POP JUMP JUMPDEST PUSH1 0x0 TLOAD POP JUMP INVALID

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/args
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/args
@@ -1,0 +1,1 @@
+--no-cbor-metadata --optimize --asm --debug-info none

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/input.sol
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/input.sol
@@ -6,7 +6,7 @@ contract C {
     function set(suint256 v) external {
         x = v;
     }
-    function get() external {
-        suint256 y = x;
+    function get() external view {
+        x;
     }
 }

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/input.sol
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0.0;
+
+contract C {
+    suint256 transient x;
+    function set(suint256 v) external {
+        x = v;
+    }
+    function get() external {
+        suint256 y = x;
+    }
+}

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/output
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/output
@@ -1,5 +1,3 @@
-Warning: This is a pre-release compiler version, please do not use it in production.
-
 
 ======= input.sol:C =======
 EVM assembly:
@@ -46,31 +44,41 @@ sub_0: assembly {
     tag_2:
       revert(0x00, 0x00)
     tag_3:
-      tag_5
-      calldataload(0x04)
-      tag_6
-      jump	// in
-    tag_5:
       stop
     tag_4:
-      tag_7
+      tag_3
       tag_8
+      calldatasize
+      0x04
+      tag_9
       jump	// in
-    tag_7:
-      stop
-    tag_6:
+    tag_8:
+      dup1
+      dup1
       0x00
-      dup2
-      swap1
       tstore
       pop
+      pop
       jump	// out
-    tag_8:
+    tag_9:
       0x00
-      tload
+      0x20
+      dup3
+      dup5
+      sub
+      slt
+      iszero
+      tag_15
+      jumpi
+      0x00
+      0x00
+      revert
+    tag_15:
+      pop
+      calldataload
+      swap2
+      swap1
       pop
       jump	// out
 }
 
-Opcodes:
-PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH1 0x11 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x66 DUP1 PUSH1 0x1F PUSH1 0x0 CODECOPY PUSH1 0x0 RETURN INVALID PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH1 0x11 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x4 CALLDATASIZE LT PUSH1 0x2E JUMPI PUSH1 0x0 CALLDATALOAD PUSH1 0xE0 SHR DUP1 PUSH4 0x6D4CE63C EQ PUSH1 0x33 JUMPI DUP1 PUSH4 0xA00DDDBD EQ PUSH1 0x3D JUMPI JUMPDEST PUSH1 0x0 DUP1 REVERT JUMPDEST PUSH1 0x3B PUSH1 0x4 CALLDATALOAD PUSH1 0x47 JUMP JUMPDEST STOP JUMPDEST PUSH1 0x45 PUSH1 0x50 JUMP JUMPDEST STOP JUMPDEST PUSH1 0x0 DUP2 SWAP1 TSTORE POP JUMP JUMPDEST PUSH1 0x0 TLOAD POP JUMP INVALID

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/output
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/output
@@ -1,0 +1,76 @@
+Warning: This is a pre-release compiler version, please do not use it in production.
+
+
+======= input.sol:C =======
+EVM assembly:
+  mstore(0x40, 0x80)
+  callvalue
+  dup1
+  iszero
+  tag_1
+  jumpi
+  revert(0x00, 0x00)
+tag_1:
+  pop
+  dataSize(sub_0)
+  dup1
+  dataOffset(sub_0)
+  0x00
+  codecopy
+  0x00
+  return
+stop
+
+sub_0: assembly {
+      mstore(0x40, 0x80)
+      callvalue
+      dup1
+      iszero
+      tag_1
+      jumpi
+      revert(0x00, 0x00)
+    tag_1:
+      pop
+      jumpi(tag_2, lt(calldatasize, 0x04))
+      shr(0xe0, calldataload(0x00))
+      dup1
+      0x6d4ce63c
+      eq
+      tag_3
+      jumpi
+      dup1
+      0xa00dddbd
+      eq
+      tag_4
+      jumpi
+    tag_2:
+      revert(0x00, 0x00)
+    tag_3:
+      tag_5
+      calldataload(0x04)
+      tag_6
+      jump	// in
+    tag_5:
+      stop
+    tag_4:
+      tag_7
+      tag_8
+      jump	// in
+    tag_7:
+      stop
+    tag_6:
+      0x00
+      dup2
+      swap1
+      tstore
+      pop
+      jump	// out
+    tag_8:
+      0x00
+      tload
+      pop
+      jump	// out
+}
+
+Opcodes:
+PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH1 0x11 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x66 DUP1 PUSH1 0x1F PUSH1 0x0 CODECOPY PUSH1 0x0 RETURN INVALID PUSH1 0x80 PUSH1 0x40 MSTORE CALLVALUE DUP1 ISZERO PUSH1 0x11 JUMPI PUSH1 0x0 DUP1 REVERT JUMPDEST POP PUSH1 0x4 CALLDATASIZE LT PUSH1 0x2E JUMPI PUSH1 0x0 CALLDATALOAD PUSH1 0xE0 SHR DUP1 PUSH4 0x6D4CE63C EQ PUSH1 0x33 JUMPI DUP1 PUSH4 0xA00DDDBD EQ PUSH1 0x3D JUMPI JUMPDEST PUSH1 0x0 DUP1 REVERT JUMPDEST PUSH1 0x3B PUSH1 0x4 CALLDATALOAD PUSH1 0x47 JUMP JUMPDEST STOP JUMPDEST PUSH1 0x45 PUSH1 0x50 JUMP JUMPDEST STOP JUMPDEST PUSH1 0x0 DUP2 SWAP1 TSTORE POP JUMP JUMPDEST PUSH1 0x0 TLOAD POP JUMP INVALID

--- a/test/libsolidity/semanticTests/variables/transient_shielded_different_types.sol
+++ b/test/libsolidity/semanticTests/variables/transient_shielded_different_types.sol
@@ -4,40 +4,27 @@ contract C {
     saddress transient sa;
     sbool transient sb;
 
-    function setSu(suint256 v) public {
-        su = v;
-    }
-    function setSi(sint256 v) public {
-        si = v;
-    }
-    function setSa(saddress v) public {
-        sa = v;
-    }
-    function setSb(sbool v) public {
-        sb = v;
-    }
-
-    function checkSu() public view returns (uint256) {
+    function setAndCheckSu(uint256 v) public returns (uint256) {
+        su = suint256(v);
         return uint256(su);
     }
-    function checkSi() public view returns (int256) {
+    function setAndCheckSi(int256 v) public returns (int256) {
+        si = sint256(v);
         return int256(si);
     }
-    function checkSa() public view returns (address) {
+    function setAndCheckSa(address v) public returns (address) {
+        sa = saddress(v);
         return address(sa);
     }
-    function checkSb() public view returns (bool) {
+    function setAndCheckSb(bool v) public returns (bool) {
+        sb = sbool(v);
         return bool(sb);
     }
 }
 // ====
 // EVMVersion: >=cancun
 // ----
-// setSu(uint256): 123 ->
-// checkSu() -> 123
-// setSi(int256): -456 ->
-// checkSi() -> -456
-// setSa(address): 0x1234567890123456789012345678901234567890 ->
-// checkSa() -> 0x1234567890123456789012345678901234567890
-// setSb(bool): true ->
-// checkSb() -> true
+// setAndCheckSu(uint256): 123 -> 123
+// setAndCheckSi(int256): -456 -> -456
+// setAndCheckSa(address): 0x1234567890123456789012345678901234567890 -> 0x1234567890123456789012345678901234567890
+// setAndCheckSb(bool): true -> true

--- a/test/libsolidity/semanticTests/variables/transient_shielded_different_types.sol
+++ b/test/libsolidity/semanticTests/variables/transient_shielded_different_types.sol
@@ -22,7 +22,7 @@ contract C {
     }
 }
 // ====
-// EVMVersion: >=cancun
+// EVMVersion: >=mercury
 // ----
 // setAndCheckSu(uint256): 123 -> 123
 // setAndCheckSi(int256): -456 -> -456

--- a/test/libsolidity/semanticTests/variables/transient_shielded_different_types.sol
+++ b/test/libsolidity/semanticTests/variables/transient_shielded_different_types.sol
@@ -1,0 +1,43 @@
+contract C {
+    suint256 transient su;
+    sint256 transient si;
+    saddress transient sa;
+    sbool transient sb;
+
+    function setSu(suint256 v) public {
+        su = v;
+    }
+    function setSi(sint256 v) public {
+        si = v;
+    }
+    function setSa(saddress v) public {
+        sa = v;
+    }
+    function setSb(sbool v) public {
+        sb = v;
+    }
+
+    function checkSu() public view returns (uint256) {
+        return uint256(su);
+    }
+    function checkSi() public view returns (int256) {
+        return int256(si);
+    }
+    function checkSa() public view returns (address) {
+        return address(sa);
+    }
+    function checkSb() public view returns (bool) {
+        return bool(sb);
+    }
+}
+// ====
+// EVMVersion: >=cancun
+// ----
+// setSu(uint256): 123 ->
+// checkSu() -> 123
+// setSi(int256): -456 ->
+// checkSi() -> -456
+// setSa(address): 0x1234567890123456789012345678901234567890 ->
+// checkSa() -> 0x1234567890123456789012345678901234567890
+// setSb(bool): true ->
+// checkSb() -> true

--- a/test/libsolidity/semanticTests/variables/transient_shielded_state_variable.sol
+++ b/test/libsolidity/semanticTests/variables/transient_shielded_state_variable.sol
@@ -1,0 +1,27 @@
+contract C {
+    suint256 transient public x;
+
+    function setX(suint256 v) public {
+        x = v;
+    }
+    function resetX() public {
+        x = suint256(0);
+    }
+    function getX() internal view returns (suint256) {
+        return x;
+    }
+    function checkX() public returns (uint256) {
+        // Return 1 if x is zero (transient behavior working), 0 otherwise
+        if (uint256(getX()) == 0) {
+            return 1;
+        }
+        return 0;
+    }
+}
+// ====
+// EVMVersion: >=cancun
+// ----
+// setX(uint256): 42 ->
+// checkX() -> 0
+// resetX() ->
+// checkX() -> 1

--- a/test/libsolidity/semanticTests/variables/transient_shielded_state_variable.sol
+++ b/test/libsolidity/semanticTests/variables/transient_shielded_state_variable.sol
@@ -1,27 +1,16 @@
 contract C {
-    suint256 transient public x;
+    suint256 transient x;
 
-    function setX(suint256 v) public {
-        x = v;
+    function setAndCheck(uint256 v) public returns (uint256) {
+        x = suint256(v);
+        return uint256(x);
     }
-    function resetX() public {
-        x = suint256(0);
-    }
-    function getX() internal view returns (suint256) {
-        return x;
-    }
-    function checkX() public returns (uint256) {
-        // Return 1 if x is zero (transient behavior working), 0 otherwise
-        if (uint256(getX()) == 0) {
-            return 1;
-        }
-        return 0;
+    function checkX() public view returns (uint256) {
+        return uint256(x);
     }
 }
 // ====
 // EVMVersion: >=cancun
 // ----
-// setX(uint256): 42 ->
+// setAndCheck(uint256): 42 -> 42
 // checkX() -> 0
-// resetX() ->
-// checkX() -> 1

--- a/test/libsolidity/semanticTests/variables/transient_shielded_state_variable.sol
+++ b/test/libsolidity/semanticTests/variables/transient_shielded_state_variable.sol
@@ -10,7 +10,7 @@ contract C {
     }
 }
 // ====
-// EVMVersion: >=cancun
+// EVMVersion: >=mercury
 // ----
 // setAndCheck(uint256): 42 -> 42
 // checkX() -> 0


### PR DESCRIPTION
For transient storage variables with a shielded type (e.g. suint256 transient), the legacy codegen path currently emits cstore (and similarly cload) instead of transient opcodes (tstore/tload). this causes the generated bytecode to use non-transient confidential storage operations for a transient variable.