### PR TITLE
chore(ir): disable --via-ir pipeline until we fully support it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,9 +86,12 @@ jobs:
       - name: Run soltest
         run: ./scripts/soltest.sh
 
+      # TODO: Remove the hardcoded commit checkout once we merge the --skip-via-ir flag into the seismic branch of seismic-revm
       - name: Clone seismic-revm repo
         run: |
           git clone https://github.com/SeismicSystems/seismic-revm.git /tmp/seismic-revm
+          cd /tmp/seismic-revm
+          git checkout b0d6010e26e365c41cb3eb05eba774e2510e861d
           echo "SEISMIC_REVM_PATH=/tmp/seismic-revm" >> $GITHUB_ENV
           echo "seismic-revm cloned to: /tmp/seismic-revm"
       - uses: Swatinem/rust-cache@v2
@@ -108,7 +111,7 @@ jobs:
           [ -x "$SSOLC_EXEC" ] || { echo "Error: solc not found at $SSOLC_EXEC"; exit 1; }
           [ -x "$SEISMIC_REVME_EXEC" ] || { echo "Error: revme executable not found at $SEISMIC_REVME_EXEC"; exit 1; }
           SEMANTIC_TESTS_DIR="$GITHUB_WORKSPACE/test/libsolidity/semanticTests"
-          RUST_LOG=info RUST_BACKTRACE=1 $SEISMIC_REVME_EXEC semantics --keep-going -s "$SSOLC_EXEC" -t "$SEMANTIC_TESTS_DIR" 2>&1
+          RUST_LOG=info RUST_BACKTRACE=1 $SEISMIC_REVME_EXEC semantics --keep-going -s "$SSOLC_EXEC" -t "$SEMANTIC_TESTS_DIR" --skip-via-ir 2>&1
       - name: Run semantic tests (with optimizer)
         run: |
           set -euo pipefail
@@ -116,7 +119,9 @@ jobs:
           [ -x "$SSOLC_EXEC" ] || { echo "Error: solc not found at $SSOLC_EXEC"; exit 1; }
           [ -x "$SEISMIC_REVME_EXEC" ] || { echo "Error: revme executable not found at $SEISMIC_REVME_EXEC"; exit 1; }
           SEMANTIC_TESTS_DIR="$GITHUB_WORKSPACE/test/libsolidity/semanticTests"
-          RUST_LOG=info RUST_BACKTRACE=1 $SEISMIC_REVME_EXEC semantics --keep-going -s "$SSOLC_EXEC" -t "$SEMANTIC_TESTS_DIR" --optimize --optimizer-runs 200 2>&1
+          RUST_LOG=info RUST_BACKTRACE=1 $SEISMIC_REVME_EXEC semantics --keep-going -s "$SSOLC_EXEC" -t "$SEMANTIC_TESTS_DIR" --optimize --optimizer-runs 200 --skip-via-ir 2>&1
+      # TODO: Add semantic test runs with --via-ir and --via-ir --optimize --optimizer-runs 200
+      # once the via-ir pipeline is re-enabled. Ideally run all 4 variants in parallel.
 
       # Save caches only on push to target branches (after PR merge)
       # Delete old caches first since GitHub caches are immutable

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -819,6 +819,8 @@ std::variant<StandardCompiler::InputsAndSettings, Json> StandardCompiler::parseI
 		if (!settings["viaIR"].is_boolean())
 			return formatFatalError(Error::Type::JSONError, "\"settings.viaIR\" must be a Boolean.");
 		ret.viaIR = settings["viaIR"].get<bool>();
+		if (ret.viaIR)
+			return formatFatalError(Error::Type::JSONError, "The via-IR pipeline is not currently supported. Support for via-IR is planned for a future release.");
 	}
 
 	if (settings.contains("evmVersion"))

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -1487,6 +1487,12 @@ void CommandLineParser::processArgs()
 		m_args.count(g_strModelCheckerTimeout);
 	m_options.output.viaIR = (m_args.count(g_strExperimentalViaIR) > 0 || m_args.count(g_strViaIR) > 0);
 
+	if (m_options.output.viaIR)
+		solThrow(
+			CommandLineValidationError,
+			"The --via-ir pipeline is not currently supported. Support for --via-ir is planned for a future release."
+		);
+
 	solAssert(
 		m_options.input.mode == InputMode::Compiler ||
 		m_options.input.mode == InputMode::CompilerWithASTImport ||

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -1921,6 +1921,8 @@ BOOST_AUTO_TEST_CASE(ethdebug_excluded_from_wildcards)
 	BOOST_REQUIRE(result.dump().find("ethdebug") == std::string::npos);
 }
 
