### PR TITLE
fix(types): warn when user casts literals or `msg.value` to s-types

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1493,52 +1493,9 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 					result.message()
 				);
 		}
-		if (auto funcCall = dynamic_cast<FunctionCall const*>(_statement.initialValue()))
-		{
-			auto const& args = funcCall->arguments();
-			if (!args.empty())
-			{
-				if (auto literal = dynamic_cast<Literal const*>(args.front().get()))
-				{
-					if (var.annotation().type->category()==Type::Category::ShieldedBool)
-					{
-						std::string val = literal->value();
-						if (val == "true" || val == "false")
-							m_errorReporter.warning(
-							9661_error,
-							_statement.location(),
-							"Bool Literals converted to shielded bools will leak during contract deployment."
-							);
-					}
-					else if (literal->looksLikeAddress() && var.annotation().type->category()==Type::Category::ShieldedAddress)
-					{
-						if (literal->passesAddressChecksum()) {
-							m_errorReporter.warning(
-							9662_error,
-							_statement.location(),
-							"Address Literals converted to shielded addresses will leak during contract deployment."
-							);
-						}
-					}
-					else if (args.front()->annotation().type->category()==Type::Category::RationalNumber && var.annotation().type->category()==Type::Category::ShieldedInteger)
-					{
-						m_errorReporter.warning(
-						9660_error,
-						_statement.location(),
-						"Literals converted to shielded integers will leak during contract deployment."
-					);
-					}
-					else if (args.front()->annotation().type->category()==Type::Category::Enum && var.annotation().type->category()==Type::Category::ShieldedInteger)
-					{
-						m_errorReporter.warning(
-						1457_error,
-						_statement.location(),
-						"Enums converted to shielded integers will leak during contract deployment."
-					);
-					}
-				}
-			}
-		}
+		// Check for msg.value being assigned to a shielded type
+		if (_statement.initialValue() && var.annotation().type)
+			checkMsgValueToShielded(*_statement.initialValue(), *var.annotation().type);
 	}
 
 	if (valueTypes.size() != variables.size())
@@ -2142,6 +2099,15 @@ Type const* TypeChecker::typeCheckTypeConversionAndRetrieveReturnType(
 				);
 				}
 			}
+
+			// Check for literals being converted to shielded types
+			if (
+				resultType->category() == Type::Category::ShieldedBool ||
+				resultType->category() == Type::Category::ShieldedAddress ||
+				resultType->category() == Type::Category::ShieldedInteger ||
+				resultType->category() == Type::Category::ShieldedFixedBytes
+			)
+				checkLiteralToShielded(*arguments.front(), *resultType, _functionCall.location());
 		}
 		else
 		{
@@ -4406,6 +4372,120 @@ void TypeChecker::checkErrorAndEventParameters(CallableDeclaration const& _calla
 				"This type is only supported in ABI coder v2. "
 				"Use \"pragma abicoder v2;\" to enable the feature."
 			);
+	}
+}
+
+void TypeChecker::checkLiteralToShielded(
+	Expression const& _expression,
+	Type const& _targetType,
+	langutil::SourceLocation const& _location
+)
+{
+	// Cases that only need annotation().type, not a Literal AST node.
+	// This covers constant expressions (BinaryOperation, UnaryOperation, etc.)
+	// that fold to RationalNumber or Enum types.
+	if (
+		_expression.annotation().type &&
+		_expression.annotation().type->category() == Type::Category::RationalNumber &&
+		_targetType.category() == Type::Category::ShieldedInteger
+	)
+	{
+		m_errorReporter.warning(
+			9660_error,
+			_location,
+			"Literals converted to shielded integers will leak during contract deployment."
+		);
+		return;
+	}
+	else if (
+		_expression.annotation().type &&
+		_expression.annotation().type->category() == Type::Category::Enum &&
+		_targetType.category() == Type::Category::ShieldedInteger
+	)
+	{
+		m_errorReporter.warning(
+			1457_error,
+			_location,
+			"Enums converted to shielded integers will leak during contract deployment."
+		);
+		return;
+	}
+	else if (
+		_expression.annotation().type &&
+		_expression.annotation().type->category() == Type::Category::RationalNumber &&
+		_targetType.category() == Type::Category::ShieldedFixedBytes
+	)
+	{
+		m_errorReporter.warning(
+			9663_error,
+			_location,
+			"FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment."
+		);
+		return;
+	}
+
+	// Cases that need the actual Literal AST node for value inspection.
+	auto literal = dynamic_cast<Literal const*>(&_expression);
+	if (!literal)
+		return;
+
+	if (_targetType.category() == Type::Category::ShieldedBool)
+	{
+		std::string val = literal->value();
+		if (val == "true" || val == "false")
+			m_errorReporter.warning(
+				9661_error,
+				_location,
+				"Bool Literals converted to shielded bools will leak during contract deployment."
+			);
+	}
+	else if (literal->looksLikeAddress() && _targetType.category() == Type::Category::ShieldedAddress)
+	{
+		if (literal->passesAddressChecksum())
+			m_errorReporter.warning(
+				9662_error,
+				_location,
+				"Address Literals converted to shielded addresses will leak during contract deployment."
+			);
+	}
+}
+
+void TypeChecker::checkMsgValueToShielded(
+	Expression const& _expression,
+	Type const& _targetType
+)
+{
+	// Only warn if target type is or contains a shielded type
+	if (!_targetType.isShielded() && !_targetType.containsShieldedType())
+		return;
+
+	// Check if expression is msg.value directly
+	if (auto memberAccess = dynamic_cast<MemberAccess const*>(&_expression))
+	{
+		if (memberAccess->memberName() == "value")
+		{
+			if (auto identifier = dynamic_cast<Identifier const*>(&memberAccess->expression()))
+			{
+				if (identifier->name() == "msg")
+				{
+					m_errorReporter.warning(
+						9664_error,
+						memberAccess->location(),
+						"msg.value is always publicly visible on-chain. "
+						"Assigning it to a shielded type does not hide the transaction value from observers."
+					);
+					return;
+				}
+			}
+		}
+	}
+
+	// Recurse into type conversion arguments: suint256(msg.value)
+	if (auto funcCall = dynamic_cast<FunctionCall const*>(&_expression))
+	{
+		for (auto const& arg : funcCall->arguments())
+			if (arg)
+				checkMsgValueToShielded(*arg, _targetType);
 	}
 }
 

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -166,6 +166,21 @@ private:
 
 	void checkErrorAndEventParameters(CallableDeclaration const& _callable);
 
