### PR TITLE
byte/string array push results in invalid yul code

### DIFF
--- a/test/libsolidity/semanticTests/array/bytes_push_boundary_transition.sol
+++ b/test/libsolidity/semanticTests/array/bytes_push_boundary_transition.sol
@@ -1,0 +1,42 @@
+// Tests bytes.push() around the short/long array boundary (31 bytes)
+// Regression test for storageArrayPushFunction bug
+contract C {
+    bytes data;
+
+    function pushByte(bytes1 b) public {
+        data.push(b);
+    }
+
+    function getLength() public view returns (uint256) {
+        return data.length;
+    }
+
+    function getByte(uint256 i) public view returns (bytes1) {
+        return data[i];
+    }
+
+    // Fill to exactly 30 bytes (still short array)
+    function fillTo30() public {
+        for (uint i = 0; i < 30; i++) {
+            data.push(bytes1(uint8(0x10 + i)));
+        }
+    }
+}
+// ----
+// getLength() -> 0
+// fillTo30() ->
+// getLength() -> 30
+// getByte(uint256): 0 -> left(0x10)
+// getByte(uint256): 29 -> left(0x2d)
+// pushByte(bytes1): left(0xE1) ->
+// getLength() -> 31
+// getByte(uint256): 30 -> left(0xE1)
+// pushByte(bytes1): left(0xE2) ->
+// getLength() -> 32
+// getByte(uint256): 31 -> left(0xE2)
+// pushByte(bytes1): left(0xE3) ->
+// getLength() -> 33
+// getByte(uint256): 32 -> left(0xE3)
+// pushByte(bytes1): left(0xE4) ->
+// getLength() -> 34
+// getByte(uint256): 33 -> left(0xE4)

--- a/test/libsolidity/semanticTests/array/bytes_push_length_update.sol
+++ b/test/libsolidity/semanticTests/array/bytes_push_length_update.sol
@@ -1,0 +1,37 @@
+// Tests that bytes.push(value) correctly updates length for long arrays
+// Regression test: sload was used instead of sstore, failing to update length
+contract C {
+    bytes data;
+
+    function setup() public {
+        // Create a 64-byte array (well into long array territory)
+        for (uint i = 0; i < 64; i++) {
+            data.push(bytes1(uint8(i)));
+        }
+    }
+
+    function pushAndReturnLength(bytes1 b) public returns (uint256) {
+        data.push(b);
+        return data.length;
+    }
+
+    function getLength() public view returns (uint256) {
+        return data.length;
+    }
+
+    function getByte(uint256 i) public view returns (bytes1) {
+        return data[i];
+    }
+}
+// ----
+// setup() ->
+// getLength() -> 64
+// pushAndReturnLength(bytes1): left(0xFF) -> 65
+// getLength() -> 65
+// getByte(uint256): 64 -> left(0xFF)
+// pushAndReturnLength(bytes1): left(0xFE) -> 66
+// getLength() -> 66
+// getByte(uint256): 65 -> left(0xFE)
+// pushAndReturnLength(bytes1): left(0xFD) -> 67
+// getLength() -> 67
+// getByte(uint256): 66 -> left(0xFD)

--- a/test/libsolidity/semanticTests/array/bytes_push_long_array.sol
+++ b/test/libsolidity/semanticTests/array/bytes_push_long_array.sol
@@ -1,0 +1,41 @@
+// Tests bytes.push(value) for long arrays (>31 bytes)
+// Regression test for bug where sload was used instead of sstore
+// and storeValue was missing template brackets in storageArrayPushFunction
+contract C {
+    bytes data;
+
+    // Fill array to exactly 32 bytes (transition to long array encoding)
+    function setup() public {
+        for (uint i = 0; i < 32; i++) {
+            data.push(bytes1(uint8(i)));
+        }
+    }
+
+    // Push to long array - this exercises the buggy code path
+    function pushToLongArray(bytes1 b) public {
+        data.push(b);
+    }
+
+    function getLength() public view returns (uint256) {
+        return data.length;
+    }
+
+    function getByte(uint256 i) public view returns (bytes1) {
+        return data[i];
+    }
+}
+// ----
+// getLength() -> 0
+// setup() ->
+// getLength() -> 32
+// getByte(uint256): 0 -> left(0x00)
+// getByte(uint256): 31 -> left(0x1f)
+// pushToLongArray(bytes1): left(0xAA) ->
+// getLength() -> 33
+// getByte(uint256): 32 -> left(0xAA)
+// pushToLongArray(bytes1): left(0xBB) ->
+// getLength() -> 34
+// getByte(uint256): 33 -> left(0xBB)
+// pushToLongArray(bytes1): left(0xCC) ->
+// getLength() -> 35
+// getByte(uint256): 34 -> left(0xCC)

--- a/test/libsolidity/semanticTests/array/string_push_via_bytes.sol
+++ b/test/libsolidity/semanticTests/array/string_push_via_bytes.sol
@@ -1,0 +1,40 @@
+// Tests string storage push via bytes cast for long strings
+// Regression test for storageArrayPushFunction bug (affects isByteArrayOrString)
+contract C {
+    string data;
+
+    function setup() public {
+        // Create a 40-character string (long string encoding)
+        data = "1234567890123456789012345678901234567890";
+    }
+
+    function pushChar(bytes1 b) public {
+        bytes(data).push(b);
+    }
+
+    function getLength() public view returns (uint256) {
+        return bytes(data).length;
+    }
+
+    function getChar(uint256 i) public view returns (bytes1) {
+        return bytes(data)[i];
+    }
+
+    function getString() public view returns (string memory) {
+        return data;
+    }
+}
+// ----
+// setup() ->
+// getLength() -> 40
+// getChar(uint256): 0 -> left(0x31)
+// getChar(uint256): 39 -> left(0x30)
+// pushChar(bytes1): left(0x41) ->
+// getLength() -> 41
+// getChar(uint256): 40 -> left(0x41)
+// pushChar(bytes1): left(0x42) ->
+// getLength() -> 42
+// getChar(uint256): 41 -> left(0x42)
+// pushChar(bytes1): left(0x43) ->
+// getLength() -> 43
+// getChar(uint256): 42 -> left(0x43)


### PR DESCRIPTION
Add additional semantic tests for the storageArrayPushFunction bug where sload was incorrectly used instead of sstore and storeValue was missing template brackets for long byte/string arrays.

Tests cover:
- bytes_push_long_array: pushing to arrays already in long encoding
- bytes_push_boundary_transition: short-to-long array transition
- bytes_push_length_update: verifies length updates correctly
- string_push_via_bytes: tests string path via bytes(str).push()

Fix occurred in https://github.com/SeismicSystems/seismic-solidity/pull/160