### PR TITLE
VER-778: (2nd PR) Maintainability and documentation warnings for shielded behavior

### DIFF
--- a/SHIELDED_TYPES.md
+++ b/SHIELDED_TYPES.md
@@ -1,0 +1,95 @@
+# Shielded Types: Privacy Edge Cases and Limitations
+
+This document describes known edge cases and privacy limitations of shielded types
+(`suint`, `sbool`, `saddress`, `sbytes`). Understanding these is critical to
+building applications that preserve confidentiality.
+
+## 1. `msg.value` Is Always Public
+
+`msg.value` is a transaction-level field that is publicly visible on-chain. Assigning
+it to a shielded type does **not** retroactively hide the value:
+
+```solidity
+function deposit() public payable {
+    // WARNING: msg.value was already visible in the transaction.
+    // Wrapping it in a shielded type does not hide the deposited amount.
+    suint256 amount = suint256(msg.value);
+}
+```
+
+If your application requires private ETH amounts, you must use a separate wrapped
+token design (e.g., a shielded ERC-20) rather than relying on native ETH transfers.
+
+## 2. Dynamic Shielded Array Lengths
+
+Dynamic arrays with shielded element types store their length in confidential storage.
+However, **an upper bound on the array length may still be observable** through gas
+cost analysis. Each `push` or `pop` operation consumes gas proportional to the work
+performed, and an observer monitoring gas usage may be able to infer whether elements
+were added or removed, and estimate the size of the array over time.
+
+For arrays of structs with mixed shielded and non-shielded fields (e.g., some
+`uint256` and some `suint256`), the length can be deduced by querying the public
+storage slots of the non-shielded fields.
+
+Fixed-length shielded arrays always have a public length by definition, since the
+length is part of the type itself.
+
+## 3. ABI Encoding and Shielded Types
+
+Shielded types **cannot** be ABI-encoded. The compiler rejects calls such as
+`abi.encode(shieldedValue)` to prevent accidental plaintext serialization.
+
+When explicitly casting a shielded value to its public counterpart (e.g.,
+`uint256(myShieldedValue)`) and then ABI-encoding the result, be aware that the
+value is revealed at the point of casting. Any intermediary or observer of the
+execution trace may see the unshielded value. Only cast from shielded to public
+when you intentionally want to reveal the data.
+
+## 4. Shielded Booleans in Branching Conditions
+
+Using an `sbool` (or an expression producing `sbool`) in control-flow constructs
+— `if`, `while`, `for`, ternary `? :`, `require()`, `assert()` — can leak
+information. Although the boolean value itself is shielded, the *branch taken* is
+observable through:
+
+- **Gas cost differences** between the two branches
+- **State changes** that only occur in one branch
+- **Execution traces** visible to sequencers / block builders
+
+The compiler emits a warning when shielded types are used in branching conditions.
+
+## 5. `saddress` Member Limitations
+
+Shielded addresses (`saddress`) only expose the `.code` and `.codehash` members.
+Other address members (`.balance`, `.transfer()`, `.send()`, `.call()`, etc.)
+require casting to a public `address` first:
+
+```solidity
+saddress secret = saddress(someAddr);
+// secret.balance;           // ERROR
+// address(secret).balance;  // OK — but reveals the address
+```
+
+Accessing these members inherently requires revealing the address on-chain, which
+is why the cast must be explicit.
+
+## 6. Literal Values Leak During Deployment
+
+Literal values that are converted to shielded types at contract construction time
+will be visible in the deployment bytecode:
+
+```solidity
+suint256 private constant SECRET = suint256(42); // 42 is visible in deploy tx
+```
+
+The compiler warns when it detects literals being directly converted to shielded
+types. To keep values confidential, pass them as encrypted constructor arguments
+or set them via a post-deployment transaction.
+
+## 7. Shielded Dynamic Bytes
+
+Shielded dynamic `bytes` and `string` types are **not supported**. The byte-array
+and string helpers (`isByteArrayOrString()`) assume non-shielded base types. If
+support for shielded dynamic bytes is added in the future, these helpers will need
+to be updated.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1496,6 +1496,9 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 		// Check for literals being converted to shielded types (including nested in structs/arrays)
 		if (_statement.initialValue() && var.annotation().type)
 			checkShieldedLiteralWarning(*_statement.initialValue(), *var.annotation().type, _statement.location());
