### PR TITLE
VER-760: Include constant expressions in shielded literal warnings (4th try)

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -4448,6 +4448,50 @@ void TypeChecker::checkLiteralToShielded(
 	langutil::SourceLocation const& _location
 )
 {
+	// Cases that only need annotation().type, not a Literal AST node.
+	// This covers constant expressions (BinaryOperation, UnaryOperation, etc.)
+	// that fold to RationalNumber or Enum types.
+	if (
+		_expression.annotation().type &&
+		_expression.annotation().type->category() == Type::Category::RationalNumber &&
+		_targetType.category() == Type::Category::ShieldedInteger
+	)
+	{
+		m_errorReporter.warning(
+			9660_error,
+			_location,
+			"Literals converted to shielded integers will leak during contract deployment."
+		);
+		return;
+	}
+	else if (
+		_expression.annotation().type &&
+		_expression.annotation().type->category() == Type::Category::Enum &&
+		_targetType.category() == Type::Category::ShieldedInteger
+	)
+	{
+		m_errorReporter.warning(
+			1457_error,
+			_location,
+			"Enums converted to shielded integers will leak during contract deployment."
+		);
+		return;
+	}
+	else if (
+		_expression.annotation().type &&
+		_expression.annotation().type->category() == Type::Category::RationalNumber &&
+		_targetType.category() == Type::Category::ShieldedFixedBytes
+	)
+	{
+		m_errorReporter.warning(
+			9663_error,
+			_location,
+			"FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment."
+		);
+		return;
+	}
+
+	// Cases that need the actual Literal AST node for value inspection.
 	auto literal = dynamic_cast<Literal const*>(&_expression);
 	if (!literal)
 		return;
@@ -4470,42 +4514,6 @@ void TypeChecker::checkLiteralToShielded(
 				_location,
 				"Address Literals converted to shielded addresses will leak during contract deployment."
 			);
-	}
-	else if (
-		_expression.annotation().type &&
-		_expression.annotation().type->category() == Type::Category::RationalNumber &&
-		_targetType.category() == Type::Category::ShieldedInteger
-	)
-	{
-		m_errorReporter.warning(
-			9660_error,
-			_location,
-			"Literals converted to shielded integers will leak during contract deployment."
-		);
-	}
-	else if (
-		_expression.annotation().type &&
-		_expression.annotation().type->category() == Type::Category::Enum &&
-		_targetType.category() == Type::Category::ShieldedInteger
-	)
-	{
-		m_errorReporter.warning(
-			1457_error,
-			_location,
-			"Enums converted to shielded integers will leak during contract deployment."
-		);
-	}
-	else if (
-		_expression.annotation().type &&
-		_expression.annotation().type->category() == Type::Category::RationalNumber &&
-		_targetType.category() == Type::Category::ShieldedFixedBytes
-	)
-	{
-		m_errorReporter.warning(
-			9663_error,
-			_location,
-			"FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment."
-		);
 	}
 }
 

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero.sol
@@ -3,3 +3,4 @@ contract C {
 }
 // ----
 // TypeError 2271: (33-38): Built-in binary operator / cannot be applied to types int_const 1 and int_const 0.
+// Warning 9660: (27-39): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero_complex.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero_complex.sol
@@ -3,3 +3,4 @@ contract C {
 }
 // ----
 // TypeError 2271: (33-46): Built-in binary operator / cannot be applied to types int_const 1 and int_const 0.
+// Warning 9660: (27-47): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero_complex_compound.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_division_by_zero_complex_compound.sol
@@ -3,3 +3,4 @@ contract A {
     constructor() { a /= suint(((2)*2)%4); }
 }
 // ----
+// Warning 9660: (51-67): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_exponent_fine.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_exponent_fine.sol
@@ -6,3 +6,4 @@ contract C {
     }
 }
 // ----
+// Warning 9660: (102-120): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero.sol
@@ -3,3 +3,4 @@ contract C {
 }
 // ----
 // TypeError 2271: (34-39): Built-in binary operator % cannot be applied to types int_const 1 and int_const 0.
