### PR TITLE
VER-775: Byte array helpers should check base type category, not array category

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -1457,7 +1457,7 @@ std::string YulUtilFunctions::resizeDynamicByteArrayFunction(ArrayType const& _t
 			}
 		)")
 		("extractLength", extractByteArrayLengthFunction())
-		("loadOpcode", _type.category() == Type::Category::ShieldedInteger ? "cload" : "sload")
+		("loadOpcode", _type.baseType()->isShielded() ? "cload" : "sload")
 		("decreaseSize", decreaseByteArraySizeFunction(_type))
 		("increaseSize", increaseByteArraySizeFunction(_type))
 		.render();
@@ -1562,7 +1562,7 @@ std::string YulUtilFunctions::increaseByteArraySizeFunction(ArrayType const& _ty
 		("maxArrayLength", (u256(1) << 64).str())
 		("dataPosition", arrayDataAreaFunction(_type))
 		("encodeUsedSetLen", shortByteArrayEncodeUsedAreaSetLengthFunction())
-		("storeOpcode", _type.category() == Type::Category::ShieldedInteger ? "cstore" : "sstore")
+		("storeOpcode", _type.baseType()->isShielded() ? "cstore" : "sstore")
 		.render();
 	});
 }
@@ -1583,8 +1583,8 @@ std::string YulUtilFunctions::byteArrayTransitLongToShortFunction(ArrayType cons
 			("functionName", functionName)
 			("dataPosition", arrayDataAreaFunction(_type))
 			("extractUsedApplyLen", shortByteArrayEncodeUsedAreaSetLengthFunction())
-			("storeOpcode", _type.category() == Type::Category::ShieldedInteger ? "cstore" : "sstore")
-			("loadOpcode", _type.category() == Type::Category::ShieldedInteger ? "cload" : "sload")
+			("storeOpcode", _type.baseType()->isShielded() ? "cstore" : "sstore")
+			("loadOpcode", _type.baseType()->isShielded() ? "cload" : "sload")
 			.render();
 	});
 }
@@ -1694,7 +1694,7 @@ std::string YulUtilFunctions::storageByteArrayPopFunction(ArrayType const& _type
 			("transitLongToShort", byteArrayTransitLongToShortFunction(_type))
 			("encodeUsedSetLen", shortByteArrayEncodeUsedAreaSetLengthFunction())
 			("indexAccessNoChecks", longByteArrayStorageIndexAccessNoCheckFunction())
-			("loadOpcode", _type.category() == Type::Category::ShieldedInteger ? "cload" : "sload")
+			("loadOpcode", _type.baseType()->isShielded() ? "cload" : "sload")
 			("setToZero", storageSetToZeroFunction(*_type.baseType(), VariableDeclaration::Location::Unspecified))
 			.render();
 	});

--- a/test/libsolidity/syntaxTests/types/sbytes_no_dynamic_byte_array.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_no_dynamic_byte_array.sol
@@ -1,0 +1,33 @@
+// Byte array helpers (resize, push, pop, transitLongToShort) only apply to
+// bytes/string. There is no shielded dynamic bytes type. sbytesN is a
+// fixed-size value type that does not route through byte array helpers.
+contract C {
+    bytes public b;
+    string public s;
+    sbytes32 sb;
+
+    // bytes/string use byte array storage helpers (sload/sstore only)
+    function testBytesPushPop() public {
+        b.push(0x01);
+        b.push(0x02);
+        b.pop();
+    }
+
+    function testBytesResize() public {
+        b = new bytes(64);
+        b = new bytes(16);
+        b = new bytes(0);
+    }
+
+    function testStringAssign() public {
+        s = "short";
+        s = "this is a long string that exceeds thirty two bytes in length!!";
+        s = "";
+    }
+
+    // sbytesN is a fixed-size value type, not a dynamic byte array
+    function testSbytesN() public {
+        sb = sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132);
+    }
+}
+// ----


### PR DESCRIPTION
I kinda middled the recommendation here: before actually implementing `sbytes` in full, I want to at least set up this dead code to not be wrong for when we do implement it