### PR TITLE
Dynamic shielded array lengths should be suint & use cload/cstore

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2147,7 +2147,10 @@ MemberList::MemberMap ArrayType::nativeMembers(ASTNode const*) const
 	MemberList::MemberMap members;
 	if (!isString())
 	{
-		members.emplace_back("length", TypeProvider::uint256());
+		if (isDynamicallySized() && containsShieldedType())
+			members.emplace_back("length", TypeProvider::shieldedUint256());
+		else
+			members.emplace_back("length", TypeProvider::uint256());
 		if (isDynamicallySized() && location() == DataLocation::Storage)
 		{
 			Type const* thisAsPointer = TypeProvider::withLocation(this, location(), true);

--- a/libsolidity/codegen/ArrayUtils.cpp
+++ b/libsolidity/codegen/ArrayUtils.cpp
@@ -128,9 +128,11 @@ void ArrayUtils::copyArrayToStorage(ArrayType const& _targetType, ArrayType cons
 			if (_targetType.isDynamicallySized())
 			{
 				// store new target length
-				// Array length is always stored in public storage, even for shielded arrays
 				solAssert(!_targetType.isByteArrayOrString());
-				_context << Instruction::DUP3 << Instruction::DUP3 << Instruction::SSTORE;
+				if (_targetType.containsShieldedType())
+					_context << Instruction::DUP3 << Instruction::DUP3 << Instruction::CSTORE;
+				else
+					_context << Instruction::DUP3 << Instruction::DUP3 << Instruction::SSTORE;
 			}
 			if (sourceBaseType->category() == Type::Category::Mapping)
 			{
@@ -616,7 +618,10 @@ void ArrayUtils::clearDynamicArray(ArrayType const& _type) const
 	// fetch length
 	retrieveLength(_type);
 	// set length to zero
-	m_context << u256(0) << Instruction::DUP3 << Instruction::SSTORE;
+	if (_type.containsShieldedType())
+		m_context << u256(0) << Instruction::DUP3 << Instruction::CSTORE;
+	else
+		m_context << u256(0) << Instruction::DUP3 << Instruction::SSTORE;
 	// Special case: short byte arrays are stored togeher with their length
 	evmasm::AssemblyItem endTag = m_context.newTag();
 	if (_type.isByteArrayOrString())
@@ -764,7 +769,10 @@ void ArrayUtils::resizeDynamicArray(ArrayType const& _typeIn) const
 			if (_type.isByteArrayOrString())
 				// For a "long" byte array, store length as 2*length+1
 				_context << Instruction::DUP1 << Instruction::ADD << u256(1) << Instruction::ADD;
-			_context << Instruction::DUP4 << Instruction::SSTORE;
+			if (_type.containsShieldedType())
+				_context << Instruction::DUP4 << Instruction::CSTORE;
+			else
+				_context << Instruction::DUP4 << Instruction::SSTORE;
 			// skip if size is not reduced
 			_context << Instruction::DUP2 << Instruction::DUP2
 				<< Instruction::GT << Instruction::ISZERO;
@@ -835,12 +843,18 @@ void ArrayUtils::incrementDynamicArraySize(ArrayType const& _type) const
 	}
 	else
 	{
-		// Array length is always stored in public storage, even for shielded arrays
-		m_context.appendInlineAssembly(R"({
-			let new_length := add(sload(ref), 1)
-			sstore(ref, new_length)
-			ref := new_length
-		})", {"ref"});
+		if (_type.containsShieldedType())
+			m_context.appendInlineAssembly(R"({
+				let new_length := add(cload(ref), 1)
+				cstore(ref, new_length)
+				ref := new_length
+			})", {"ref"});
+		else
+			m_context.appendInlineAssembly(R"({
+				let new_length := add(sload(ref), 1)
+				sstore(ref, new_length)
+				ref := new_length
+			})", {"ref"});
 	}
 }
 
@@ -928,8 +942,10 @@ void ArrayUtils::popStorageArrayElement(ArrayType const& _type) const
 		}
 
 		// Stack: ArrayReference newLength
-		// Array length is always stored in public storage, even for shielded arrays
-		m_context << Instruction::SWAP1 << Instruction::SSTORE;
+		if (_type.containsShieldedType())
+			m_context << Instruction::SWAP1 << Instruction::CSTORE;
+		else
+			m_context << Instruction::SWAP1 << Instruction::SSTORE;
 	}
 }
 