+// NOTE: ethdebug tests skipped (require via-ir pipeline which is disabled)
+#if 0
 BOOST_AUTO_TEST_CASE(ethdebug_debug_info_ethdebug)
 {
 	static std::vector<std::tuple<Json, std::optional<std::function<bool(Json)>>>> tests{
@@ -2257,6 +2259,7 @@ BOOST_DATA_TEST_CASE(ethdebug_output_instructions_smoketest, boost::unit_test::d
 			BOOST_REQUIRE(!instruction["operation"].contains("arguments"));
 	}
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/solc/CommandLineInterface.cpp
+++ b/test/solc/CommandLineInterface.cpp
@@ -1527,6 +1527,9 @@ BOOST_AUTO_TEST_CASE(cli_ethdebug_incompatible_input_modes)
 	}
 }
 
+// NOTE: cli_ethdebug_debug_info_ethdebug and cli_ethdebug_ethdebug_output tests
+// skipped (require --via-ir which is disabled)
+#if 0
 BOOST_AUTO_TEST_CASE(cli_ethdebug_debug_info_ethdebug)
 {
 	TemporaryDirectory tempDir(TEST_CASE_NAME);
@@ -1696,6 +1699,7 @@ BOOST_AUTO_TEST_CASE(cli_ethdebug_ethdebug_output)
 		BOOST_REQUIRE(result.success);
 	}
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/solc/CommandLineParser.cpp
+++ b/test/solc/CommandLineParser.cpp
@@ -118,8 +118,7 @@ BOOST_AUTO_TEST_CASE(cli_mode_options)
 			"--output-dir=/tmp/out",
 			"--overwrite",
 			"--evm-version=spuriousDragon",
-			"--via-ir",
-			"--experimental-via-ir",
+			// NOTE: --via-ir and --experimental-via-ir removed (via-ir pipeline disabled)
 			"--revert-strings=strip",
 			"--debug-info=location",
 			"--pretty-json",
@@ -180,7 +179,7 @@ BOOST_AUTO_TEST_CASE(cli_mode_options)
 		expectedOptions.output.dir = "/tmp/out";
 		expectedOptions.output.overwriteFiles = true;
 		expectedOptions.output.evmVersion = EVMVersion::spuriousDragon();
-		expectedOptions.output.viaIR = true;
+		expectedOptions.output.viaIR = false;
 		expectedOptions.output.revertStrings = RevertStrings::Strip;
 		expectedOptions.output.debugInfoSelection = DebugInfoSelection::fromString("location");
 		expectedOptions.formatting.json = JsonFormat{JsonFormat::Pretty, 7};
@@ -260,12 +259,15 @@ BOOST_AUTO_TEST_CASE(no_import_callback)
 	}
 }
 
+// NOTE: via_ir_options test skipped (via-ir pipeline disabled)
+#if 0
 BOOST_AUTO_TEST_CASE(via_ir_options)
 {
 	BOOST_TEST(!parseCommandLine({"solc", "contract.sol"}).output.viaIR);
 	for (std::string viaIrOption: {"--via-ir", "--experimental-via-ir"})
 		BOOST_TEST(parseCommandLine({"solc", viaIrOption, "contract.sol"}).output.viaIR);
 }
+#endif
 
 BOOST_AUTO_TEST_CASE(assembly_mode_options)
 {
@@ -628,6 +630,8 @@ BOOST_AUTO_TEST_CASE(invalid_optimizer_sequence_without_optimize)
 	}
 }
 
+// NOTE: ethdebug test skipped (requires --via-ir which is disabled)
+#if 0
 BOOST_AUTO_TEST_CASE(ethdebug)
 {
 	CommandLineOptions commandLineOptions = parseCommandLine({"solc", "contract.sol", "--debug-info", "ethdebug", "--ethdebug", "--via-ir"});
@@ -664,6 +668,7 @@ BOOST_AUTO_TEST_CASE(ethdebug)
 	BOOST_CHECK_EQUAL(commandLineOptions.output.debugInfoSelection.has_value(), true);
 	BOOST_CHECK_EQUAL(commandLineOptions.output.debugInfoSelection->ethdebug, true);
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Note: to support this in CI, we are checking out to a hardcoded commit for seismic-revm semantic tests runner, until we merge in https://github.com/SeismicSystems/seismic-revm/pull/183