+		// Check for msg.value being assigned to a shielded type
+		if (_statement.initialValue() && var.annotation().type)
+			checkMsgValueToShielded(*_statement.initialValue(), *var.annotation().type);
 	}
 
 	if (valueTypes.size() != variables.size())
@@ -4559,6 +4562,45 @@ void TypeChecker::checkShieldedLiteralWarning(
 				if (args[i] && members[i]->annotation().type)
 					checkShieldedLiteralWarning(*args[i], *members[i]->annotation().type, _location);
 		}
+	}
+}
+
+void TypeChecker::checkMsgValueToShielded(
+	Expression const& _expression,
+	Type const& _targetType
+)
+{
+	// Only warn if target type is or contains a shielded type
+	if (!_targetType.isShielded() && !_targetType.containsShieldedType())
+		return;
+
+	// Check if expression is msg.value directly
+	if (auto memberAccess = dynamic_cast<MemberAccess const*>(&_expression))
+	{
+		if (memberAccess->memberName() == "value")
+		{
+			if (auto identifier = dynamic_cast<Identifier const*>(&memberAccess->expression()))
+			{
+				if (identifier->name() == "msg")
+				{
+					m_errorReporter.warning(
+						9664_error,
+						memberAccess->location(),
+						"msg.value is always publicly visible on-chain. "
+						"Assigning it to a shielded type does not hide the transaction value from observers."
+					);
+					return;
+				}
+			}
+		}
+	}
+
+	// Recurse into type conversion arguments: suint256(msg.value)
+	if (auto funcCall = dynamic_cast<FunctionCall const*>(&_expression))
+	{
+		for (auto const& arg : funcCall->arguments())
+			if (arg)
+				checkMsgValueToShielded(*arg, _targetType);
 	}
 }
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -585,6 +585,21 @@ bool TypeChecker::visit(VariableDeclaration const& _variable)
 		}
 	}
 
+	// Warn about dynamic shielded array length observability via gas costs
+	if (_variable.isStateVariable())
+	{
+		if (auto arrayType = dynamic_cast<ArrayType const*>(varType))
+		{
+			if (arrayType->isDynamicallySized() && arrayType->baseType()->containsShieldedType())
+				m_errorReporter.warning(
+					9665_error,
+					_variable.location(),
+					"Dynamic arrays with shielded element types store their length confidentially, "
+					"but an upper bound on the length may still be observable through gas cost analysis."
+				);
+		}
+	}
+
 	bool isStructMemberDeclaration = dynamic_cast<StructDefinition const*>(_variable.scope()) != nullptr;
 	if (isStructMemberDeclaration)
 		return false;

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -184,6 +184,13 @@ private:
 		langutil::SourceLocation const& _location
 	);
 
+	/// Checks if msg.value is being assigned to a shielded type and emits a warning,
+	/// since msg.value is always publicly visible on-chain.
+	void checkMsgValueToShielded(
+		Expression const& _expression,
+		Type const& _targetType
+	);
+
 	/// @returns the referenced declaration and throws on error.
 	Declaration const& dereference(Identifier const& _identifier) const;
 	/// @returns the referenced declaration and throws on error.

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1003,8 +1003,12 @@ public:
 	BoolResult validForLocation(DataLocation _loc) const override;
 
 	/// @returns true if this is a byte array.
+	/// NOTE: Byte arrays (bytes) and strings assume non-shielded base types.
+	/// If shielded dynamic bytes are added in the future, these helpers and their
+	/// callers (e.g. stride calculations, storage layout) must be revisited.
 	bool isByteArray() const { return m_arrayKind == ArrayKind::Bytes; }