+// Warning 9660: (28-40): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero_complex.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero_complex.sol
@@ -3,3 +3,4 @@ contract C {
 }
 // ----
 // TypeError 2271: (34-50): Built-in binary operator % cannot be applied to types int_const 1 and int_const 0.
+// Warning 9660: (28-51): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero_complex_compound.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/shielded_mod_zero_complex_compound.sol
@@ -4,3 +4,4 @@ contract A {
 }
 // ----
 // Warning 9660: (27-35): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (62-78): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_128_enum_explicit_conversion_is_okay.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_128_enum_explicit_conversion_is_okay.sol
@@ -8,3 +8,5 @@ contract test {
     suint64 b;
 }
 // ----
+// Warning 1457: (108-142): Enums converted to shielded integers will leak during contract deployment.
+// Warning 1457: (156-182): Enums converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_191_negative_integers_to_signed_min.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_191_negative_integers_to_signed_min.sol
@@ -2,3 +2,4 @@ contract test {
     sint8 i = sint8(-128);
 }
 // ----
+// Warning 9660: (30-41): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_199_integer_unsigned_exp_signed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_199_integer_unsigned_exp_signed.sol
@@ -1,5 +1,6 @@
 contract test { fallback() external { suint x = suint(3); sint y = sint(-4); x ** y; } }
 // ----
 // Warning 9660: (48-56): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (67-75): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (77-83): Built-in binary operator ** cannot be applied to types suint256 and sint256. Exponentiation power is not allowed to be a signed shielded integer type.
 // Warning 3817: (77-83): Shielded integer exponentiation will leak the exponent value through gas cost.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_200_integer_signed_exp_unsigned.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_200_integer_signed_exp_unsigned.sol
@@ -5,6 +5,7 @@ contract test {
 }
 // ----
 // Warning 9660: (52-60): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (71-79): Literals converted to shielded integers will leak during contract deployment.
 // Warning 3817: (81-87): Shielded integer exponentiation will leak the exponent value through gas cost.
 // Warning 9660: (132-141): Literals converted to shielded integers will leak during contract deployment.
 // Warning 9660: (154-163): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_201_integer_signed_exp_signed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_201_integer_signed_exp_signed.sol
