### PR TITLE
test(analysis): Yul/assembly should not allow mismatched privacy opcodes (compiles, but reverts at runtime)

### DIFF
--- a/test/libsolidity/semanticTests/inlineAssembly/cstore_then_sload_dynamic_slot_should_fail.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/cstore_then_sload_dynamic_slot_should_fail.sol
@@ -1,0 +1,16 @@
+contract C {
+    function test(uint slot) external returns (uint) {
+        assembly {
+            cstore(0, 42)
+        }
+        // Separate block to avoid compile-time detection.
+        // When slot == 0, sload should revert because the slot is now private.
+        assembly {
+            let x := sload(slot)
+            mstore(0, x)
+            return(0, 32)
+        }
+    }
+}
+// ----
+// test(uint256): 0 -> FAILURE

--- a/test/libsolidity/syntaxTests/inlineAssembly/shielded_cstore_caller_then_sload.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/shielded_cstore_caller_then_sload.sol
@@ -1,0 +1,14 @@
+// Audit regression: cstore with caller() value followed by sload on same literal slot
+contract C {
+    event e(uint);
+    function test() external {
+        uint c;
+        assembly {
+            cstore(0, caller())
+            c := sload(0)
+        }
+        emit e(c);
+    }
+}
+// ----
+// TypeError 5768: (234-242): Cannot use sload() on a slot that was previously written with cstore(). cstore() makes the slot private, and sload() cannot access private storage. Use cload() instead.

--- a/test/libsolidity/syntaxTests/inlineAssembly/shielded_cstore_then_sload_dynamic_slot_ok.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/shielded_cstore_then_sload_dynamic_slot_ok.sol
@@ -1,0 +1,12 @@
+// Known limitation: dynamic slot prevents compile-time detection.
+// cstore(0, 0) then sload(slot) with dynamic slot cannot be matched statically.
+// Will revert at runtime if slot == 0.
+contract C {
+    function test(uint slot) external returns (uint c) {
+        assembly {
+            cstore(0, 0)
+            c := sload(slot)
+        }
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/inlineAssembly/shielded_cstore_then_sload_var_slot.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/shielded_cstore_then_sload_var_slot.sol
@@ -1,0 +1,12 @@
+// Variable-based slot matching: same Yul variable for cstore and sload slots
+contract C {
+    function test() external returns (uint c) {
+        assembly {
+            let s := 0
+            cstore(s, 42)
+            c := sload(s)
+        }
+    }
+}
+// ----
+// TypeError 5768: (224-232): Cannot use sload() on a slot that was previously written with cstore(). cstore() makes the slot private, and sload() cannot access private storage. Use cload() instead.


### PR DESCRIPTION
The issue was already fixed in https://github.com/SeismicSystems/seismic-solidity/pull/136 (Commit `ad883e156`)

This PR simply adds tests to confirm the fix