-	/// @returns true if this is a byte array or a string
+	/// @returns true if this is a byte array or a string.
+	/// @see isByteArray() for the shielded-type assumption.
 	bool isByteArrayOrString() const { return m_arrayKind != ArrayKind::Ordinary; }
 	/// @returns true if this is a string
 	bool isString() const { return m_arrayKind == ArrayKind::String; }

--- a/test/libsolidity/syntaxTests/array/shielded_dynamic_array_length_suint_type.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_dynamic_array_length_suint_type.sol
@@ -10,5 +10,6 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-37): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // Warning 2072: (158-173): Unused local variable.
 // Warning 2072: (263-277): Unused local variable.

--- a/test/libsolidity/syntaxTests/array/shielded_dynamic_array_length_type_error.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_dynamic_array_length_type_error.sol
@@ -7,4 +7,5 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-37): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 9574: (171-204): Type suint256 is not implicitly convertible to expected type uint256.

--- a/test/libsolidity/syntaxTests/array/shielded_index_addition.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_addition.sol
@@ -7,6 +7,7 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-31): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // Warning 9660: (71-105): Literals converted to shielded integers will leak during contract deployment.
 // Warning 4282: (132-157): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.
 // TypeError 7407: (132-157): Type suint256 is not implicitly convertible to expected type uint256.

--- a/test/libsolidity/syntaxTests/array/shielded_index_function_return.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_function_return.sol
@@ -10,5 +10,6 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-31): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 7407: (198-216): Type suint256 is not implicitly convertible to expected type uint256.
 // TypeError 5910: (198-216): Shielded types are not allowed as array indices.

--- a/test/libsolidity/syntaxTests/array/shielded_index_multidimensional.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_multidimensional.sol
@@ -8,6 +8,7 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-33): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // Warning 9660: (77-104): Literals converted to shielded integers will leak during contract deployment.
 // Warning 9660: (114-141): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7407: (168-172): Type suint256 is not implicitly convertible to expected type uint256.

--- a/test/libsolidity/syntaxTests/array/shielded_index_not_allowed.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_not_allowed.sol
@@ -13,6 +13,7 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (33-52): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // Warning 9660: (96-132): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7407: (220-233): Type suint256 is not implicitly convertible to expected type uint256.
 // TypeError 5910: (220-233): Shielded types are not allowed as array indices.

--- a/test/libsolidity/syntaxTests/array/shielded_index_suint16.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_suint16.sol
@@ -7,6 +7,7 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-30): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // Warning 9660: (74-98): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7407: (124-127): Type suint16 is not implicitly convertible to expected type uint256.
 // TypeError 5910: (124-127): Shielded types are not allowed as array indices.

--- a/test/libsolidity/syntaxTests/array/shielded_index_suint256.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_suint256.sol
@@ -7,6 +7,7 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-31): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // Warning 9660: (75-101): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7407: (128-131): Type suint256 is not implicitly convertible to expected type uint256.
 // TypeError 5910: (128-131): Shielded types are not allowed as array indices.

--- a/test/libsolidity/syntaxTests/array/shielded_index_suint32.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_suint32.sol
@@ -7,6 +7,7 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-30): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // Warning 9660: (74-98): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7407: (124-127): Type suint32 is not implicitly convertible to expected type uint256.
 // TypeError 5910: (124-127): Shielded types are not allowed as array indices.

--- a/test/libsolidity/syntaxTests/array/shielded_index_suint8.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_suint8.sol
@@ -7,6 +7,7 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-29): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // Warning 9660: (73-95): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7407: (120-123): Type suint8 is not implicitly convertible to expected type uint256.
 // TypeError 5910: (120-123): Shielded types are not allowed as array indices.

--- a/test/libsolidity/syntaxTests/array/shielded_push.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_push.sol
@@ -7,3 +7,5 @@ contract c {
         data.push(suint(3));
     }
 }
