### PR TITLE
chore: add forkdiff

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,53 @@
+name: Build & publish forkdiff github-pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - seismic
+
+jobs:
+  build:
+    concurrency: ci-${{ github.ref }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1000 # make sure to fetch the old commit we diff against
+
+      - name: Build forkdiff
+        uses: "docker://protolambda/forkdiff:0.1.0"
+        with:
+          args: -repo=/github/workspace -fork=/github/workspace/fork.yaml -out=/github/workspace/index.html
+
+      # TODO(samlaf): this was part of the gh-action I copied from, but doesn't seem necessary...
+      # if we are successful in pushing to gh-pages, then just delete these comments
+
+      # - name: Setup Pages
+      #   uses: actions/configure-pages@v5
+
+      # - name: Build with Jekyll
+      #   uses: actions/jekyll-build-pages@v1
+      #   with:
+      #     source: ./
+      #     destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # This needs to run in the github-pages environment to deploy successfully. For more info see:
+  # https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ emscripten_build/
 # OS specific local files
 .DS_Store
 Thumbs.db
+
+# forkdiff output
+index.html

--- a/fork.yaml
+++ b/fork.yaml
@@ -1,0 +1,95 @@
+title: "SeismicSystems/seismic-solidity" # Define the HTML page title
+logo: "logo.png"
+footer: | # define the footer with markdown
+  SeismicSystems' [seismic-solidity](https://github.com/SeismicSystems/seismic-solidity) fork overview - created with [Forkdiff](https://github.com/protolambda/forkdiff)
+base:
+  name: solidity
+  url: https://github.com/SeismicSystems/seismic-solidity
+  ref: refs/remotes/origin/develop
+fork:
+  name: seismic-solidity
+  url: https://github.com/SeismicSystems/seismic-solidity
+  ref: refs/heads/chore--add-forkdiff
+  # hash: d28d5527f20f7d295e4c616fcfcad3205e42e199
+def:
+  title: "Seismic-Solidity fork diff"
+  description: | # description in markdown
+    - Original solidity codebase: [`https://github.com/argotorg/solidity/`](https://github.com/argotorg/solidity/).
+    - Seismic solidity fork: [`https://github.com/SeismicSystems/seismic-solidity`](https://github.com/SeismicSystems/seismic-solidity).
+
+  sub:
+    - title: "EVM ASM"
+      description: |
+        Add support for new opcodes that we added in our seismic-revm fork:
+
+        - CLOAD/CSTORE - confidential storage opcodes
+        - TIMESTAMPMS - timestamp with millisecond precision given that our blocks are subsecond
+      sub:
+        - title: "evmasm"
+          globs:
+            - "libevmasm/**"
+
+    - title: "Solidity Compiler"
+      description: |
+        Add support for shielded types: sint, suint, sbytes, saddress, sbool.
+      sub:
+        - title: "lexing + parsing + ast"
+          globs:
+            - "liblangutil/Token.**"
+            - "libsolidity/parsing/**"
+            - "libsolidity/ast/**"
+
+        - title: "analysis"
+          globs:
+            - "libsolidity/analysis/**"
+
+        - title: "codegen"
+          globs:
+            - "libsolidity/codegen/**"
+
+        - title: "formal verification"
+          globs:
+            - "libsolidity/formal/**"
+
+        - title: "language server (lsp)"
+          globs:
+            - "libsolidity/lsp/**"
+
+    - title: "Tests"
+      description: |
+        tests ^.^
+      sub:
+        - title: "ast json tests"
+          globs:
+            - "test/libsolidity/ASTJSON/**"
+
+        - title: "syntax tests"
+          globs:
+            - "test/libsolidity/syntaxTests/**"
+
+        - title: "semantic tests"
+          globs:
+            - "test/libsolidity/semanticTests/**"
+
+        - title: "other tests"
+          globs:
+            - "test/**"
+
+        - title: "testing scripts"
+          globs:
+            - "scripts/**"
+
+    - title: "CICD"
+      description: |
+        Changes to CICD workflows to support our custom testing and deployment.
+      sub:
+        - title: "Github workflows"
+          globs:
+            - ".github/**"
+            - ".circleci/**"
+
+# files can be ignored globally, these will be listed in a separate grayed-out section,
+# and do not count towards the total line count.
+ignore:
+  - "**/Cargo.toml"
+  - "fork.yaml"

--- a/fork.yaml
+++ b/fork.yaml
@@ -1,3 +1,7 @@
+# Uses https://github.com/protolambda/forkdiff to generate a diff overview index.html page.
+# To use:
+# 1. install forkdiff: `go install github.com/protolambda/forkdiff@latest`
+# 2. run `forkdiff`
 title: "SeismicSystems/seismic-solidity" # Define the HTML page title
 logo: "logo.png"
 footer: | # define the footer with markdown


### PR DESCRIPTION
Adds `fork.yaml` and a CI pipeline to push the generated [forkdiff](https://github.com/protolambda/forkdiff) `index.html` page to github pages, which looks like:
<img width="1122" height="746" alt="image" src="https://github.com/user-attachments/assets/20b098d5-80f5-4cef-b82b-6a3a0994bd33" />

## Usage

To run locally, just install forkdiff with `go install github.com/protolambda/forkdiff@latest`, and then from the repo root just run `forkdiff`. It'll generate an `index.html` page which you can open in a browser to view the result.

## Github Page CI

Added a CI workflow to publish the forkdiff index.html page to a github page. Not sure if it'll work before we merge to seismic branch... for now propose merging into the audit branch, or just leaving here until we finish the audit.