@@ -26,6 +26,7 @@ contract test {
 // Warning 3149: (221-227): The result type of the exponentiation operation is equal to the type of the first operand (suint8) ignoring the (larger) type of the second operand (sint16) which might be unexpected. Silence this warning by either converting the first or the second operand to the type of the other.
 // TypeError 9640: (216-228): Explicit type conversion not allowed from "suint8" to "sint256".
 // Warning 9660: (281-290): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (310-318): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (305-318): Built-in binary operator ** cannot be applied to types sint16 and sint256. Exponentiation power is not allowed to be a signed shielded integer type.
 // Warning 3817: (305-318): Shielded integer exponentiation will leak the exponent value through gas cost.
 // Warning 3149: (305-318): The result type of the exponentiation operation is equal to the type of the first operand (sint16) ignoring the (larger) type of the second operand (sint256) which might be unexpected. Silence this warning by either converting the first or the second operand to the type of the other.

--- a/test/libsolidity/syntaxTests/types/shielded_constant_expression_leak.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_constant_expression_leak.sol
@@ -1,0 +1,45 @@
+contract C {
+    function f() public pure {
+        // BinaryOperation folding to RationalNumber → shielded integer
+        sint a;
+        a = sint(0 ** 1E1233);
+        a = sint(1 ** 1E1233);
+        a = sint(2 + 3);
+        a = sint(10 - 7);
+        a = sint(2 * 3);
+
+        // UnaryOperation folding to RationalNumber → shielded integer
+        a = sint(-1 ** 1E1233);
+        a = sint(-(2 + 3));
+
+        // Parenthesised literal → shielded integer (still a Literal node)
+        a = sint(42);
+
+        // Direct literal → shielded integer (baseline)
+        a = sint(0E123456789);
+
+        // BinaryOperation → shielded unsigned integer
+        suint b;
+        b = suint(2 + 3);
+        b = suint(10 * 20);
+
+        // BinaryOperation → shielded fixed bytes
+        sbytes32 c;
+        c = sbytes32(2 + 3);
+        c = sbytes32(0xff * 2);
+    }
+}
+// ----
+// Warning 9660: (146-163): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (177-194): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (208-219): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (233-245): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (259-270): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (358-376): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (390-404): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (496-504): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (577-594): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (683-695): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (709-723): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9663: (810-825): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 9663: (839-857): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_rational_number_bitshift_limit.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_rational_number_bitshift_limit.sol
@@ -9,5 +9,6 @@ contract c {
 // ----
 // TypeError 9640: (72-87): Explicit type conversion not allowed from "int_const 5221...(1225 digits omitted)...5168" to "sint256". Literal is too large to fit in sint256.
 // TypeError 2271: (145-154): Built-in binary operator << cannot be applied to types int_const 1 and int_const 4096.
+// Warning 9660: (140-155): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (187-200): Built-in binary operator << cannot be applied to types int_const 1000...(1226 digits omitted)...0000 and int_const 2.
 // TypeError 9640: (182-201): Explicit type conversion not allowed from "int_const 1000...(1226 digits omitted)...0000" to "sint256". Literal is too large to fit in sint256.

--- a/test/libsolidity/syntaxTests/types/shielded_rational_number_exp_limit_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_rational_number_exp_limit_fail.sol
@@ -25,10 +25,15 @@ contract c {
 // TypeError 9640: (133-182): Explicit type conversion not allowed from "int_const 1340...(147 digits omitted)...4096" to "sint256". Literal is too large to fit in sint256.
 // TypeError 2271: (219-235): Built-in binary operator ** cannot be applied to types int_const 4 and int_const 1340...(147 digits omitted)...4096.
 // TypeError 2271: (201-237): Built-in binary operator ** cannot be applied to types int_const 4 and int_const -115...(71 digits omitted)...9936.
+// Warning 9660: (196-238): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (257-268): Built-in binary operator ** cannot be applied to types int_const 2 and int_const 1000...(1226 digits omitted)...0000.
+// Warning 9660: (252-269): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (288-300): Built-in binary operator ** cannot be applied to types int_const -2 and int_const 1000...(1226 digits omitted)...0000.
+// Warning 9660: (283-301): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (320-332): Built-in binary operator ** cannot be applied to types int_const 2 and int_const -100...(1227 digits omitted)...0000.
+// Warning 9660: (315-333): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (352-365): Built-in binary operator ** cannot be applied to types int_const -2 and int_const -100...(1227 digits omitted)...0000.
+// Warning 9660: (347-366): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2271: (385-396): Built-in binary operator ** cannot be applied to types int_const 1000...(1226 digits omitted)...0000 and int_const 2.
 // TypeError 9640: (380-397): Explicit type conversion not allowed from "int_const 1000...(1226 digits omitted)...0000" to "sint256". Literal is too large to fit in sint256.
 // TypeError 2271: (416-428): Built-in binary operator ** cannot be applied to types int_const -100...(1227 digits omitted)...0000 and int_const 2.

--- a/test/libsolidity/syntaxTests/types/shielded_rational_number_exp_limit_fine.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_rational_number_exp_limit_fine.sol
@@ -8,4 +8,7 @@ contract c {
     }
 }
 // ----
+// Warning 9660: (72-89): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (103-120): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (134-152): Literals converted to shielded integers will leak during contract deployment.
 // Warning 9660: (166-183): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_rational_number_literal_limit_1.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_rational_number_literal_limit_1.sol
@@ -6,4 +6,5 @@ contract c {
     }
 }
 // ----
+// Warning 9660: (76-98): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 2826: (136-142): Invalid literal value.


### PR DESCRIPTION
The first 3 PRs:
- https://github.com/SeismicSystems/seismic-solidity/pull/126
- https://github.com/SeismicSystems/seismic-solidity/pull/158
- https://github.com/SeismicSystems/seismic-solidity/pull/192