+// ----
+// Warning 9665: (17-32): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_152_array_copy_with_different_types1.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_152_array_copy_with_different_types1.sol
@@ -4,4 +4,5 @@ contract c {
     function f() public { b = a; }
 }
 // ----
+// Warning 9665: (30-39): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 7407: (71-72): Type bytes storage ref is not implicitly convertible to expected type suint256[] storage ref.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_153_array_copy_with_different_types2.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_153_array_copy_with_different_types2.sol
@@ -4,4 +4,6 @@ contract c {
     function f() public { b = a; }
 }
 // ----
+// Warning 9665: (17-28): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// Warning 9665: (34-44): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 7407: (76-77): Type suint32[] storage ref is not implicitly convertible to expected type suint8[] storage ref.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_154_array_copy_with_different_types_conversion_possible.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_154_array_copy_with_different_types_conversion_possible.sol
@@ -4,3 +4,5 @@ contract c {
     function f() public { a = b; }
 }
 // ----
+// Warning 9665: (17-28): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// Warning 9665: (34-44): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_155_array_copy_with_different_types_static_dynamic.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_155_array_copy_with_different_types_static_dynamic.sol
@@ -4,3 +4,4 @@ contract c {
     function f() public { a = b; }
 }
 // ----
+// Warning 9665: (17-28): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_156_array_copy_with_different_types_dynamic_static.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_156_array_copy_with_different_types_dynamic_static.sol
@@ -4,4 +4,5 @@ contract c {
     function f() public { b = a; }
 }
 // ----
+// Warning 9665: (17-26): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 7407: (75-76): Type suint256[] storage ref is not implicitly convertible to expected type suint256[80] storage ref.

--- a/test/libsolidity/syntaxTests/parsing/shielded_address_payable_state_variable.sol
+++ b/test/libsolidity/syntaxTests/parsing/shielded_address_payable_state_variable.sol
@@ -8,4 +8,6 @@ contract C {
 }
 // ----
 // TypeError 7091: (41-66): Shielded Types are not supported for public state variables.
+// Warning 9665: (72-92): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 7091: (98-125): Shielded Types are not supported for public state variables.
+// Warning 9665: (98-125): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_dynamic_array_length_warning.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_dynamic_array_length_warning.sol
@@ -1,0 +1,9 @@
+contract TestDynamicShieldedArrayWarning {
+    suint256[] arr;
+
+    function f() public {
+        arr.push(suint256(1));
+    }
+}
+// ----
+// Warning 9665: (47-61): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_msg_value_warning.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_msg_value_warning.sol
@@ -1,0 +1,8 @@
+contract TestMsgValueShielded {
+    function f() public payable {
+        suint256 x = suint256(msg.value);
+    }
+}
+// ----
+// Warning 9664: (96-105): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.
+// Warning 2072: (74-84): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_push_address_literal_without_conversion.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_push_address_literal_without_conversion.sol
@@ -7,4 +7,5 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-30): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 4254: (132-139): Cannot push a non-shielded type to a shielded array

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_push_address_without_conversion.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_push_address_without_conversion.sol
@@ -8,4 +8,5 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-30): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 4254: (164-171): Cannot push a non-shielded type to a shielded array

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_event_emission.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_event_emission.sol
@@ -7,4 +7,5 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-29): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 9553: (111-112): Invalid type for argument in function call. Invalid implicit conversion from saddress[] storage ref to address[] memory requested.

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_function_parameter.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_function_parameter.sol
@@ -21,6 +21,7 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-30): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 9553: (324-326): Invalid type for argument in function call. Invalid implicit conversion from saddress[] storage ref to address[] memory requested.
 // TypeError 9553: (414-415): Invalid type for argument in function call. Invalid implicit conversion from address[] storage ref to saddress[] memory requested.
 // TypeError 9553: (640-646): Invalid type for argument in function call. Invalid implicit conversion from saddress[] memory to address[] memory requested.

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_return_type.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_return_type.sol
@@ -35,6 +35,7 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-30): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 6359: (216-218): Return argument type saddress[] storage ref is not implicitly convertible to expected type (type of first return variable) address[] memory.
 // TypeError 6359: (395-396): Return argument type address[] storage ref is not implicitly convertible to expected type (type of first return variable) saddress[] memory.
 // TypeError 9574: (523-571): Type saddress[] memory is not implicitly convertible to expected type address[] memory.