+	/// Checks if a literal expression is being converted to a shielded type and emits a warning.
+	/// This is the core check that matches the original warning logic.
+	void checkLiteralToShielded(
+		Expression const& _expression,
+		Type const& _targetType,
+		langutil::SourceLocation const& _location
+	);
+
+	/// Checks if msg.value is being assigned to a shielded type and emits a warning,
+	/// since msg.value is always publicly visible on-chain.
+	void checkMsgValueToShielded(
+		Expression const& _expression,
+		Type const& _targetType
+	);
+
 	/// @returns the referenced declaration and throws on error.
 	Declaration const& dereference(Identifier const& _identifier) const;
 	/// @returns the referenced declaration and throws on error.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_packed_shielded.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_packed_shielded.sol
@@ -5,5 +5,5 @@ contract C {
     }
 }
 // ----
-// Warning 9661: (52-73): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 9661: (62-73): Bool Literals converted to shielded bools will leak during contract deployment.
 // TypeError 3648: (100-101): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_shielded_types.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_shielded_types.sol
@@ -5,5 +5,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (52-76): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (65-76): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 3648: (97-98): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_with_selector_shielded.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_with_selector_shielded.sol
@@ -5,5 +5,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (52-76): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (65-76): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 3648: (129-130): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_with_signature_shielded.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_with_signature_shielded.sol
@@ -5,5 +5,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (52-76): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (65-76): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 3648: (126-127): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/array/shielded_array_constructor_length_suint.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_array_constructor_length_suint.sol
@@ -5,4 +5,5 @@ contract C {
     }
 }
 // ----
+// Warning 9660: (95-103): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 9553: (95-103): Invalid type for argument in function call. Invalid implicit conversion from suint256 to uint256 requested.

--- a/test/libsolidity/syntaxTests/array/shielded_index_addition.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_addition.sol
@@ -7,6 +7,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (75-109): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (98-109): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (150-161): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7407: (136-161): Type suint256 is not implicitly convertible to expected type uint256.
 // TypeError 5910: (136-161): Shielded types are not allowed as array indices.

--- a/test/libsolidity/syntaxTests/array/shielded_index_function_return.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_function_return.sol
@@ -10,5 +10,6 @@ contract C {
     }
 }
 // ----
+// Warning 9660: (120-131): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7407: (198-216): Type suint256 is not implicitly convertible to expected type uint256.
 // TypeError 5910: (198-216): Shielded types are not allowed as array indices.

--- a/test/libsolidity/syntaxTests/array/shielded_index_multidimensional.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_multidimensional.sol
@@ -8,7 +8,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (77-104): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (114-141): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (93-104): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (130-141): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7407: (168-172): Type suint256 is not implicitly convertible to expected type uint256.
 // TypeError 5910: (168-172): Shielded types are not allowed as array indices.

--- a/test/libsolidity/syntaxTests/array/shielded_index_not_allowed.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_not_allowed.sol
@@ -13,6 +13,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (96-132): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (121-132): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7407: (220-233): Type suint256 is not implicitly convertible to expected type uint256.
 // TypeError 5910: (220-233): Shielded types are not allowed as array indices.

--- a/test/libsolidity/syntaxTests/array/shielded_index_suint16.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_suint16.sol
@@ -7,6 +7,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (74-98): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (88-98): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7407: (124-127): Type suint16 is not implicitly convertible to expected type uint256.
 // TypeError 5910: (124-127): Shielded types are not allowed as array indices.

--- a/test/libsolidity/syntaxTests/array/shielded_index_suint256.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_suint256.sol
@@ -7,6 +7,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (75-101): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (90-101): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7407: (128-131): Type suint256 is not implicitly convertible to expected type uint256.
 // TypeError 5910: (128-131): Shielded types are not allowed as array indices.

--- a/test/libsolidity/syntaxTests/array/shielded_index_suint32.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_suint32.sol
@@ -7,6 +7,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (74-98): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (88-98): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7407: (124-127): Type suint32 is not implicitly convertible to expected type uint256.
 // TypeError 5910: (124-127): Shielded types are not allowed as array indices.

--- a/test/libsolidity/syntaxTests/array/shielded_index_suint8.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_index_suint8.sol
@@ -7,6 +7,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (73-95): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (86-95): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7407: (120-123): Type suint8 is not implicitly convertible to expected type uint256.
 // TypeError 5910: (120-123): Shielded types are not allowed as array indices.

--- a/test/libsolidity/syntaxTests/array/shielded_push.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_push.sol
@@ -7,3 +7,5 @@ contract c {
         data.push(suint(3));
     }
 }
+// ----
+// Warning 9660: (148-156): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero.sol
@@ -3,3 +3,4 @@ contract C {
 }
 // ----
 // TypeError 2271: (33-38): Built-in binary operator / cannot be applied to types int_const 1 and int_const 0.
