### PR TITLE
fix(ver-793): Transient shielded stores should NOT be persisted

### DIFF
--- a/libsolidity/codegen/LValue.cpp
+++ b/libsolidity/codegen/LValue.cpp
@@ -235,7 +235,7 @@ void GenericStorageItem<IsTransient>::retrieveValue(langutil::SourceLocation con
 	if (!_remove)
 		CompilerUtils(m_context).copyToStackTop(sizeOnStack(), sizeOnStack());
 	if (m_dataType->isShielded() && m_dataType->storageBytes() == 32)
-		m_context << Instruction::POP << Instruction::CLOAD;
+		m_context << Instruction::POP << (IsTransient ? s_loadInstruction : Instruction::CLOAD);
 	else if (m_dataType->storageBytes() == 32)
 		m_context << Instruction::POP << s_loadInstruction;
 	else
@@ -317,7 +317,7 @@ void GenericStorageItem<IsTransient>::storeValue(Type const& _sourceType, langut
 			utils.convertType(_sourceType, *m_dataType, true);
 			m_context << Instruction::SWAP1;
 
-			m_context << Instruction::CSTORE;
+			m_context << (IsTransient ? s_storeInstruction : Instruction::CSTORE);
 		}
 		else if (m_dataType->storageBytes() == 32)
 		{
@@ -516,7 +516,7 @@ void GenericStorageItem<IsTransient>::setToZero(langutil::SourceLocation const&,
 			// offset should be zero. remember, shielded types have to be 32 bytes!!
 			m_context
 				<< Instruction::POP << u256(0)
-				<< Instruction::SWAP1 << Instruction::CSTORE;
+				<< Instruction::SWAP1 << (IsTransient ? s_storeInstruction : Instruction::CSTORE);
 		}
 		else if (m_dataType->isShielded())
 		{

--- a/libsolidity/codegen/LValue.h
+++ b/libsolidity/codegen/LValue.h
@@ -174,6 +174,10 @@ public:
 		bool _removeReference = true
 	) const override;
 private:
+	// NOTE: when using s_sload/s_storeInstruction on shielded types,
+	//       we instead use CLOAD/CSTORE when the type is not transient.
+	// IMPORTANT to use similar pattern on any future usage these instructions.
+	// Be especially cautious about merging in upstream code that uses these
 	static constexpr evmasm::Instruction s_storeInstruction = IsTransient ? evmasm::Instruction::TSTORE : evmasm::Instruction::SSTORE;
 	static constexpr evmasm::Instruction s_loadInstruction = IsTransient ? evmasm::Instruction::TLOAD : evmasm::Instruction::SLOAD;
 };

--- a/test/cmdlineTests/evmasm_transient_storage_delete_shielded/args
+++ b/test/cmdlineTests/evmasm_transient_storage_delete_shielded/args
@@ -1,0 +1,1 @@
+--no-cbor-metadata --optimize --asm --debug-info none

--- a/test/cmdlineTests/evmasm_transient_storage_delete_shielded/input.sol
+++ b/test/cmdlineTests/evmasm_transient_storage_delete_shielded/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0.0;
+
+contract C {
+    suint256 transient x;
+    function set(suint256 v) external {
+        x = v;
+    }
+    function clr() external {
+        delete x;
+    }
+}

--- a/test/cmdlineTests/evmasm_transient_storage_delete_shielded/output
+++ b/test/cmdlineTests/evmasm_transient_storage_delete_shielded/output
@@ -1,0 +1,96 @@
+
+======= input.sol:C =======
+EVM assembly:
+  mstore(0x40, 0x80)
+  callvalue
+  dup1
+  iszero
+  tag_1
+  jumpi
+  revert(0x00, 0x00)
+tag_1:
+  pop
+  dataSize(sub_0)
+  dup1
+  dataOffset(sub_0)
+  0x00
+  codecopy
+  0x00
+  return
+stop
+
+sub_0: assembly {
+      mstore(0x40, 0x80)
+      callvalue
+      dup1
+      iszero
+      tag_1
+      jumpi
+      revert(0x00, 0x00)
+    tag_1:
+      pop
+      jumpi(tag_2, lt(calldatasize, 0x04))
+      shr(0xe0, calldataload(0x00))
+      dup1
+      0x0ef1346a
+      eq
+      tag_3
+      jumpi
+      dup1
+      0xa00dddbd
+      eq
+      tag_4
+      jumpi
+    tag_2:
+      revert(0x00, 0x00)
+    tag_3:
+      tag_5
+      tag_6
+      jump	// in
+    tag_5:
+      stop
+    tag_4:
+      tag_5
+      tag_8
+      calldatasize
+      0x04
+      tag_9
+      jump	// in
+    tag_8:
+      tag_10
+      jump	// in
+    tag_6:
+      0x00
+      dup1
+      tstore
+      jump	// out
+    tag_10:
+      dup1
+      dup1
+      0x00
+      tstore
+      pop
+      pop
+      jump	// out
+    tag_9:
+      0x00
+      0x20
+      dup3
+      dup5
+      sub
+      slt
+      iszero
+      tag_15
+      jumpi
+      0x00
+      0x00
+      revert
+    tag_15:
+      pop
+      calldataload
+      swap2
+      swap1
+      pop
+      jump	// out
+}
+

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/args
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/args
@@ -1,0 +1,1 @@
+--no-cbor-metadata --optimize --asm --debug-info none

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/input.sol
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0.0;
+
+contract C {
+    sint256 transient x;
+    function set(sint256 v) external {
+        x = v;
+    }
+    function get() external view {
+        x;
+    }
+}

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/output
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_sint256/output
@@ -1,0 +1,84 @@
+
+======= input.sol:C =======
+EVM assembly:
+  mstore(0x40, 0x80)
+  callvalue
+  dup1
+  iszero
+  tag_1
+  jumpi
+  revert(0x00, 0x00)
+tag_1:
+  pop
+  dataSize(sub_0)
+  dup1
+  dataOffset(sub_0)
+  0x00
+  codecopy
+  0x00
+  return
+stop
+
+sub_0: assembly {
+      mstore(0x40, 0x80)
+      callvalue
+      dup1
+      iszero
+      tag_1
+      jumpi
+      revert(0x00, 0x00)
+    tag_1:
+      pop
+      jumpi(tag_2, lt(calldatasize, 0x04))
+      shr(0xe0, calldataload(0x00))
+      dup1
+      0x6d4ce63c
+      eq
+      tag_3
+      jumpi
+      dup1
+      0xf9e5def4
+      eq
+      tag_4
+      jumpi
+    tag_2:
+      revert(0x00, 0x00)
+    tag_3:
+      stop
+    tag_4:
+      tag_3
+      tag_8
+      calldatasize
+      0x04
+      tag_9
+      jump	// in
+    tag_8:
+      dup1
+      dup1
+      0x00
+      tstore
+      pop
+      pop
+      jump	// out
+    tag_9:
+      0x00
+      0x20
+      dup3
+      dup5
+      sub
+      slt
+      iszero
+      tag_15
+      jumpi
+      0x00
+      0x00
+      revert
+    tag_15:
+      pop
+      calldataload
+      swap2
+      swap1
+      pop
+      jump	// out
+}
+

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/args
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/args
@@ -1,0 +1,1 @@
+--no-cbor-metadata --optimize --asm --debug-info none

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/input.sol
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0.0;
+
+contract C {
+    suint256 transient x;
+    function set(suint256 v) external {
+        x = v;
+    }
+    function get() external view {
+        x;
+    }
+}

--- a/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/output
+++ b/test/cmdlineTests/evmasm_transient_storage_shielded_suint256/output
@@ -1,0 +1,84 @@
+
+======= input.sol:C =======
+EVM assembly:
+  mstore(0x40, 0x80)
+  callvalue
+  dup1
+  iszero
+  tag_1
+  jumpi
+  revert(0x00, 0x00)
+tag_1:
+  pop
+  dataSize(sub_0)
+  dup1
+  dataOffset(sub_0)
+  0x00
+  codecopy
+  0x00
+  return
+stop
+
+sub_0: assembly {
+      mstore(0x40, 0x80)
+      callvalue
+      dup1
+      iszero
+      tag_1
+      jumpi
+      revert(0x00, 0x00)
+    tag_1:
+      pop
+      jumpi(tag_2, lt(calldatasize, 0x04))
+      shr(0xe0, calldataload(0x00))
+      dup1
+      0x6d4ce63c
+      eq
+      tag_3
+      jumpi
+      dup1
+      0xa00dddbd
+      eq
+      tag_4
+      jumpi
+    tag_2:
+      revert(0x00, 0x00)
+    tag_3:
+      stop
+    tag_4:
+      tag_3
+      tag_8
+      calldatasize
+      0x04
+      tag_9
+      jump	// in
+    tag_8:
+      dup1
+      dup1
+      0x00
+      tstore
+      pop
+      pop
+      jump	// out
+    tag_9:
+      0x00
+      0x20
+      dup3
+      dup5
+      sub
+      slt
+      iszero
+      tag_15
+      jumpi
+      0x00
+      0x00
+      revert
+    tag_15:
+      pop
+      calldataload
+      swap2
+      swap1
+      pop
+      jump	// out
+}
+

--- a/test/libsolidity/semanticTests/variables/transient_shielded_different_types.sol
+++ b/test/libsolidity/semanticTests/variables/transient_shielded_different_types.sol
@@ -1,0 +1,30 @@
+contract C {
+    suint256 transient su;
+    sint256 transient si;
+    saddress transient sa;
+    sbool transient sb;
+
+    function setAndCheckSu(uint256 v) public returns (uint256) {
+        su = suint256(v);
+        return uint256(su);
+    }
+    function setAndCheckSi(int256 v) public returns (int256) {
+        si = sint256(v);
+        return int256(si);
+    }
+    function setAndCheckSa(address v) public returns (address) {
+        sa = saddress(v);
+        return address(sa);
+    }
+    function setAndCheckSb(bool v) public returns (bool) {
+        sb = sbool(v);
+        return bool(sb);
+    }
+}
+// ====
+// EVMVersion: >=mercury
+// ----
+// setAndCheckSu(uint256): 123 -> 123
+// setAndCheckSi(int256): -456 -> -456
+// setAndCheckSa(address): 0x1234567890123456789012345678901234567890 -> 0x1234567890123456789012345678901234567890
+// setAndCheckSb(bool): true -> true

--- a/test/libsolidity/semanticTests/variables/transient_shielded_state_variable.sol
+++ b/test/libsolidity/semanticTests/variables/transient_shielded_state_variable.sol
@@ -1,0 +1,16 @@
+contract C {
+    suint256 transient x;
+
+    function setAndCheck(uint256 v) public returns (uint256) {
+        x = suint256(v);
+        return uint256(x);
+    }
+    function checkX() public view returns (uint256) {
+        return uint256(x);
+    }
+}
+// ====
+// EVMVersion: >=mercury
+// ----
+// setAndCheck(uint256): 42 -> 42
+// checkX() -> 0


### PR DESCRIPTION
Cherry-picked from `zellic-audit` PR https://github.com/SeismicSystems/seismic-solidity/pull/124