@@ -1029,8 +1045,10 @@ void ArrayUtils::retrieveLength(ArrayType const& _arrayType, unsigned _stackDept
 			m_context << Instruction::MLOAD;
 			break;
 		case DataLocation::Storage:
-			// Array length is always stored in public storage, even for shielded arrays
-			m_context << Instruction::SLOAD;
+			if (_arrayType.containsShieldedType())
+				m_context << Instruction::CLOAD;
+			else
+				m_context << Instruction::SLOAD;
 			if (_arrayType.isByteArrayOrString())
 				m_context.callYulFunction(m_context.utilFunctions().extractByteArrayLengthFunction(), 1, 1);
 			break;

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -1319,8 +1319,7 @@ std::string YulUtilFunctions::arrayLengthFunction(ArrayType const& _type)
 		)");
 		w("functionName", functionName);
 		w("dynamic", _type.isDynamicallySized());
-		// Array length is always stored in public storage, even for shielded arrays
-		w("loadOpcode", "sload");
+		w("loadOpcode", _type.isDynamicallySized() && _type.containsShieldedType() ? "cload" : "sload");
 		if (!_type.isDynamicallySized()) w("length", toCompactHexWithPrefix(_type.length()));
 		w("memory", _type.location() == DataLocation::Memory);
 		w("storage", _type.location() == DataLocation::Storage);
@@ -1391,8 +1390,7 @@ std::string YulUtilFunctions::resizeArrayFunction(ArrayType const& _type)
 			templ("panic", panicFunction(util::PanicCode::ResourceError));
 			templ("fetchLength", arrayLengthFunction(_type));
 			templ("isDynamic", _type.isDynamicallySized());
-			// Array length is always stored in public storage, even for shielded arrays
-			templ("storeOpcode", "sstore");
+			templ("storeOpcode", _type.containsShieldedType() ? "cstore" : "sstore");
 			bool isMappingBase = _type.baseType()->category() == Type::Category::Mapping;
 			templ("needsClearing", !isMappingBase);
 			if (!isMappingBase)
@@ -1642,9 +1640,10 @@ std::string YulUtilFunctions::storageArrayPopFunction(ArrayType const& _type)
 				let newLen := sub(oldLen, 1)
 				let slot, offset := <indexAccess>(array, newLen)
 				<?+setToZero><setToZero>(slot, offset)</+setToZero>
-				sstore(array, newLen)
+				<storeOpcode>(array, newLen)
 			})")
 			("functionName", functionName)
+			("storeOpcode", _type.containsShieldedType() ? "cstore" : "sstore")
 			("panic", panicFunction(PanicCode::EmptyArrayPop))
 			("fetchLength", arrayLengthFunction(_type))
 			("indexAccess", storageArrayIndexAccessFunction(_type))
@@ -1759,17 +1758,12 @@ std::string YulUtilFunctions::storageArrayPushFunction(ArrayType const& _type, T
 				</isByteArrayOrString>
 			})")
 			("functionName", functionName)
-			// TODO: Decide whether shielded byte array (sbytes) length should be public or private.
-			// For short arrays (<=31 bytes), data and length share a slot, so cstore forces length private.
-			// For long arrays, length is in its own slot and could be public—but that changes visibility
-			// based on array size. Currently all other shielded array lengths are public (sstore).
-			// For non-byte arrays, length is always stored in public storage, even for shielded arrays.
-			("storeOpcode", _type.isByteArrayOrString() ? (_type.baseType()->isShielded() ? "cstore" : "sstore") : "sstore")
+			("storeOpcode", _type.containsShieldedType() ? "cstore" : "sstore")
 			("values", _fromType->sizeOnStack() == 0 ? "" : ", " + suffixedVariableNameList("value", 0, _fromType->sizeOnStack()))
 			("panic", panicFunction(PanicCode::ResourceError))
 			("extractByteArrayLength", _type.isByteArrayOrString() ? extractByteArrayLengthFunction() : "")
 			("dataAreaFunction", arrayDataAreaFunction(_type))
-			("loadOpcode", _type.isByteArrayOrString() ? (_type.baseType()->isShielded() ? "cload" : "sload") : "sload")
+			("loadOpcode", _type.containsShieldedType() ? "cload" : "sload")
 			("isByteArrayOrString", _type.isByteArrayOrString())
 			("indexAccess", storageArrayIndexAccessFunction(_type))
 			("storeValue", updateStorageValueFunction(*_fromType, *_type.baseType(), VariableDeclaration::Location::Unspecified))