+// Warning 9660: (27-39): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero_complex.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero_complex.sol
@@ -3,3 +3,4 @@ contract C {
 }
 // ----
 // TypeError 2271: (33-46): Built-in binary operator / cannot be applied to types int_const 1 and int_const 0.
+// Warning 9660: (27-47): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero_complex_compound.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero_complex_compound.sol
@@ -3,3 +3,4 @@ contract A {
     constructor() { a /= suint(((2)*2)%4); }
 }
 // ----
+// Warning 9660: (51-67): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero_compound.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero_compound.sol
@@ -3,3 +3,5 @@ contract A {
     constructor() { a /= suint(0); }
 }
 // ----
+// Warning 9660: (27-35): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (62-70): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero_nonliteral.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero_nonliteral.sol
@@ -2,3 +2,4 @@ contract A {
     constructor() { suint a; a / suint(0); }
 }
 // ----
+// Warning 9660: (46-54): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_exponent_fine.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_exponent_fine.sol
@@ -6,3 +6,4 @@ contract C {
     }
 }
 // ----
+// Warning 9660: (102-120): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero.sol
@@ -3,3 +3,4 @@ contract C {
 }
 // ----
 // TypeError 2271: (34-39): Built-in binary operator % cannot be applied to types int_const 1 and int_const 0.
+// Warning 9660: (28-40): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero_complex.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero_complex.sol
@@ -3,3 +3,4 @@ contract C {
 }
 // ----
 // TypeError 2271: (34-50): Built-in binary operator % cannot be applied to types int_const 1 and int_const 0.
+// Warning 9660: (28-51): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero_complex_compound.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero_complex_compound.sol
@@ -3,3 +3,5 @@ contract A {
     constructor() { a %= suint(((2)*2)%4); }
 }
 // ----
+// Warning 9660: (27-35): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (62-78): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero_compound.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero_compound.sol
@@ -3,3 +3,5 @@ contract A {
     constructor() { a = suint(5); a %= suint(0); }
 }
 // ----
+// Warning 9660: (50-58): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (65-73): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero_nonliteral.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero_nonliteral.sol
@@ -2,3 +2,4 @@ contract A {
     constructor() { suint a; a % suint(0); }
 }
 // ----
+// Warning 9660: (46-54): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literals/shielded_ternary_operator_return_type_with_literal_arguments.sol
+++ b/test/libsolidity/syntaxTests/literals/shielded_ternary_operator_return_type_with_literal_arguments.sol
@@ -33,5 +33,9 @@ contract TestTernary
     }
 }
 // ----
-// Warning 9660: (113-138): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (148-171): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (127-138): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (161-171): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (591-602): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (617-627): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (876-887): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (906-916): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_010_type_conversion_for_comparison.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_010_type_conversion_for_comparison.sol
@@ -2,5 +2,7 @@ contract test {
     function f() public { suint32(2) == suint64(2); }
 }
 // ----
+// Warning 9660: (42-52): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (56-66): Literals converted to shielded integers will leak during contract deployment.
 // Warning 6133: (42-66): Statement has no effect.
 // Warning 2018: (20-69): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_011_type_conversion_for_comparison_invalid.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_011_type_conversion_for_comparison_invalid.sol
@@ -2,4 +2,6 @@ contract test {
     function f() public { sint32(2) == suint64(2); }
 }
 // ----
+// Warning 9660: (42-51): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (55-65): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (42-65): Built-in binary operator == cannot be applied to types sint32 and suint64.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_113_exp_warn_literal_base_1.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_113_exp_warn_literal_base_1.sol
@@ -5,5 +5,5 @@ contract test {
     }
 }
 // ----
-// Warning 9660: (69-91): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (80-91): Literals converted to shielded integers will leak during contract deployment.
 // Warning 3817: (113-118): Shielded integer exponentiation will leak the exponent value through gas cost.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_114_exp_warn_literal_base_2.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_114_exp_warn_literal_base_2.sol
@@ -5,5 +5,6 @@ contract test {
     }
 }
 // ----
-// Warning 9660: (69-91): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (80-91): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (113-123): Literals converted to shielded integers will leak during contract deployment.
 // Warning 3817: (113-126): Shielded integer exponentiation will leak the exponent value through gas cost.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_116_shift_warn_literal_base_1.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_116_shift_warn_literal_base_1.sol
@@ -5,4 +5,4 @@ contract test {
     }
 }
 // ----
-// Warning 9660: (69-91): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (80-91): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_117_shift_warn_literal_base_2.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_117_shift_warn_literal_base_2.sol
@@ -5,4 +5,5 @@ contract test {
     }
 }
 // ----
-// Warning 9660: (69-91): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (80-91): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (113-123): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_119_shift_warn_literal_base_4.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_119_shift_warn_literal_base_4.sol
@@ -5,4 +5,4 @@ contract test {
     }
 }
 // ----
-// Warning 9660: (70-92): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (81-92): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_128_enum_explicit_conversion_is_okay.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_128_enum_explicit_conversion_is_okay.sol
@@ -8,3 +8,5 @@ contract test {
     suint64 b;
 }
 // ----
+// Warning 1457: (108-142): Enums converted to shielded integers will leak during contract deployment.
+// Warning 1457: (156-182): Enums converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_129_int_to_enum_explicit_conversion_is_okay.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_129_int_to_enum_explicit_conversion_is_okay.sol
@@ -8,3 +8,4 @@ contract test {
     ActionChoices b;
 }
 // ----
+// Warning 9660: (108-116): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_191_negative_integers_to_signed_min.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_191_negative_integers_to_signed_min.sol
@@ -2,3 +2,4 @@ contract test {
     sint8 i = sint8(-128);
 }
 // ----
