### PR TITLE
test(types): add regression tests for UDVT shielded mapping keys

### DIFF
--- a/test/libsolidity/syntaxTests/shieldedTypes/udvt_nonshielded_mapping_key.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/udvt_nonshielded_mapping_key.sol
@@ -1,0 +1,6 @@
+// Non-shielded user defined value types should still be allowed as mapping keys
+type MyUint is uint256;
+contract C {
+    mapping(MyUint => uint256) m;
+}
+// ----

--- a/test/libsolidity/syntaxTests/shieldedTypes/udvt_shielded_mapping_key.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/udvt_shielded_mapping_key.sol
@@ -1,0 +1,6 @@
+contract C {
+    type SB is sbool;
+    mapping(SB => uint256) m;
+}
+// ----
+// TypeError 7804: (47-49): Shielded types are not allowed as mapping keys.

--- a/test/libsolidity/syntaxTests/shieldedTypes/udvt_shielded_mapping_key_saddress.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/udvt_shielded_mapping_key_saddress.sol
@@ -1,0 +1,6 @@
+contract C {
+    type SA is saddress;
+    mapping(SA => uint256) m;
+}
+// ----
+// TypeError 7804: (50-52): Shielded types are not allowed as mapping keys.

--- a/test/libsolidity/syntaxTests/shieldedTypes/udvt_shielded_mapping_key_suint.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/udvt_shielded_mapping_key_suint.sol
@@ -1,0 +1,6 @@
+contract C {
+    type SU is suint256;
+    mapping(SU => uint256) m;
+}
+// ----
+// TypeError 7804: (50-52): Shielded types are not allowed as mapping keys.


### PR DESCRIPTION
Add syntax tests verifying that user-defined value types wrapping shielded types (sbool, suint256, saddress) are rejected as mapping keys. Also includes a positive test confirming non-shielded UDVTs remain allowed.

These tests validate the fix in https://github.com/SeismicSystems/seismic-solidity/pull/156 (commit [5fbd4d4bb](https://github.com/SeismicSystems/seismic-solidity/commit/5fbd4d4bb332114898804e1cd7511fb9c41db0f9)) which added isShielded() delegation to UserDefinedValueType.