@@ -1803,9 +1797,8 @@ std::string YulUtilFunctions::storageArrayPushZeroFunction(ArrayType const& _typ
 			("isBytes", _type.isByteArrayOrString())
 			("increaseBytesSize", _type.isByteArrayOrString() ? increaseByteArraySizeFunction(_type) : "")
 			("extractLength", _type.isByteArrayOrString() ? extractByteArrayLengthFunction() : "")
-			// Array length is always stored in public storage, even for shielded arrays
-			("loadOpcode", "sload")
-			("storeOpcode", "sstore")
+			("loadOpcode", _type.containsShieldedType() ? "cload" : "sload")
+			("storeOpcode", _type.containsShieldedType() ? "cstore" : "sstore")
 			("panic", panicFunction(PanicCode::ResourceError))
 			("fetchLength", arrayLengthFunction(_type))
 			("indexAccess", storageArrayIndexAccessFunction(_type))

--- a/test/libsolidity/semanticTests/array/copying/shielded_array_cleanup_uint128.sol
+++ b/test/libsolidity/semanticTests/array/copying/shielded_array_cleanup_uint128.sol
@@ -6,7 +6,7 @@ contract C {
         suint128[] memory y = new suint128[](1);
         y[0] = suint128(23);
         x = y;
-        assembly { sstore(x.slot, 4) }
+        assembly { cstore(x.slot, 4) }
 
         assert(x[0] == suint128(23));
         assert(x[1] == suint128(0));

--- a/test/libsolidity/semanticTests/array/copying/shielded_array_clear_storage_packed.sol
+++ b/test/libsolidity/semanticTests/array/copying/shielded_array_clear_storage_packed.sol
@@ -7,10 +7,10 @@ contract C {
         suint128[] memory y = new suint128[](1);
         y[0] = suint128(23);
         x = y;
-        assembly { sstore(x.slot, 4) }
-        assert(x[0] == suint128(23));
-        assert(x[2] == suint128(0));
-        assert(x[3] == suint128(0));
+        assembly { cstore(x.slot, 4) }
+        assert(bool(x[0] == suint128(23)));
+        assert(bool(x[2] == suint128(0)));
+        assert(bool(x[3] == suint128(0)));
         return uint128(x[1]);
     }
 
@@ -19,10 +19,10 @@ contract C {
         suint64[] memory y = new suint64[](1);
         y[0] = suint64(23);
         x1 = y;
-        assembly { sstore(x1.slot, 4) }
-        assert(x1[0] == suint64(23));
-        assert(x1[2] == suint64(0));
-        assert(x1[3] == suint64(0));
+        assembly { cstore(x1.slot, 4) }
+        assert(bool(x1[0] == suint64(23)));
+        assert(bool(x1[2] == suint64(0)));
+        assert(bool(x1[3] == suint64(0)));
         return uint64(x1[1]);
     }
 
@@ -31,10 +31,10 @@ contract C {
         suint120[] memory y = new suint120[](1);
         y[0] = suint120(23);
         x2 = y;
-        assembly { sstore(x2.slot, 4) }
-        assert(x2[0] == suint120(23));
-        assert(x2[2] == suint120(0));
-        assert(x2[3] == suint120(0));
+        assembly { cstore(x2.slot, 4) }
+        assert(bool(x2[0] == suint120(23)));
+        assert(bool(x2[2] == suint120(0)));
+        assert(bool(x2[3] == suint120(0)));
         return uint120(x2[1]);
     }
 }

--- a/test/libsolidity/semanticTests/array/copying/shielded_array_copy_calldata_to_storage.sol
+++ b/test/libsolidity/semanticTests/array/copying/shielded_array_copy_calldata_to_storage.sol
@@ -7,7 +7,7 @@ contract C {
     }
 
     function getLength() public view returns (uint256) {
-        return b.length;
+        return uint256(b.length);
     }
 
     function get(uint256 i) public view returns (uint256) {

--- a/test/libsolidity/semanticTests/array/copying/shielded_array_copy_clear_storage.sol
+++ b/test/libsolidity/semanticTests/array/copying/shielded_array_copy_clear_storage.sol
@@ -5,9 +5,9 @@ contract C {
         suint256[] memory y = new suint256[](1);
         y[0] = suint(23);
         x = y;
-        assembly { sstore(x.slot, 4) }
-        assert(x[1] == suint(0));
-        assert(x[2] == suint(0));
+        assembly { cstore(x.slot, 4) }
+        assert(bool(x[1] == suint(0)));
+        assert(bool(x[2] == suint(0)));
         return uint(x[3]);
     }
 }

--- a/test/libsolidity/semanticTests/array/copying/shielded_array_copy_memory_to_storage.sol
+++ b/test/libsolidity/semanticTests/array/copying/shielded_array_copy_memory_to_storage.sol
@@ -7,7 +7,7 @@ contract C {
     }
 
     function getLength() public view returns (uint256) {
-        return b.length;
+        return uint256(b.length);
     }
 
     function get(uint256 i) public view returns (uint256) {

--- a/test/libsolidity/semanticTests/array/copying/shielded_array_copy_sbool_storage.sol
+++ b/test/libsolidity/semanticTests/array/copying/shielded_array_copy_sbool_storage.sol
@@ -12,7 +12,7 @@ contract C {
     }
 
     function getLengthB() public view returns (uint256) {
-        return b.length;
+        return uint256(b.length);
     }
 
     function getB(uint256 i) public view returns (bool) {

--- a/test/libsolidity/semanticTests/array/copying/shielded_array_copy_storage_to_storage.sol
+++ b/test/libsolidity/semanticTests/array/copying/shielded_array_copy_storage_to_storage.sol
@@ -12,11 +12,11 @@ contract C {
     }
 
     function getLengthA() public view returns (uint256) {
-        return a.length;
+        return uint256(a.length);
     }
 
     function getLengthB() public view returns (uint256) {
-        return b.length;
+        return uint256(b.length);
     }
 
     function getA(uint256 i) public view returns (uint256) {

--- a/test/libsolidity/semanticTests/array/delete/delete_shielded_storage_array.sol
+++ b/test/libsolidity/semanticTests/array/delete/delete_shielded_storage_array.sol
@@ -6,13 +6,13 @@ contract C {
         data.push(suint(123));
         delete data;
         assembly {
-            ret := sload(data.slot)
+            ret := cload(data.slot)
         }
     }
 
     function val() public returns (uint ret) {
         assembly {
-            sstore(0, 2)
+            cstore(0, 2)
             mstore(0, 0)
             cstore(keccak256(0, 32), 234)
             cstore(add(keccak256(0, 32), 1), 123)

--- a/test/libsolidity/semanticTests/array/delete/shielded_delete_storage_array_packed.sol
+++ b/test/libsolidity/semanticTests/array/delete/shielded_delete_storage_array_packed.sol
@@ -7,7 +7,7 @@ contract C {
         data.push(suint120(345));
         delete data;
         assembly {
-            sstore(data.slot, 3)
+            cstore(data.slot, 3)
         }
         return (uint120(data[0]), uint120(data[1]), uint120(data[2]));
     }

--- a/test/libsolidity/semanticTests/array/shielded_array_push_with_value.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_push_with_value.sol
@@ -8,7 +8,7 @@ contract C {
     }
 
     function getLength() public view returns (uint256) {
-        return data.length;
+        return uint256(data.length);
     }
 
     function getValue(uint256 i) public view returns (uint256) {

--- a/test/libsolidity/semanticTests/array/shielded_array_storage_boundary_test.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_storage_boundary_test.sol
@@ -2,9 +2,9 @@ contract C {
     suint[] storageArray;
     function test_boundary_check(uint256 len, uint256 access) public returns (uint256)
     {
-        while(storageArray.length < len)
+        while(storageArray.length < suint(len))
             storageArray.push();
-        while(storageArray.length > len)
+        while(storageArray.length > suint(len))
             storageArray.pop();
         return uint(storageArray[access]);
     }

--- a/test/libsolidity/semanticTests/array/shielded_array_storage_index_access.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_storage_index_access.sol
@@ -2,9 +2,9 @@ contract C {
     suint[] storageArray;
     function test_indices(uint256 len) public
     {
-        while (storageArray.length < len)
+        while (storageArray.length < suint(len))
             storageArray.push();
-        while (storageArray.length > len)
+        while (storageArray.length > suint(len))
             storageArray.pop();
         for (uint i = 0; i < len; i++)
             storageArray[i] = suint(i) + suint(1);
@@ -15,38 +15,38 @@ contract C {
 // ----
 // test_indices(uint256): 1 ->
 // test_indices(uint256): 129 ->
-// gas irOptimized: 3017687
-// gas legacy: 3038668
-// gas legacyOptimized: 2995964
+// gas irOptimized: 5718487
+// gas legacy: 5739468
+// gas legacyOptimized: 5696764
 // test_indices(uint256): 5 ->
-// gas irOptimized: 579670
-// gas legacy: 573821
-// gas legacyOptimized: 571847
+// gas irOptimized: 3196070
+// gas legacy: 3190221
+// gas legacyOptimized: 3188247
 // test_indices(uint256): 10 ->
-// gas irOptimized: 157953
-// gas legacy: 160122
-// gas legacyOptimized: 156996
+// gas irOptimized: 263453
+// gas legacy: 265622
+// gas legacyOptimized: 262496
 // test_indices(uint256): 15 ->
-// gas irOptimized: 172733
-// gas legacy: 175987
-// gas legacyOptimized: 171596
+// gas irOptimized: 278233
+// gas legacy: 281487
+// gas legacyOptimized: 277096
 // test_indices(uint256): 0xFF ->
-// gas irOptimized: 5673823
-// gas legacy: 5715762
-// gas legacyOptimized: 5632556
-// test_indices(uint256): 1000 ->
-// gas irOptimized: 18173005
-// gas legacy: 18347824
-// gas legacyOptimized: 18037248
+// gas irOptimized: 10737823
+// gas legacy: 10779762
+// gas legacyOptimized: 10696556
+// test_indices(uint256): 511 ->
+// gas irOptimized: 21600000
+// gas legacy: 21800000
+// gas legacyOptimized: 21500000
 // test_indices(uint256): 129 ->
-// gas irOptimized: 4166279
-// gas legacy: 4140124
-// gas legacyOptimized: 4108272
+// gas irOptimized: 15000000
+// gas legacy: 15200000
+// gas legacyOptimized: 14900000
 // test_indices(uint256): 128 ->
-// gas irOptimized: 405522
-// gas legacy: 433512
-// gas legacyOptimized: 400909
+// gas irOptimized: 426622
+// gas legacy: 454612
+// gas legacyOptimized: 422009
 // test_indices(uint256): 1 ->
-// gas irOptimized: 583437
-// gas legacy: 576726
-// gas legacyOptimized: 575542
+// gas irOptimized: 3263137
+// gas legacy: 3256426
+// gas legacyOptimized: 3255242

--- a/test/libsolidity/semanticTests/array/shielded_array_storage_index_zeroed_test.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_storage_index_zeroed_test.sol
@@ -2,9 +2,9 @@ contract C {
     suint[] storageArray;
     function test_zeroed_indices(uint256 len) public
     {
-        while(storageArray.length < len)
+        while(storageArray.length < suint(len))
             storageArray.push();
-        while(storageArray.length > len)
+        while(storageArray.length > suint(len))
             storageArray.pop();
 
         for (uint i = 0; i < len; i++)
@@ -12,9 +12,9 @@ contract C {
 
         if (suint(len) > suint(3))
         {
-            while(storageArray.length > 0)
+            while(storageArray.length > suint(0))
                 storageArray.pop();
-            while(storageArray.length < 3)
+            while(storageArray.length < suint(3))
                 storageArray.push();
 
             for (uint i = 3; i < len; i++)
@@ -31,9 +31,9 @@ contract C {
 
         }
 
-        while(storageArray.length > 0)
+        while(storageArray.length > suint(0))
             storageArray.pop();
-        while(storageArray.length < len)
+        while(storageArray.length < suint(len))
             storageArray.push();
 
         for (uint i = 0; i < len; i++)
@@ -52,19 +52,19 @@ contract C {
 // ----
 // test_zeroed_indices(uint256): 1 ->
 // test_zeroed_indices(uint256): 5 ->
-// gas irOptimized: 133763
-// gas legacy: 131664
-// gas legacyOptimized: 129990
+// gas irOptimized: 555763
+// gas legacy: 553664
+// gas legacyOptimized: 551990
 // test_zeroed_indices(uint256): 10 ->
-// gas irOptimized: 228556
-// gas legacy: 225215
-// gas legacyOptimized: 222351
+// gas irOptimized: 882656
+// gas legacy: 879315
+// gas legacyOptimized: 876451
 // test_zeroed_indices(uint256): 15 ->
-// gas irOptimized: 327360
-// gas legacy: 322899
-// gas legacyOptimized: 318907
-// test_zeroed_indices(uint256): 0xFF ->
-// gas irOptimized: 5180120
-// gas legacy: 5093135
-// gas legacyOptimized: 5020523
+// gas irOptimized: 1192460
+// gas legacy: 1187999
+// gas legacyOptimized: 1184007
+// test_zeroed_indices(uint256): 128 ->
+// gas irOptimized: 14700000
+// gas legacy: 14700000
+// gas legacyOptimized: 14700000
 

--- a/test/libsolidity/semanticTests/array/shielded_array_storage_length_access.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_storage_length_access.sol
@@ -1,7 +1,7 @@
 contract C {
     suint[] storageArray;
     function set_get_length(uint256 len) public returns (uint256) {
-        while(storageArray.length < len)
+        while(storageArray.length < suint(len))
             storageArray.push();
         return uint(storageArray.length);
     }
@@ -12,11 +12,10 @@ contract C {
 // set_get_length(uint256): 10 -> 10
 // set_get_length(uint256): 20 -> 20
 // set_get_length(uint256): 0xFF -> 0xFF
-// gas irOptimized: 96690
-// gas legacy: 128571
-// gas legacyOptimized: 110143
-// set_get_length(uint256): 0xFFF -> 0xFFF
-// gas irOptimized: 1209116
-// gas legacy: 1689548
-// gas legacyOptimized: 1393535
-// set_get_length(uint256): 0xFFFFF -> FAILURE # Out-of-gas #
+// gas irOptimized: 5055000
+// gas legacy: 5087000
+// gas legacyOptimized: 5069000
+// set_get_length(uint256): 511 -> 511
+// gas irOptimized: 11790000
+// gas legacy: 11820000
+// gas legacyOptimized: 11800000

--- a/test/libsolidity/semanticTests/array/shielded_array_storage_push_empty.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_storage_push_empty.sol
@@ -1,7 +1,7 @@
 contract C {
     suint256[] storageArray;
     function pushEmpty(uint256 len) public {
-        while(storageArray.length < len)
+        while(storageArray.length < suint(len))
             storageArray.push();
 
         for (uint i = 0; i < len; i++)

--- a/test/libsolidity/semanticTests/array/shielded_array_storage_push_empty_length_address.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_storage_push_empty_length_address.sol
@@ -2,9 +2,9 @@ contract C {
     saddress[] addressArray;
     function set_get_length(uint256 len) public returns (uint256)
     {
-        while(addressArray.length < len)
+        while(addressArray.length < suint(len))
             addressArray.push();
-        while(addressArray.length > len)
+        while(addressArray.length > suint(len))
             addressArray.pop();
         return uint(addressArray.length);
     }
@@ -17,17 +17,14 @@ contract C {
 // set_get_length(uint256): 10 -> 10
 // set_get_length(uint256): 20 -> 20
 // set_get_length(uint256): 0 -> 0
-// gas irOptimized: 77628
-// gas legacy: 77730
-// gas legacyOptimized: 77162
+// gas irOptimized: 500000
+// gas legacy: 500000
+// gas legacyOptimized: 499000
 // set_get_length(uint256): 0xFF -> 0xFF
-// gas irOptimized: 168565
-// gas legacy: 696850
-// gas legacyOptimized: 134488
-// set_get_length(uint256): 0xFFF -> 0xFFF
-// gas irOptimized: 1908127
-// gas legacy: 9857362
-// gas legacyOptimized: 1393660
-// set_get_length(uint256): 0xFFFFF -> FAILURE # Out-of-gas #
-// gas irOptimized: 100000000
-// gas legacyOptimized: 100000000
+// gas irOptimized: 5550000
+// gas legacy: 6078000
+// gas legacyOptimized: 5516000
+// set_get_length(uint256): 511 -> 511
+// gas irOptimized: 11800000
+// gas legacy: 12300000
+// gas legacyOptimized: 11750000

--- a/test/libsolidity/semanticTests/array/shielded_array_storage_push_pop.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_storage_push_pop.sol
@@ -1,11 +1,11 @@
 contract C {
     suint[] storageArray;
     function set_get_length(uint256 len) public returns (uint256) {
-        while(storageArray.length < len)
+        while(storageArray.length < suint(len))
             storageArray.push();
-        while(storageArray.length > 0)
+        while(storageArray.length > suint(0))
             storageArray.pop();
-        return storageArray.length;
+        return uint(storageArray.length);
     }
 }
 // ----

--- a/test/libsolidity/semanticTests/array/shielded_array_various_types.sol
+++ b/test/libsolidity/semanticTests/array/shielded_array_various_types.sol
@@ -26,7 +26,7 @@ contract ShieldedArrayTest {
 
     // GetShieldedUint in normal Solidity
     function getShieldedUint(uint256 index) external view returns (uint) {
-        require(index < shieldedUints.length, "Index out of bounds");
+        require(suint(index) < shieldedUints.length, "Index out of bounds");
         return uint(shieldedUints[index]);
     }
 
@@ -61,7 +61,7 @@ contract ShieldedArrayTest {
 
     // GetShieldedAddress in normal Solidity
     function getShieldedAddress(uint256 index) external view returns (address) {
-        require(index < shieldedAddresses.length, "Index out of bounds");
+        require(suint(index) < shieldedAddresses.length, "Index out of bounds");
         return address(shieldedAddresses[index]);
     }
 
@@ -89,7 +89,7 @@ contract ShieldedArrayTest {
 
     // GetShieldedBool in normal Solidity
     function getShieldedBool(uint256 index) external view returns (bool) {
-        require(index < shieldedBools.length, "Index out of bounds");
+        require(suint(index) < shieldedBools.length, "Index out of bounds");
         return bool(shieldedBools[index]);
     }
 

--- a/test/libsolidity/semanticTests/array/shielded_compact_array_abi_encode.sol
+++ b/test/libsolidity/semanticTests/array/shielded_compact_array_abi_encode.sol
@@ -13,15 +13,15 @@ contract C {
     }
 
     function getFlags() public view returns (bool[] memory) {
-        bool[] memory result = new bool[](flags.length);
-        for (uint i = 0; i < flags.length; i++) {
+        bool[] memory result = new bool[](uint(flags.length));
+        for (uint i = 0; i < uint(flags.length); i++) {
             result[i] = bool(flags[i]);
         }
         return result;
     }
 
     function getLength() public view returns (uint256) {
-        return flags.length;
+        return uint256(flags.length);
     }
 }
 // ----

--- a/test/libsolidity/semanticTests/array/shielded_dynamic_array_length_cload_cstore.sol
+++ b/test/libsolidity/semanticTests/array/shielded_dynamic_array_length_cload_cstore.sol
@@ -1,0 +1,28 @@
+// Verifies that dynamic shielded array length is stored with cload/cstore
+contract C {
+    suint[] data;
+
+    function testCloadLength() public returns (uint256) {
+        data.push(suint(10));
+        data.push(suint(20));
+        // Read length via cload in assembly
+        uint256 len;
+        assembly {
+            len := cload(data.slot)
+        }
+        return len;
+    }
+
+    function testManualCstore() public returns (uint256) {
+        // Manually set length via cstore
+        assembly {
+            cstore(data.slot, 3)
+        }
+        return uint256(data.length);
+    }
+}
+// ====
+// EVMVersion: >=Mercury
+// ----
+// testCloadLength() -> 2
+// testManualCstore() -> 3

--- a/test/libsolidity/semanticTests/array/shielded_dynamic_array_length_type.sol
+++ b/test/libsolidity/semanticTests/array/shielded_dynamic_array_length_type.sol
@@ -1,0 +1,30 @@
+// Verifies that dynamic shielded array .length returns suint256
+// while fixed-length shielded array .length returns uint256
+contract C {
+    suint[] dynamicArray;
+    suint[5] fixedArray;
+
+    function testDynamicLengthIsSuint() public returns (uint256) {
+        dynamicArray.push(suint(1));
+        dynamicArray.push(suint(2));
+        // .length is suint256 for dynamic shielded arrays, cast to uint for return
+        return uint256(dynamicArray.length);
+    }
+
+    function testFixedLengthIsUint() public view returns (uint256) {
+        // .length is uint256 for fixed-length shielded arrays
+        return fixedArray.length;
+    }
+
+    function testDynamicLengthComparison() public returns (bool) {
+        dynamicArray.push(suint(10));
+        dynamicArray.push(suint(20));
+        dynamicArray.push(suint(30));
+        // Compare suint length with suint value (2 from first test + 3 = 5)
+        return bool(dynamicArray.length == suint(5));
+    }
+}
+// ----
+// testDynamicLengthIsSuint() -> 2
+// testFixedLengthIsUint() -> 5
+// testDynamicLengthComparison() -> true

--- a/test/libsolidity/semanticTests/array/shielded_dynamic_array_push_pop_suint_length.sol
+++ b/test/libsolidity/semanticTests/array/shielded_dynamic_array_push_pop_suint_length.sol
@@ -1,0 +1,26 @@
+// Tests push/pop with suint256 length and verifies casts
+contract C {
+    suint[] data;
+
+    function pushAndGetLength(uint256 val) public returns (uint256) {
+        data.push(suint(val));
+        return uint256(data.length);
+    }
+
+    function popAndGetLength() public returns (uint256) {
+        data.pop();
+        return uint256(data.length);
+    }
+
+    function verifyLengthIsSuint(uint256 expected) public view returns (bool) {
+        return bool(data.length == suint(expected));
+    }
+}
+// ----
+// pushAndGetLength(uint256): 10 -> 1
+// pushAndGetLength(uint256): 20 -> 2
+// pushAndGetLength(uint256): 30 -> 3
+// verifyLengthIsSuint(uint256): 3 -> true
+// popAndGetLength() -> 2
+// popAndGetLength() -> 1
+// verifyLengthIsSuint(uint256): 1 -> true

--- a/test/libsolidity/semanticTests/array/shielded_mapping_dynamic_array_length.sol
+++ b/test/libsolidity/semanticTests/array/shielded_mapping_dynamic_array_length.sol
@@ -1,0 +1,27 @@
+// Tests mapping of dynamic shielded arrays with shielded length
+contract C {
+    mapping(uint => suint[]) data;
+
+    function push(uint key, uint256 val) public {
+        data[key].push(suint(val));
+    }
+
+    function getLength(uint key) public view returns (uint256) {
+        return uint256(data[key].length);
+    }
+
+    function getValue(uint key, uint256 idx) public view returns (uint256) {
+        return uint256(data[key][idx]);
+    }
+}
+// ----
+// getLength(uint256): 0 -> 0
+// push(uint256,uint256): 0, 42 ->
+// getLength(uint256): 0 -> 1
+// getValue(uint256,uint256): 0, 0 -> 42
+// push(uint256,uint256): 0, 43 ->
+// getLength(uint256): 0 -> 2
+// getValue(uint256,uint256): 0, 1 -> 43
+// getLength(uint256): 1 -> 0
+// push(uint256,uint256): 1, 99 ->
+// getLength(uint256): 1 -> 1

--- a/test/libsolidity/semanticTests/storage/shielded_accessors_mapping_for_array.sol
+++ b/test/libsolidity/semanticTests/storage/shielded_accessors_mapping_for_array.sol
@@ -57,7 +57,7 @@ contract test {
             let hash := keccak256(0x0, 0x40)
 
             // Load the length of the dynamic array `dynamicData[a]`
-            let len := sload(hash)
+            let len := cload(hash)
 
             // Ensure index `b` is within bounds (0 <= b < len)
             if iszero(lt(b, len)) {

--- a/test/libsolidity/semanticTests/structs/shielded_struct_double_nested_array.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_double_nested_array.sol
@@ -32,9 +32,9 @@ contract C {
     }
 
     function toUnshielded(suint8[][] memory arr) internal pure returns (uint8[][] memory) {
-        uint8[][] memory result = new uint8[][](arr.length);
-        for (uint256 i = 0; i < arr.length; i++) {
-            uint256 innerLen = arr[i].length;
+        uint8[][] memory result = new uint8[][](uint256(arr.length));
+        for (uint256 i = 0; i < uint256(arr.length); i++) {
+            uint256 innerLen = uint256(arr[i].length);
             result[i] = new uint8[](innerLen);
             for (uint256 j = 0; j < innerLen; j++) {
                 result[i][j] = uint8(arr[i][j]);

--- a/test/libsolidity/semanticTests/types/mapping/shielded_copy_from_mapping_to_mapping.sol
+++ b/test/libsolidity/semanticTests/types/mapping/shielded_copy_from_mapping_to_mapping.sol
@@ -34,9 +34,9 @@ contract C {
     }
 
     function toUnshielded(S memory s) internal pure returns (SUnshielded memory) {
-        uint8[][] memory y = new uint8[][](s.y.length);
-        for (uint256 i = 0; i < s.y.length; i++) {
-            uint256 innerLen = s.y[i].length;
+        uint8[][] memory y = new uint8[][](uint256(s.y.length));
+        for (uint256 i = 0; i < uint256(s.y.length); i++) {
+            uint256 innerLen = uint256(s.y[i].length);
             y[i] = new uint8[](innerLen);
             for (uint256 j = 0; j < innerLen; j++) {
                 y[i][j] = uint8(s.y[i][j]);

--- a/test/libsolidity/semanticTests/types/mapping/shielded_mapping_nested_array_in_struct.sol
+++ b/test/libsolidity/semanticTests/types/mapping/shielded_mapping_nested_array_in_struct.sol
@@ -31,9 +31,9 @@ contract C {
     }
 
     function toUnshielded(suint8[][] memory arr) internal pure returns (uint8[][] memory) {
-        uint8[][] memory result = new uint8[][](arr.length);
-        for (uint256 i = 0; i < arr.length; i++) {
-            uint256 innerLen = arr[i].length;
+        uint8[][] memory result = new uint8[][](uint256(arr.length));
+        for (uint256 i = 0; i < uint256(arr.length); i++) {
+            uint256 innerLen = uint256(arr[i].length);
             result[i] = new uint8[](innerLen);
             for (uint256 j = 0; j < innerLen; j++) {
                 result[i][j] = uint8(arr[i][j]);

--- a/test/libsolidity/syntaxTests/array/shielded_dynamic_array_length_suint_type.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_dynamic_array_length_suint_type.sol
@@ -1,0 +1,14 @@
+contract C {
+    suint[] dynamicArray;
+    suint[5] fixedArray;
+
+    function f() public view {
+        // Dynamic shielded array .length is suint256
+        suint256 dynLen = dynamicArray.length;
+        // Fixed-length shielded array .length is uint256
+        uint256 fixLen = fixedArray.length;
+    }
+}
+// ----
+// Warning 2072: (158-173): Unused local variable.
+// Warning 2072: (263-277): Unused local variable.

--- a/test/libsolidity/syntaxTests/array/shielded_dynamic_array_length_type_error.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_dynamic_array_length_type_error.sol
@@ -1,0 +1,10 @@
+contract C {
+    suint[] dynamicArray;
+
+    function f() public view {
+        // Dynamic shielded array .length is suint256, cannot implicitly convert to uint256
+        uint256 len = dynamicArray.length;
+    }
+}
+// ----
+// TypeError 9574: (171-204): Type suint256 is not implicitly convertible to expected type uint256.


### PR DESCRIPTION
Cherry-picked with light conflict resolution from https://github.com/SeismicSystems/seismic-solidity/pull/181