### PR TITLE
fix(yul-optimiser): dont hoist sloads since they can revert

### DIFF
--- a/libevmasm/SemanticInformation.cpp
+++ b/libevmasm/SemanticInformation.cpp
@@ -546,7 +546,10 @@ bool SemanticInformation::movableApartFromEffects(Instruction _instruction)
 	case Instruction::RETURNDATASIZE:
 	case Instruction::BALANCE:
 	case Instruction::SELFBALANCE:
-	case Instruction::SLOAD:
+	// SLOAD is NOT movable apart from effects because it can revert due to
+	// confidentiality mismatch (reading private storage).
+	// Hoisting SLOAD out of a loop could change behavior from non-reverting
+	// to reverting for zero-iteration loops.
 	case Instruction::CLOAD:
 	case Instruction::TLOAD:
 	case Instruction::KECCAK256:

--- a/test/libyul/functionSideEffects/storage.yul
+++ b/test/libyul/functionSideEffects/storage.yul
@@ -11,4 +11,4 @@
 // a: writes storage
 // f: writes storage
 // g: writes other state, writes storage, writes memory
-// h: movable apart from effects, can be removed, can be removed if no msize, reads storage
+// h: can be removed, can be removed if no msize, reads storage

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/move_cload.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/move_cload.yul
@@ -1,0 +1,25 @@
+{
+    let b := 1
+    // CLOAD CAN be hoisted because it cannot revert (in Seismic's updated semantics).
+    // Unlike SLOAD, CLOAD can read both public and private slots.
+    for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
+        let inv := add(b, 42)
+        let x := cload(mul(inv, 3))
+        a := add(x, 1)
+        mstore(a, inv)
+    }
+}
+// ----
+// step: loopInvariantCodeMotion
+//
+// {
+//     let b := 1
+//     let a := 1
+//     let inv := add(b, 42)
+//     let x := cload(mul(inv, 3))
+//     for { } iszero(eq(a, 10)) { a := add(a, 1) }
+//     {
+//         a := add(x, 1)
+//         mstore(a, inv)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/move_memory_function.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/move_memory_function.yul
@@ -1,4 +1,6 @@
 {
+    // In Seismic, SLOAD is marked as having effects because it can revert.
+    // Therefore, it cannot be hoisted out of loops.
   function g() -> x { x := add(sload(mload(x)), 1) }
 
   let b := 1
@@ -14,11 +16,12 @@
 // {
 //     let b := 1
 //     let a := 1
-//     let t := mload(g())
-//     let s := keccak256(g(), 32)
-//     let q := g()
 //     for { } iszero(eq(a, 10)) { a := add(a, 1) }
-//     { }
+//     {
+//         let t := mload(g())
+//         let s := keccak256(g(), 32)
+//         let q := g()
+//     }
 //     function g() -> x
 //     { x := add(sload(mload(x)), 1) }
 // }

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/move_state_function.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/move_state_function.yul
@@ -1,5 +1,7 @@
 {
   function f() -> x { x := mload(g()) }
+    // In Seismic, SLOAD is marked as having effects because it can revert.
+    // Therefore, it cannot be hoisted out of loops.
   function g() -> x { x := add(sload(x), 1) }
 
   let b := 1
@@ -14,10 +16,11 @@
 // {
 //     let b := 1
 //     let a := 1
-//     let t := balance(f())
-//     let q := g()
 //     for { } iszero(eq(a, 10)) { a := add(a, 1) }
-//     { }
+//     {
+//         let t := balance(f())
+//         let q := g()
+//     }
 //     function f() -> x
 //     { x := mload(g()) }
 //     function g() -> x_1

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/move_storage_function.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/move_storage_function.yul
@@ -4,6 +4,8 @@
 
   let b := 1
   for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
+    // In Seismic, SLOAD is marked as having effects because it can revert.
+    // Therefore, it cannot be hoisted out of loops.
     let t := sload(f())
     let q := g()
   }
@@ -14,10 +16,11 @@
 // {
 //     let b := 1
 //     let a := 1
-//     let t := sload(f())
 //     let q := g()
 //     for { } iszero(eq(a, 10)) { a := add(a, 1) }
-//     { }
+//     {
+//         let t := sload(f())
+//     }
 //     function f() -> x
 //     { x := g() }
 //     function g() -> x_1

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/move_storage_function.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/move_storage_function.yul
@@ -18,9 +18,7 @@
 //     let a := 1
 //     let q := g()
 //     for { } iszero(eq(a, 10)) { a := add(a, 1) }
-//     {
-//         let t := sload(f())
-//     }
+//     { let t := sload(f()) }
 //     function f() -> x
 //     { x := g() }
 //     function g() -> x_1

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_sload_can_revert.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_sload_can_revert.yul
@@ -1,0 +1,27 @@
+{
+    let b := 1
+    // SLOAD should NOT be hoisted even though there's no storage write in the loop.
+    // In Seismic, SLOAD can revert due to confidentiality mismatch.
+    // Hoisting it out of a zero-iteration loop would change behavior from
+    // non-reverting to reverting.
+    for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
+        let inv := add(b, 42)
+        let x := sload(mul(inv, 3))
+        a := add(x, 1)
+        mstore(a, inv)
+    }
+}
+// ----
+// step: loopInvariantCodeMotion
+//
+// {
+//     let b := 1
+//     let a := 1
+//     let inv := add(b, 42)
+//     for { } iszero(eq(a, 10)) { a := add(a, 1) }
+//     {
+//         let x := sload(mul(inv, 3))
+//         a := add(x, 1)
+//         mstore(a, inv)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/simple_storage.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/simple_storage.yul
@@ -2,6 +2,8 @@
   let b := 1
   for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
     let inv := add(b, 42)
+    // In Seismic, SLOAD is marked as having effects because it can revert.
+    // Therefore, it cannot be hoisted out of loops.
     let x := sload(mul(inv, 3))
     a := add(x, 1)
     mstore(a, inv)
@@ -14,9 +16,9 @@
 //     let b := 1
 //     let a := 1
 //     let inv := add(b, 42)
-//     let x := sload(mul(inv, 3))
 //     for { } iszero(eq(a, 10)) { a := add(a, 1) }
 //     {
+//         let x := sload(mul(inv, 3))
 //         a := add(x, 1)
 //         mstore(a, inv)
 //     }


### PR DESCRIPTION
Fixes https://app.audithub.dev/app/organizations/224/projects/585/project-viewer?issueId=767

Made SLOAD be movableExceptForSideEffects so that the yul optimiser won't hoist it out of for loops (since it would be wrong in cases where the loop might run 0 times, but hoisting it could cause a revert).

Companion to https://github.com/SeismicSystems/seismic-solidity/pull/148.

## Gas costs effect

This is actually potentially very bad for certain contracts... see some of the tests that get changed with a lot of function calls not getting hoisted anymore. That being said.. the tests do seem a bit artificial.