+// Warning 9660: (30-41): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_193_positive_integers_to_signed_out_of_bound_max.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_193_positive_integers_to_signed_out_of_bound_max.sol
@@ -2,3 +2,4 @@ contract test {
     sint8 j = sint8(127);
 }
 // ----
+// Warning 9660: (30-40): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_196_integer_boolean_or.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_196_integer_boolean_or.sol
@@ -1,5 +1,5 @@
 contract test { fallback() external { suint x = suint(1); suint y = suint(2); x || y; } }
 // ----
-// Warning 9660: (38-56): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (58-76): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (48-56): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (68-76): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (78-84): Built-in binary operator || cannot be applied to types suint256 and suint256.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_197_integer_boolean_and.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_197_integer_boolean_and.sol
@@ -1,5 +1,5 @@
 contract test { fallback() external { suint x = suint(1); suint y = suint(2); x && y; } }
 // ----
-// Warning 9660: (38-56): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (58-76): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (48-56): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (68-76): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (78-84): Built-in binary operator && cannot be applied to types suint256 and suint256.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_198_integer_boolean_not.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_198_integer_boolean_not.sol
@@ -1,4 +1,4 @@
 contract test { fallback() external { suint x = suint(1); !x; } }
 // ----
-// Warning 9660: (38-56): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (48-56): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 4907: (58-60): Built-in unary operator ! cannot be applied to type suint256.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_199_integer_unsigned_exp_signed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_199_integer_unsigned_exp_signed.sol
@@ -1,5 +1,6 @@
 contract test { fallback() external { suint x = suint(3); sint y = sint(-4); x ** y; } }
 // ----
-// Warning 9660: (38-56): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (48-56): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (67-75): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (77-83): Built-in binary operator ** cannot be applied to types suint256 and sint256. Exponentiation power is not allowed to be a signed shielded integer type.
 // Warning 3817: (77-83): Shielded integer exponentiation will leak the exponent value through gas cost.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_200_integer_signed_exp_unsigned.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_200_integer_signed_exp_unsigned.sol
@@ -4,11 +4,12 @@ contract test {
     function g() public pure { sint16 x =sint16(3); suint16 y = suint16(4); x ** y; }
 }
 // ----
-// Warning 9660: (42-60): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (52-60): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (71-79): Literals converted to shielded integers will leak during contract deployment.
 // Warning 3817: (81-87): Shielded integer exponentiation will leak the exponent value through gas cost.
-// Warning 9660: (122-141): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (143-163): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (132-141): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (154-163): Literals converted to shielded integers will leak during contract deployment.
 // Warning 3817: (165-171): Shielded integer exponentiation will leak the exponent value through gas cost.
-// Warning 9660: (206-225): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (227-249): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (216-225): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (239-249): Literals converted to shielded integers will leak during contract deployment.
 // Warning 3817: (251-257): Shielded integer exponentiation will leak the exponent value through gas cost.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_201_integer_signed_exp_signed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_201_integer_signed_exp_signed.sol
@@ -15,17 +15,18 @@ contract test {
     }
 }
 // ----
-// Warning 9660: (50-66): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (76-92): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (59-66): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (85-92): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (107-113): Built-in binary operator ** cannot be applied to types sint256 and sint256. Exponentiation power is not allowed to be a signed shielded integer type.
 // Warning 3817: (107-113): Shielded integer exponentiation will leak the exponent value through gas cost.
-// Warning 9660: (156-176): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (186-206): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (167-176): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (197-206): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (221-227): Built-in binary operator ** cannot be applied to types suint8 and sint16. Exponentiation power is not allowed to be a signed shielded integer type.
 // Warning 3817: (221-227): Shielded integer exponentiation will leak the exponent value through gas cost.
 // Warning 3149: (221-227): The result type of the exponentiation operation is equal to the type of the first operand (suint8) ignoring the (larger) type of the second operand (sint16) which might be unexpected. Silence this warning by either converting the first or the second operand to the type of the other.
 // TypeError 9640: (216-228): Explicit type conversion not allowed from "suint8" to "sint256".
-// Warning 9660: (270-290): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (281-290): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (310-318): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (305-318): Built-in binary operator ** cannot be applied to types sint16 and sint256. Exponentiation power is not allowed to be a signed shielded integer type.
 // Warning 3817: (305-318): Shielded integer exponentiation will leak the exponent value through gas cost.
 // Warning 3149: (305-318): The result type of the exponentiation operation is equal to the type of the first operand (sint16) ignoring the (larger) type of the second operand (sint256) which might be unexpected. Silence this warning by either converting the first or the second operand to the type of the other.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_arithmetic_inc_dec_info_leak.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_arithmetic_inc_dec_info_leak.sol