--- a/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_storage_conversion.sol
+++ b/test/libsolidity/syntaxTests/types/address/saddress_array_to_address_array_storage_conversion.sol
@@ -10,5 +10,6 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-30): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 7407: (208-212): Type saddress[] storage pointer is not implicitly convertible to expected type address[] storage pointer.
 // TypeError 7407: (229-233): Type address[] storage pointer is not implicitly convertible to expected type saddress[] storage pointer.

--- a/test/libsolidity/syntaxTests/types/address/shielded_address_payable_storage_array_conversion.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_address_payable_storage_array_conversion.sol
@@ -8,4 +8,6 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-37): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// Warning 9665: (43-55): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 7407: (176-177): Type saddress payable[] storage pointer is not implicitly convertible to expected type saddress[] storage pointer.

--- a/test/libsolidity/syntaxTests/types/address/shielded_address_payable_storage_array_conversion_fail.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_address_payable_storage_array_conversion_fail.sol
@@ -8,4 +8,6 @@ contract C {
     }
 }
 // ----
+// Warning 9665: (17-37): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// Warning 9665: (43-55): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 7407: (176-177): Type saddress[] storage pointer is not implicitly convertible to expected type saddress payable[] storage pointer.

--- a/test/libsolidity/syntaxTests/types/shielded_nested_array_public_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_nested_array_public_fail.sol
@@ -3,3 +3,4 @@ contract Test {
 }
 // ----
 // TypeError 7091: (20-42): Shielded Types are not supported for public state variables.
+// Warning 9665: (20-42): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.


### PR DESCRIPTION
Follow up to https://github.com/SeismicSystems/seismic-solidity/pull/173

Adds documentation and compiler warnings for remaining audit items:
- 778: "Maintainability and documentation warnings for shielded behavior" (https://github.com/SeismicSystems/seismic-solidity/pull/173)
- 766: "Array lengths are public" (https://github.com/SeismicSystems/seismic-solidity/pull/181)
- 792: "ABI encoding exposes shielded values" (https://github.com/SeismicSystems/seismic-solidity/pull/165)

### Docs
We added **`SHIELDED_TYPES.md`**: a new document in the repo root covering all known shielded type edge cases and privacy limitations:
- array length metadata leakage (VER-766)
- ABI encoding restrictions (VER-792)
- & the following from VER-778:
  - `msg.value` visibility
  - `sbool` branching info leaks
  - `saddress` member limitations
  - literal deployment leakage
  - the shielded dynamic bytes non-support assumption

We also added light documentation around **`isByteArrayOrString()`**: Added comments to the `isByteArray()` / `isByteArrayOrString()` helpers in `Types.h` noting that they assume non-shielded base types, so that future work
  adding shielded dynamic bytes knows to revisit these helpers and their callers. *VER-778 (5)*

### Warnings
We also added a few warnings that the compiler will throw, corresponding to these footguns:
- **Warning 9664 — `msg.value` to shielded type**: The compiler now warns when `msg.value` is assigned to a shielded type (e.g. `suint256 x = suint256(msg.value)`), since `msg.value` is always publicly
  visible in the transaction and wrapping it does not hide the deposited amount. *VER-778 (2)*
- **Warning 9665 — dynamic shielded array length upper-bound**: The compiler now warns when a state variable is a dynamic array with shielded element types, informing the user that an upper bound on the array length may still be observable through gas cost analysis even though the length itself is stored in confidential storage. *VER-766 followup*

### Testing
- New syntax test `shielded_msg_value_warning.sol` validates **Warning 9664**
- New syntax test `shielded_dynamic_array_length_warning.sol` validates **Warning 9665**
- Updated 26 existing syntax tests with new **Warning 9665** expectations