### PR TITLE
test(semantic): update the storage tests to reflect new semantics

### DIFF
--- a/test/libsolidity/semanticTests/inlineAssembly/shielded_cstore_then_sstore.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/shielded_cstore_then_sstore.sol
@@ -1,16 +1,16 @@
 contract C {
-    uint256 a;
+    suint256 a;
 
     function f1() public {
-        a = 7;
+        a = suint(7);
     }
 
     function f() public returns (uint256 x) {
        assembly {
-            x :=cload(a.slot)
+            sstore(a.slot, 42)
        }
     }
 }
 // ----
 // f1()
-// f() -> 7
+// f() -> FAILURE

--- a/test/libsolidity/semanticTests/inlineAssembly/shielded_sstore_then_cstore.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/shielded_sstore_then_cstore.sol
@@ -1,0 +1,22 @@
+contract C {
+    uint256 a;
+
+    function set() public {
+        a = 7;
+    }
+
+    function deletea() public {
+        delete a;
+    }
+
+    function f() public {
+       assembly {
+            cstore(a.slot, 42)
+       }
+    }
+}
+// ----
+// set()
+// f() -> FAILURE
+// deletea()
+// f()

--- a/test/libsolidity/semanticTests/inlineAssembly/sstore_then_cload_no_optimize.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/sstore_then_cload_no_optimize.sol
@@ -7,4 +7,4 @@ contract C {
     }
 }
 // ----
-// f() -> FAILURE
+// f() -> 42


### PR DESCRIPTION
Same commit as in https://github.com/SeismicSystems/seismic-solidity/pull/130

For unbreaking build vs. latest seismic-revm, with updates CSTORE/CLOAD rules