@@ -1,0 +1,11 @@
+contract C {
+    function f() public pure {
+        suint256 a = suint256(1);
+        a++;
+        a--;
+        ++a;
+        --a;
+    }
+}
+// ----
+// Warning 9660: (65-76): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_negative_rational_shift_requires_shielded_result.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_negative_rational_shift_requires_shielded_result.sol
@@ -1,0 +1,10 @@
+contract test {
+    function f() pure internal returns(sint256) {
+        suint8 x = suint8(2);
+        sint256 result = -1 << x;  // Should work: negative rational << shielded -> sint256
+        return result;
+    }
+}
+// ----
+// Warning 9660: (85-94): Literals converted to shielded integers will leak during contract deployment.
+// TypeError 9574: (104-128): Type int256 is not implicitly convertible to expected type sint256.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_rational_exp_implicit_public_fails.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_rational_exp_implicit_public_fails.sol
@@ -1,0 +1,10 @@
+contract test {
+    function f() pure internal returns(uint256) {
+        suint8 x = suint8(2);
+        uint256 result = 10 ** x;  // Should fail: implicit conversion from shielded to public
+        return result;
+    }
+}
+// ----
+// Warning 9660: (85-94): Literals converted to shielded integers will leak during contract deployment.
+// Warning 3817: (121-128): Shielded integer exponentiation will leak the exponent value through gas cost.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_rational_exp_requires_shielded_result.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_rational_exp_requires_shielded_result.sol
@@ -1,0 +1,11 @@
+contract test {
+    function f() pure internal returns(suint256) {
+        suint8 x = suint8(2);
+        suint256 result = 10 ** x;  // Should work: rational ** shielded -> shielded
+        return result;
+    }
+}
+// ----
+// Warning 9660: (86-95): Literals converted to shielded integers will leak during contract deployment.
+// Warning 3817: (123-130): Shielded integer exponentiation will leak the exponent value through gas cost.
+// TypeError 9574: (105-130): Type uint256 is not implicitly convertible to expected type suint256.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_rational_shift_implicit_public_fails.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_rational_shift_implicit_public_fails.sol
@@ -1,0 +1,9 @@
+contract test {
+    function f() pure internal returns(uint256) {
+        suint8 x = suint8(100);
+        uint256 result = 1 << x;  // Should fail: implicit conversion from shielded to public
+        return result;
+    }
+}
+// ----
+// Warning 9660: (85-96): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_rational_shift_requires_shielded_result.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_rational_shift_requires_shielded_result.sol
@@ -1,0 +1,10 @@
+contract test {
+    function f() pure internal returns(suint256) {
+        suint8 x = suint8(100);
+        suint256 result = 1 << x;  // Should work: rational << shielded -> shielded
+        return result;
+    }
+}
+// ----
+// Warning 9660: (86-97): Literals converted to shielded integers will leak during contract deployment.
+// TypeError 9574: (107-131): Type uint256 is not implicitly convertible to expected type suint256.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_address_literal.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_address_literal.sol
@@ -5,4 +5,4 @@ contract test {
     }
 }
 // ----
-// Warning 9662: (72-137): Address Literals converted to shielded addresses will leak during contract deployment.
+// Warning 9662: (85-137): Address Literals converted to shielded addresses will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_bool_literal.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_bool_literal.sol
@@ -5,4 +5,4 @@ contract test {
     }
 }
 // ----
-// Warning 9661: (69-90): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 9661: (79-90): Bool Literals converted to shielded bools will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_fixedbytes_literal.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_fixedbytes_literal.sol
@@ -1,0 +1,11 @@
+contract C {
+    constructor() {
+        sbytes4 x = sbytes4(0x01020304);
+        sbytes8 y = sbytes8(0x0102030405060708);
+    }
+}
+// ----
+// Warning 9663: (53-72): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (94-121): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 2072: (41-50): Unused local variable.
+// Warning 2072: (82-91): Unused local variable.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_fixedbytes_literal_struct.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_fixedbytes_literal_struct.sol
@@ -1,0 +1,13 @@
+contract C {
+    struct S {
+        sbytes4 b;
+    }
+    constructor() {
+        sbytes4 direct = sbytes4(0x01020304);
+        S memory s = S({b: sbytes4(0x01020304)});
+        s.b = direct;
+    }
+}
+// ----
+// Warning 9663: (98-117): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (146-165): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_array.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_array.sol
@@ -1,0 +1,15 @@
+contract C {
+    constructor() {
+        suint[2] memory a = [suint(1), suint(2)];
+        sbool[2] memory b = [sbool(true), sbool(false)];
+        a[0] = suint(3);
+        b[1] = sbool(true);
+    }
+}
+// ----
+// Warning 9660: (62-70): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (72-80): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9661: (112-123): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 9661: (125-137): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 9660: (155-163): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9661: (180-191): Bool Literals converted to shielded bools will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_array_nested.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_array_nested.sol
@@ -1,0 +1,16 @@
+contract C {
+    constructor() {
+        // Nested arrays
+        suint[2][2] memory a = [[suint(1), suint(2)], [suint(3), suint(4)]];
+        // Array in struct
+        // Single element array
+        suint[1] memory b = [suint(5)];
+        b[0] = a[0][0]; // Use the variables
+    }
+}
+// ----
+// Warning 9660: (91-99): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (101-109): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (113-121): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (123-131): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (223-231): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_multiple_args.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_multiple_args.sol
@@ -1,0 +1,14 @@
+contract C {
+    struct S {
+        uint x;
+        sbool a;
+        sbool b;
+    }
+    constructor() {
+        S memory s = S(42, sbool(true), sbool(false));
+    }
+}
+// ----
+// Warning 9661: (131-142): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 9661: (144-156): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 2072: (112-122): Unused local variable.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_struct.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_struct.sol
@@ -1,0 +1,11 @@
+contract C {
+    struct S { sbool b; }
+    constructor() {
+        sbool direct = sbool(true);
+        S memory s = S({b: sbool(true)});
+        s.b = direct;
+    }
+}
+// ----
+// Warning 9661: (82-93): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 9661: (122-133): Bool Literals converted to shielded bools will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_struct_positional.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_struct_positional.sol
@@ -1,0 +1,11 @@
+contract C {
+    struct S { sbool b; }
+    constructor() {
+        sbool direct = sbool(true);
+        S memory s = S(sbool(true));
+        s.b = direct;
+    }
+}
+// ----
+// Warning 9661: (82-93): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 9661: (118-129): Bool Literals converted to shielded bools will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/parsing/shielded_conditional.sol
+++ b/test/libsolidity/syntaxTests/parsing/shielded_conditional.sol
@@ -21,7 +21,7 @@ contract TestSbool {
 }
 
 // ----
