### PR TITLE
fix(ver-770): `saddress[]` should not be implicitly convertible to `address[]`

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -543,7 +543,7 @@ TypeResult AddressType::binaryOperatorResult(Token _operator, Type const* _other
 
 bool AddressType::operator==(Type const& _other) const
 {
-	if (_other.category() != Category::Address && _other.category() != Category::ShieldedAddress)
+	if (_other.category() != category())
 		return false;
 	AddressType const& other = dynamic_cast<AddressType const&>(_other);
 	return other.m_stateMutability == m_stateMutability;

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_push_address_literal_without_conversion.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_push_address_literal_without_conversion.sol
@@ -1,0 +1,10 @@
+contract C {
+    saddress[] sa;
+
+    function pushAddressLiteral() external {
+        // Should require explicit conversion
+        sa.push(address(0x456));
+    }
+}
+// ----
+// TypeError 4254: (132-139): Cannot push a non-shielded type to a shielded array

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_push_address_without_conversion.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_push_address_without_conversion.sol
@@ -1,0 +1,11 @@
+contract C {
+    saddress[] sa;
+
+    function pushAddress() external {
+        address addr = address(0x123);
+        // Should require explicit conversion
+        sa.push(addr);
+    }
+}
+// ----
+// TypeError 4254: (164-171): Cannot push a non-shielded type to a shielded array

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_calldata_conversion.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_calldata_conversion.sol
@@ -1,0 +1,10 @@
+contract C {
+    function testCalldataToMemory(saddress[] calldata sa, address[] calldata a) external pure {
+        // Assignment from calldata to memory with wrong types
+        address[] memory a_mem = sa;
+        saddress[] memory sa_mem = a;
+    }
+}
+// ----
+// TypeError 9574: (180-207): Type saddress[] calldata is not implicitly convertible to expected type address[] memory.
+// TypeError 9574: (217-245): Type address[] calldata is not implicitly convertible to expected type saddress[] memory.

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_calldata_param.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_calldata_param.sol
@@ -1,0 +1,13 @@
+contract C {
+    function takesAddressArrayCalldata(address[] calldata arr) internal pure {}
+    function takesSaddressArrayCalldata(saddress[] calldata arr) internal pure {}
+
+    function testCalldataParam(saddress[] calldata sa, address[] calldata a) external pure {
+        // Both directions should fail with calldata
+        takesAddressArrayCalldata(sa);
+        takesSaddressArrayCalldata(a);
+    }
+}
+// ----
+// TypeError 9553: (356-358): Invalid type for argument in function call. Invalid implicit conversion from saddress[] calldata to address[] calldata requested.
+// TypeError 9553: (396-397): Invalid type for argument in function call. Invalid implicit conversion from address[] calldata to saddress[] calldata requested.

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_event_emission.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_event_emission.sol
@@ -1,0 +1,10 @@
+contract C {
+    saddress[] s;
+    event E(address[]);
+
+    function emit_shielded() external {
+        emit E(s);
+    }
+}
+// ----
+// TypeError 9553: (111-112): Invalid type for argument in function call. Invalid implicit conversion from saddress[] storage ref to address[] memory requested.

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_external_call.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_external_call.sol
@@ -4,8 +4,12 @@ contract Helper {
     function returnsAddressArray() external pure returns (address[] memory) {
         return new address[](5);
     }
-    function returnsSaddressArray() external pure returns (saddress[] memory) {
+    function returnsSaddressArray() internal pure returns (saddress[] memory) {
         return new saddress[](5);
+    }
+    // External wrapper to test implicit conversion of return value
+    function testReturnsSaddressArrayConversion() external pure {
+        address[] memory a = returnsSaddressArray();
     }
 }
 
@@ -23,11 +27,10 @@ contract C {
     function testExternalCallReturnAssignment() external view {
         // Assignment from external call with wrong return type
         saddress[] memory sa = helper.returnsAddressArray();
-        address[] memory a = helper.returnsSaddressArray();
     }
 }
 // ----
-// TypeError 9553: (655-657): Invalid type for argument in function call. Invalid implicit conversion from saddress[] memory to address[] memory requested.
-// TypeError 9553: (694-695): Invalid type for argument in function call. Invalid implicit conversion from address[] memory to saddress[] memory requested.
-// TypeError 9574: (841-892): Type address[] memory is not implicitly convertible to expected type saddress[] memory.
-// TypeError 9574: (902-952): Type saddress[] memory is not implicitly convertible to expected type address[] memory.
+// TypeError 9574: (539-582): Type saddress[] memory is not implicitly convertible to expected type address[] memory.
+// TypeError 9553: (848-850): Invalid type for argument in function call. Invalid implicit conversion from saddress[] memory to address[] memory requested.
+// TypeError 9553: (887-888): Invalid type for argument in function call. Invalid implicit conversion from address[] memory to saddress[] memory requested.
+// TypeError 9574: (1034-1085): Type address[] memory is not implicitly convertible to expected type saddress[] memory.

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_external_call.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_external_call.sol
@@ -1,0 +1,33 @@
+contract Helper {
+    function takesAddressArray(address[] memory arr) external pure {}
+    function takesSaddressArray(saddress[] memory arr) external pure {}
+    function returnsAddressArray() external pure returns (address[] memory) {
+        return new address[](5);
+    }
+    function returnsSaddressArray() external pure returns (saddress[] memory) {
+        return new saddress[](5);
+    }
+}
+
+contract C {
+    Helper helper;
+
+    function testExternalCallParam() external view {
+        saddress[] memory sa = new saddress[](5);
+        address[] memory a = new address[](5);
+        // Both directions should fail
+        helper.takesAddressArray(sa);
+        helper.takesSaddressArray(a);
+    }
+
+    function testExternalCallReturnAssignment() external view {
+        // Assignment from external call with wrong return type
+        saddress[] memory sa = helper.returnsAddressArray();
+        address[] memory a = helper.returnsSaddressArray();
+    }
+}
+// ----
+// TypeError 9553: (655-657): Invalid type for argument in function call. Invalid implicit conversion from saddress[] memory to address[] memory requested.
+// TypeError 9553: (694-695): Invalid type for argument in function call. Invalid implicit conversion from address[] memory to saddress[] memory requested.
+// TypeError 9574: (841-892): Type address[] memory is not implicitly convertible to expected type saddress[] memory.
+// TypeError 9574: (902-952): Type saddress[] memory is not implicitly convertible to expected type address[] memory.

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_function_parameter.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_function_parameter.sol
@@ -1,0 +1,27 @@
+contract C {
+    saddress[] sa;
+    address[] a;
+
+    function takesAddressArray(address[] memory arr) internal pure {}
+    function takesSaddressArray(saddress[] memory arr) internal pure {}
+
+    function testMemoryParam() external view {
+        // Passing saddress[] where address[] is expected
+        takesAddressArray(sa);
+        // Passing address[] where saddress[] is expected
+        takesSaddressArray(a);
+    }
+
+    function testWithLocal() external pure {
+        saddress[] memory sa_mem = new saddress[](5);
+        address[] memory a_mem = new address[](5);
+        // Both directions should fail
+        takesAddressArray(sa_mem);
+        takesSaddressArray(a_mem);
+    }
+}
+// ----
+// TypeError 9553: (324-326): Invalid type for argument in function call. Invalid implicit conversion from saddress[] storage ref to address[] memory requested.
+// TypeError 9553: (414-415): Invalid type for argument in function call. Invalid implicit conversion from address[] storage ref to saddress[] memory requested.
+// TypeError 9553: (640-646): Invalid type for argument in function call. Invalid implicit conversion from saddress[] memory to address[] memory requested.
+// TypeError 9553: (676-681): Invalid type for argument in function call. Invalid implicit conversion from address[] memory to saddress[] memory requested.

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_memory_conversion.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_memory_conversion.sol
@@ -1,0 +1,12 @@
+contract C {
+    function f(uint length) public pure {
+        saddress[] memory sa = new saddress[](length);
+        address[] memory a = new address[](length);
+        // Both directions should fail
+        a = sa;
+        sa = a;
+    }
+}
+// ----
+// TypeError 7407: (213-215): Type saddress[] memory is not implicitly convertible to expected type address[] memory.
+// TypeError 7407: (230-231): Type address[] memory is not implicitly convertible to expected type saddress[] memory.

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_nested.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_nested.sol
@@ -1,0 +1,33 @@
+contract C {
+    function testNestedArrays() external pure {
+        saddress[][] memory sa2d = new saddress[][](3);
+        address[][] memory a2d = new address[][](3);
+        // Both directions should fail for nested arrays
+        a2d = sa2d;
+        sa2d = a2d;
+    }
+
+    function testNestedInFunction(saddress[][] memory sa2d, address[][] memory a2d) external pure {
+        // Assignment from parameters
+        address[][] memory a_local = sa2d;
+        saddress[][] memory sa_local = a2d;
+    }
+
+    function takesNestedAddressArray(address[][] memory arr) internal pure {}
+    function takesNestedSaddressArray(saddress[][] memory arr) internal pure {}
+
+    function testNestedFunctionParam() external pure {
+        saddress[][] memory sa2d = new saddress[][](3);
+        address[][] memory a2d = new address[][](3);
+        // Both directions should fail
+        takesNestedAddressArray(sa2d);
+        takesNestedSaddressArray(a2d);
+    }
+}
+// ----
+// TypeError 7407: (241-245): Type saddress[][] memory is not implicitly convertible to expected type address[][] memory.
+// TypeError 7407: (262-265): Type address[][] memory is not implicitly convertible to expected type saddress[][] memory.
+// TypeError 9574: (420-453): Type saddress[][] memory is not implicitly convertible to expected type address[][] memory.
+// TypeError 9574: (463-497): Type address[][] memory is not implicitly convertible to expected type saddress[][] memory.
+// TypeError 9553: (900-904): Invalid type for argument in function call. Invalid implicit conversion from saddress[][] memory to address[][] memory requested.
+// TypeError 9553: (940-943): Invalid type for argument in function call. Invalid implicit conversion from address[][] memory to saddress[][] memory requested.

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_return_type.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_return_type.sol
@@ -7,9 +7,14 @@ contract C {
         return sa;
     }
 
-    function returnsSaddressArray() external view returns (saddress[] memory) {
+    function returnsSaddressArray() internal view returns (saddress[] memory) {
         // Should fail: returning address[] where saddress[] is expected
         return a;
+    }
+
+    // External wrapper to test the internal function
+    function testReturnsSaddressArray() external view {
+        address[] memory result = returnsSaddressArray();
     }
 
     function returnsAddressArrayMemory() external pure returns (address[] memory) {
@@ -18,14 +23,21 @@ contract C {
         return sa_mem;
     }
 
-    function returnsSaddressArrayMemory() external pure returns (saddress[] memory) {
+    function returnsSaddressArrayMemory() internal pure returns (saddress[] memory) {
         address[] memory a_mem = new address[](5);
         // Should fail: returning address[] memory where saddress[] memory is expected
         return a_mem;
+    }
+
+    // External wrapper to test the internal function
+    function testReturnsSaddressArrayMemory() external pure {
+        address[] memory result = returnsSaddressArrayMemory();
     }
 }
 // ----
 // TypeError 6359: (216-218): Return argument type saddress[] storage ref is not implicitly convertible to expected type (type of first return variable) address[] memory.
 // TypeError 6359: (395-396): Return argument type address[] storage ref is not implicitly convertible to expected type (type of first return variable) saddress[] memory.
-// TypeError 6359: (645-651): Return argument type saddress[] memory is not implicitly convertible to expected type (type of first return variable) address[] memory.
-// TypeError 6359: (899-904): Return argument type address[] memory is not implicitly convertible to expected type (type of first return variable) saddress[] memory.
+// TypeError 9574: (523-571): Type saddress[] memory is not implicitly convertible to expected type address[] memory.
+// TypeError 6359: (820-826): Return argument type saddress[] memory is not implicitly convertible to expected type (type of first return variable) address[] memory.
+// TypeError 6359: (1074-1079): Return argument type address[] memory is not implicitly convertible to expected type (type of first return variable) saddress[] memory.
+// TypeError 9574: (1212-1266): Type saddress[] memory is not implicitly convertible to expected type address[] memory.

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_return_type.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_return_type.sol
@@ -1,0 +1,31 @@
+contract C {
+    saddress[] sa;
+    address[] a;
+
+    function returnsAddressArray() external view returns (address[] memory) {
+        // Should fail: returning saddress[] where address[] is expected
+        return sa;
+    }
+
+    function returnsSaddressArray() external view returns (saddress[] memory) {
+        // Should fail: returning address[] where saddress[] is expected
+        return a;
+    }
+
+    function returnsAddressArrayMemory() external pure returns (address[] memory) {
+        saddress[] memory sa_mem = new saddress[](5);
+        // Should fail: returning saddress[] memory where address[] memory is expected
+        return sa_mem;
+    }
+
+    function returnsSaddressArrayMemory() external pure returns (saddress[] memory) {
+        address[] memory a_mem = new address[](5);
+        // Should fail: returning address[] memory where saddress[] memory is expected
+        return a_mem;
+    }
+}
+// ----
+// TypeError 6359: (216-218): Return argument type saddress[] storage ref is not implicitly convertible to expected type (type of first return variable) address[] memory.
+// TypeError 6359: (395-396): Return argument type address[] storage ref is not implicitly convertible to expected type (type of first return variable) saddress[] memory.
+// TypeError 6359: (645-651): Return argument type saddress[] memory is not implicitly convertible to expected type (type of first return variable) address[] memory.
+// TypeError 6359: (899-904): Return argument type address[] memory is not implicitly convertible to expected type (type of first return variable) saddress[] memory.

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_storage_conversion.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_storage_conversion.sol
@@ -1,0 +1,14 @@
+contract C {
+    saddress[] sa;
+    address[] a;
+    function f() public view {
+        saddress[] storage sptr = sa;
+        address[] storage aptr = a;
+        // Both directions should fail
+        aptr = sptr;
+        sptr = aptr;
+    }
+}
+// ----
+// TypeError 7407: (208-212): Type saddress[] storage pointer is not implicitly convertible to expected type address[] storage pointer.
+// TypeError 7407: (229-233): Type address[] storage pointer is not implicitly convertible to expected type saddress[] storage pointer.


### PR DESCRIPTION
We no longer consider shielded and unshielded address as equal

The fix is [one line](https://github.com/SeismicSystems/seismic-solidity/pull/131/files#diff-5cc133bfc337e9ca7fe7ee9842d5ddfa492fa559149cf8acec4a7d9ede50c9aaR546). The rest of the diff is tests