### PR TITLE
Don't allow ABI encoding shielded values

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -168,6 +168,12 @@ TypePointers TypeChecker::typeCheckABIDecodeAndRetrieveReturnType(FunctionCall c
 					typeArgument->location(),
 					"Decoding type " + actualType->humanReadableName() + " not supported."
 				);
+			else if (actualType->containsShieldedType())
+				m_errorReporter.typeError(
+					4851_error,
+					typeArgument->location(),
+					"Shielded types cannot be ABI encoded."
+				);
 
 			if (auto referenceType = dynamic_cast<ReferenceType const*>(actualType))
 			{
@@ -2424,6 +2430,12 @@ void TypeChecker::typeCheckABIEncodeFunctions(
 				arguments[i]->location(),
 				"This type cannot be encoded."
 			);
+		else if (argType->containsShieldedType())
+			m_errorReporter.typeError(
+				3648_error,
+				arguments[i]->location(),
+				"Shielded types cannot be ABI encoded."
+			);
 	}
 }
 
@@ -2576,6 +2588,12 @@ void TypeChecker::typeCheckABIEncodeCallFunction(FunctionCall const& _functionCa
 				externalFunctionType->parameterTypes()[i]->humanReadableName() +
 				"\"" +
 				(result.message().empty() ?  "." : ": " + result.message())
+			);
+		else if (argType.containsShieldedType())
+			m_errorReporter.typeError(
+				3648_error,
+				callArguments[i]->location(),
+				"Shielded types cannot be ABI encoded."
 			);
 	}
 }

--- a/test/libsolidity/semanticTests/functionCall/seismic_precompiles/AESEncryptAndDecryptWithRng.sol
+++ b/test/libsolidity/semanticTests/functionCall/seismic_precompiles/AESEncryptAndDecryptWithRng.sol
@@ -20,7 +20,7 @@ contract AES {
     function encryptAndStore() public {
         address AESEncryptAddr = address(0x66);
 
-        bytes memory input = abi.encodePacked(AES_KEY, NONCE, PLAINTEXT);
+        bytes memory input = abi.encodePacked(AES_KEY, uint96(NONCE), PLAINTEXT);
 
         (bool success, bytes memory output) = AESEncryptAddr.staticcall(input);
         require(success, "Precompile encryption call failed");
@@ -34,7 +34,7 @@ contract AES {
 
         address AESDecryptAddr = address(0x67);
 
-        bytes memory input = abi.encodePacked(AES_KEY, NONCE, encryptedData);
+        bytes memory input = abi.encodePacked(AES_KEY, uint96(NONCE), encryptedData);
 
         (bool success, bytes memory output) = AESDecryptAddr.staticcall(input);
         require(success, "Precompile decryption call failed");

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_decode_shielded_address.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_decode_shielded_address.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f(bytes memory data) public pure {
+        abi.decode(data, (saddress));
+    }
+}
+// ----
+// TypeError 4851: (87-95): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_decode_shielded_bool.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_decode_shielded_bool.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f(bytes memory data) public pure {
+        abi.decode(data, (sbool));
+    }
+}
+// ----
+// TypeError 4851: (87-92): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_decode_shielded_struct.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_decode_shielded_struct.sol
@@ -1,0 +1,8 @@
+contract C {
+    struct S { suint256 a; suint256 b; }
+    function f(bytes memory data) public pure {
+        abi.decode(data, (S));
+    }
+}
+// ----
+// TypeError 4851: (128-129): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_decode_shielded_types.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_decode_shielded_types.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f(bytes memory data) public pure {
+        abi.decode(data, (suint256));
+    }
+}
+// ----
+// TypeError 4851: (87-95): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_packed_shielded.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_packed_shielded.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure {
+        sbool b = sbool(true);
+        abi.encodePacked(b);
+    }
+}
+// ----
+// Warning 9661: (52-73): Bool Literals converted to shielded bools will leak during contract deployment.
+// TypeError 3648: (100-101): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_shielded_address.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_shielded_address.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() public pure {
+        saddress a = saddress(0);
+        abi.encode(a);
+    }
+}
+// ----
+// TypeError 3648: (97-98): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_shielded_array.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_shielded_array.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() public pure {
+        suint256[] memory arr = new suint256[](1);
+        abi.encode(arr);
+    }
+}
+// ----
+// TypeError 3648: (114-117): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_shielded_struct.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_shielded_struct.sol
@@ -1,0 +1,8 @@
+contract C {
+    struct S { suint256 a; suint256 b; }
+    function f(S memory s) internal pure {
+        abi.encode(s);
+    }
+}
+// ----
+// TypeError 3648: (116-117): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_shielded_types.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_shielded_types.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure {
+        suint256 a = suint256(1);
+        abi.encode(a);
+    }
+}
+// ----
+// Warning 9660: (52-76): Literals converted to shielded integers will leak during contract deployment.
+// TypeError 3648: (97-98): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_with_selector_shielded.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_with_selector_shielded.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure {
+        suint256 a = suint256(1);
+        abi.encodeWithSelector(bytes4(0x12345678), a);
+    }
+}
+// ----
+// Warning 9660: (52-76): Literals converted to shielded integers will leak during contract deployment.
+// TypeError 3648: (129-130): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_with_signature_shielded.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_with_signature_shielded.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure {
+        suint256 a = suint256(1);
+        abi.encodeWithSignature("foo(uint256)", a);
+    }
+}
+// ----
+// Warning 9660: (52-76): Literals converted to shielded integers will leak during contract deployment.
+// TypeError 3648: (126-127): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/types/address/shielded_address_abi_decode.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_address_abi_decode.sol
@@ -5,3 +5,4 @@ contract C {
     }
 }
 // ----
+// TypeError 4851: (130-138): Shielded types cannot be ABI encoded.


### PR DESCRIPTION
Cherry picked from https://github.com/SeismicSystems/seismic-solidity/pull/165