-// Warning 9661: (294-315): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 9661: (304-315): Bool Literals converted to shielded bools will leak during contract deployment.
 // Warning 2018: (25-162): Function state mutability can be restricted to pure
 // Warning 2018: (168-243): Function state mutability can be restricted to pure
 // Warning 2018: (249-394): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/parsing/shielded_exp_expression.sol
+++ b/test/libsolidity/syntaxTests/parsing/shielded_exp_expression.sol
@@ -4,6 +4,7 @@ contract test {
     }
 }
 // ----
+// Warning 9660: (75-83): Literals converted to shielded integers will leak during contract deployment.
 // Warning 3817: (75-88): Shielded integer exponentiation will leak the exponent value through gas cost.
 // Warning 2072: (62-72): Unused local variable.
 // Warning 2018: (20-95): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/parsing/shielded_for_loop_simple_initexpr.sol
+++ b/test/libsolidity/syntaxTests/parsing/shielded_for_loop_simple_initexpr.sol
@@ -7,7 +7,8 @@ contract test {
     }
 }
 // ----
-// Warning 9660: (62-85): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (74-85): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (107-116): Literals converted to shielded integers will leak during contract deployment.
 // Warning 5740: (118-121): Unreachable code.
 // Warning 5740: (160-168): Unreachable code.
 // Warning 5667: (33-43): Unused function parameter. Remove or comment out the variable name to silence this warning.

--- a/test/libsolidity/syntaxTests/parsing/shielded_for_loop_single_stmt_body.sol
+++ b/test/libsolidity/syntaxTests/parsing/shielded_for_loop_single_stmt_body.sol
@@ -6,6 +6,8 @@ contract test {
     }
 }
 // ----
-// Warning 9660: (62-83): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (75-83): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (102-110): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (116-125): Literals converted to shielded integers will leak during contract deployment.
 // Warning 5667: (33-43): Unused function parameter. Remove or comment out the variable name to silence this warning.
 // Warning 2018: (20-159): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/parsing/shielded_for_loop_vardef_initexpr.sol
+++ b/test/libsolidity/syntaxTests/parsing/shielded_for_loop_vardef_initexpr.sol
@@ -6,7 +6,8 @@ contract test {
     }
 }
 // ----
-// Warning 9660: (67-88): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (80-88): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (94-103): Literals converted to shielded integers will leak during contract deployment.
 // Warning 5740: (105-108): Unreachable code.
 // Warning 5740: (147-155): Unreachable code.
 // Warning 5667: (33-43): Unused function parameter. Remove or comment out the variable name to silence this warning.

--- a/test/libsolidity/syntaxTests/parsing/shielded_if_statement.sol
+++ b/test/libsolidity/syntaxTests/parsing/shielded_if_statement.sol
@@ -4,7 +4,8 @@ contract test {
     }
 }
 // ----
-// Warning 9660: (117-135): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (86-94): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (127-135): Literals converted to shielded integers will leak during contract deployment.
 // Warning 6321: (61-65): Unnamed return variable can remain unassigned. Add an explicit return with value to all non-reverting code paths or name the variable.
 // Warning 2072: (117-124): Unused local variable.
 // Warning 2018: (20-144): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/parsing/shielded_while_loop.sol
+++ b/test/libsolidity/syntaxTests/parsing/shielded_while_loop.sol
@@ -5,4 +5,6 @@ contract test {
     }
 }
 // ----
+// Warning 9660: (96-104): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (129-137): Literals converted to shielded integers will leak during contract deployment.
 // Warning 5740: (113-121): Unreachable code.

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_dynamic_array_length_warning.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_dynamic_array_length_warning.sol
@@ -1,0 +1,9 @@
+contract TestDynamicShieldedArrayWarning {
+    suint256[] arr;
+
+    function f() public {
+        arr.push(suint256(1));
+    }
+}
+// ----
+// Warning 9660: (107-118): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/address/shielded_address_literal_to_payable.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_address_literal_to_payable.sol
@@ -7,3 +7,5 @@ contract C {
     }
 }
 // ----
+// Warning 9662: (81-133): Address Literals converted to shielded addresses will leak during contract deployment.
+// Warning 9662: (173-225): Address Literals converted to shielded addresses will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/address/shielded_address_literal_to_payable_err.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_address_literal_to_payable_err.sol
@@ -5,6 +5,6 @@ contract C {
     }
 }
 // ----
+// Warning 9662: (73-125): Address Literals converted to shielded addresses will leak during contract deployment.
 // TypeError 9574: (52-125): Type saddress is not implicitly convertible to expected type saddress payable.
-// Warning 9662: (52-125): Address Literals converted to shielded addresses will leak during contract deployment.
 // TypeError 9574: (135-198): Type address is not implicitly convertible to expected type saddress payable.

--- a/test/libsolidity/syntaxTests/types/address/shielded_literal_to_address.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_literal_to_address.sol
@@ -8,4 +8,6 @@ contract C {
     }
 }
 // ----
-// Warning 9662: (111-176): Address Literals converted to shielded addresses will leak during contract deployment.
+// Warning 9662: (124-176): Address Literals converted to shielded addresses will leak during contract deployment.
+// Warning 9662: (190-242): Address Literals converted to shielded addresses will leak during contract deployment.
+// Warning 9662: (256-317): Address Literals converted to shielded addresses will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/address/shielded_literal_to_payable_address.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_literal_to_payable_address.sol
@@ -8,3 +8,5 @@ contract C {
     }
 }
 // ----
+// Warning 9662: (205-257): Address Literals converted to shielded addresses will leak during contract deployment.
+// Warning 9662: (280-332): Address Literals converted to shielded addresses will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/address/shielded_payable_conversions_literals.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_payable_conversions_literals.sol
@@ -11,3 +11,4 @@ contract C {
     }
 }
 // ----
+// Warning 9662: (181-233): Address Literals converted to shielded addresses will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/sbytes_arrays.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_arrays.sol
@@ -26,6 +26,9 @@ contract C {
     }
 }
 // ----
+// Warning 9663: (238-251): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (271-298): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (319-395): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
 // Warning 2072: (435-447): Unused local variable.
 // Warning 2072: (467-479): Unused local variable.
 // Warning 2072: (499-513): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/sbytes_basic_declarations.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_basic_declarations.sol
@@ -18,3 +18,6 @@ contract C {
     }
 }
 // ----
+// Warning 9663: (287-300): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (319-334): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (354-430): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/sbytes_explicit_conversions.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_explicit_conversions.sol
@@ -20,3 +20,7 @@ contract C {
         sb32 = sbytes32(b32);
     }
 }
+// ----
+// Warning 9663: (72-85): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (109-136): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (162-238): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/sbytes_function_returns.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_function_returns.sol
@@ -23,6 +23,9 @@ contract C {
 }
 
 // ----
+// Warning 9663: (91-104): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (195-222): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (315-391): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
 // Warning 2072: (448-459): Unused local variable.
 // Warning 2072: (487-498): Unused local variable.
 // Warning 2072: (526-539): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/sbytes_implicit_conversions_fail.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_implicit_conversions_fail.sol
@@ -20,6 +20,9 @@ contract C {
     }
 }
 // ----
+// Warning 9663: (71-84): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (108-135): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (161-237): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
 // TypeError 7407: (523-526): Type sbytes1 is not implicitly convertible to expected type bytes1.
 // TypeError 7407: (541-544): Type sbytes8 is not implicitly convertible to expected type bytes8.
 // TypeError 7407: (560-564): Type sbytes32 is not implicitly convertible to expected type bytes32.

--- a/test/libsolidity/syntaxTests/types/sbytes_no_dynamic_byte_array.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_no_dynamic_byte_array.sol
@@ -31,3 +31,4 @@ contract C {
     }
 }
 // ----
+// Warning 9663: (880-956): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/sbytes_operations.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_operations.sol
@@ -24,6 +24,18 @@ contract C {
     }
 }
 // ----
+// Warning 9663: (71-84): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (108-135): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (161-237): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (315-328): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (362-389): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (426-502): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (677-690): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (718-745): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (771-784): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (812-839): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (866-942): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (971-1047): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
 // Warning 2072: (291-306): Unused local variable.
 // Warning 2072: (338-353): Unused local variable.
 // Warning 2072: (399-416): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/sbytes_public_variables.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_public_variables.sol
@@ -15,3 +15,6 @@ contract C {
 // TypeError 7091: (88-106): Shielded Types are not supported for public state variables.
 // TypeError 7091: (112-130): Shielded Types are not supported for public state variables.
 // TypeError 7091: (136-156): Shielded Types are not supported for public state variables.
+// Warning 9663: (197-210): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (226-253): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (270-346): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/sbytes_size_conversions.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_size_conversions.sol
@@ -16,6 +16,9 @@ contract C {
     }
 }
 // ----
+// Warning 9663: (71-84): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (108-135): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (161-237): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
 // TypeError 7407: (639-642): Type sbytes8 is not implicitly convertible to expected type sbytes1.
 // TypeError 7407: (705-709): Type sbytes32 is not implicitly convertible to expected type sbytes1.
 // TypeError 7407: (772-776): Type sbytes32 is not implicitly convertible to expected type sbytes8.

--- a/test/libsolidity/syntaxTests/types/sbytes_struct.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_struct.sol
@@ -29,6 +29,12 @@ contract C {
     }
 }
 // ----
+// Warning 9663: (261-274): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (296-323): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (350-426): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (562-575): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (595-622): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (647-723): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
 // Warning 2072: (823-837): Unused local variable.
 // Warning 2072: (858-874): Unused local variable.
 // Warning 2072: (897-913): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/shielded_constant_expression_leak.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_constant_expression_leak.sol
@@ -1,0 +1,45 @@
+contract C {
+    function f() public pure {
+        // BinaryOperation folding to RationalNumber → shielded integer
+        sint a;
+        a = sint(0 ** 1E1233);
+        a = sint(1 ** 1E1233);
+        a = sint(2 + 3);
+        a = sint(10 - 7);
+        a = sint(2 * 3);
+
+        // UnaryOperation folding to RationalNumber → shielded integer
+        a = sint(-1 ** 1E1233);
+        a = sint(-(2 + 3));
+
+        // Parenthesised literal → shielded integer (still a Literal node)
+        a = sint(42);
+
+        // Direct literal → shielded integer (baseline)
+        a = sint(0E123456789);
+
+        // BinaryOperation → shielded unsigned integer
+        suint b;
+        b = suint(2 + 3);
+        b = suint(10 * 20);
+
+        // BinaryOperation → shielded fixed bytes
+        sbytes32 c;
+        c = sbytes32(2 + 3);
+        c = sbytes32(0xff * 2);
+    }
+}
+// ----
+// Warning 9660: (146-163): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (177-194): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (208-219): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (233-245): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (259-270): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (358-376): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (390-404): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (496-504): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (577-594): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (683-695): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (709-723): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9663: (810-825): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (839-857): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_rational_number_bitshift_limit.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_rational_number_bitshift_limit.sol
@@ -9,5 +9,6 @@ contract c {
 // ----
 // TypeError 9640: (72-87): Explicit type conversion not allowed from "int_const 5221...(1225 digits omitted)...5168" to "sint256". Literal is too large to fit in sint256.
 // TypeError 2271: (145-154): Built-in binary operator << cannot be applied to types int_const 1 and int_const 4096.
+// Warning 9660: (140-155): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (187-200): Built-in binary operator << cannot be applied to types int_const 1000...(1226 digits omitted)...0000 and int_const 2.
 // TypeError 9640: (182-201): Explicit type conversion not allowed from "int_const 1000...(1226 digits omitted)...0000" to "sint256". Literal is too large to fit in sint256.

--- a/test/libsolidity/syntaxTests/types/shielded_rational_number_exp_limit_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_rational_number_exp_limit_fail.sol
@@ -25,10 +25,15 @@ contract c {
 // TypeError 9640: (133-182): Explicit type conversion not allowed from "int_const 1340...(147 digits omitted)...4096" to "sint256". Literal is too large to fit in sint256.
 // TypeError 2271: (219-235): Built-in binary operator ** cannot be applied to types int_const 4 and int_const 1340...(147 digits omitted)...4096.
 // TypeError 2271: (201-237): Built-in binary operator ** cannot be applied to types int_const 4 and int_const -115...(71 digits omitted)...9936.
+// Warning 9660: (196-238): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (257-268): Built-in binary operator ** cannot be applied to types int_const 2 and int_const 1000...(1226 digits omitted)...0000.
+// Warning 9660: (252-269): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (288-300): Built-in binary operator ** cannot be applied to types int_const -2 and int_const 1000...(1226 digits omitted)...0000.
+// Warning 9660: (283-301): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (320-332): Built-in binary operator ** cannot be applied to types int_const 2 and int_const -100...(1227 digits omitted)...0000.
+// Warning 9660: (315-333): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (352-365): Built-in binary operator ** cannot be applied to types int_const -2 and int_const -100...(1227 digits omitted)...0000.
+// Warning 9660: (347-366): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (385-396): Built-in binary operator ** cannot be applied to types int_const 1000...(1226 digits omitted)...0000 and int_const 2.
 // TypeError 9640: (380-397): Explicit type conversion not allowed from "int_const 1000...(1226 digits omitted)...0000" to "sint256". Literal is too large to fit in sint256.
 // TypeError 2271: (416-428): Built-in binary operator ** cannot be applied to types int_const -100...(1227 digits omitted)...0000 and int_const 2.

--- a/test/libsolidity/syntaxTests/types/shielded_rational_number_exp_limit_fine.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_rational_number_exp_limit_fine.sol
@@ -8,3 +8,7 @@ contract c {
     }
 }
 // ----
+// Warning 9660: (72-89): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (103-120): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (134-152): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (166-183): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_rational_number_huge.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_rational_number_huge.sol
@@ -8,3 +8,5 @@ contract C {
     }
 }
 // ----
+// Warning 9660: (112-185): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (306-380): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_rational_number_literal_limit_1.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_rational_number_literal_limit_1.sol
@@ -6,4 +6,5 @@ contract c {
     }
 }
 // ----
+// Warning 9660: (76-98): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2826: (136-142): Invalid literal value.

--- a/test/libsolidity/syntaxTests/types/shielded_rational_number_too_large.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_rational_number_too_large.sol
@@ -8,5 +8,4 @@ contract C {
 // ----
 // TypeError 9574: (52-66): Type int_const 256 is not implicitly convertible to expected type suint8.
 // TypeError 9640: (87-98): Explicit type conversion not allowed from "int_const 256" to "suint8". Literal is too large to fit in suint8.
-// Warning 9660: (76-98): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 9640: (118-129): Explicit type conversion not allowed from "int_const -129" to "sint8". Literal is too large to fit in sint8.

--- a/test/libsolidity/syntaxTests/visibility/shielded_array_return.sol
+++ b/test/libsolidity/syntaxTests/visibility/shielded_array_return.sol
@@ -39,6 +39,10 @@ contract C {
 }
 // ----
 // TypeError 7492: (155-172): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.
+// Warning 9660: (244-256): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7492: (341-358): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.
+// Warning 9660: (430-442): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (654-666): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (875-887): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7492: (1029-1047): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.
 // TypeError 7492: (1171-1189): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.

--- a/test/libsolidity/syntaxTests/visibility/shielded_sbytes_return.sol
+++ b/test/libsolidity/syntaxTests/visibility/shielded_sbytes_return.sol
@@ -33,7 +33,14 @@ contract C {
 }
 // ----
 // TypeError 7492: (134-141): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.
+// Warning 9663: (160-173): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
 // TypeError 7492: (237-245): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.
+// Warning 9663: (264-308): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
 // TypeError 7492: (372-380): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.
+// Warning 9663: (399-475): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
 // TypeError 7492: (599-606): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.
+// Warning 9663: (625-638): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
 // TypeError 7492: (698-706): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.
+// Warning 9663: (725-801): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (926-1002): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (1124-1200): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/visibility/shielded_struct_return.sol
+++ b/test/libsolidity/syntaxTests/visibility/shielded_struct_return.sol
@@ -26,4 +26,8 @@ contract C {
 }
 // ----
 // TypeError 7492: (292-309): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.
+// Warning 9660: (342-353): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 7492: (424-441): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.
+// Warning 9660: (474-485): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (644-655): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (811-822): Literals converted to shielded integers will leak during contract deployment.


### PR DESCRIPTION
We provide warnings to the contract developer when they are casting literals to their shielded counterparts

However, these warnings were severely incomplete. This PR adds (strictly*) more warnings for these casts. Previously we missed several cases:
- inside function calls
- array indexing
- array element assignments
- return statements
- compound assignment, e.g. `+=`
- inside structs
- literal casts to sbytesN in general
- rational types

Also, we add a warning for when the developer casts `msg.value` as an `suint256`, since the value will be visible on-chain anyway.

`*` for "strictly", because there will be some cases where the user gets a compiler error before the warning would be thrown. So strictly more warnings for code that compiles successfully