### PR TITLE
Fix transient/storage collision when deleting (SOL-2026-1)

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -4502,7 +4502,31 @@ std::string YulUtilFunctions::zeroValueFunction(Type const& _type, bool _splitFu
 
 std::string YulUtilFunctions::storageSetToZeroFunction(Type const& _type, VariableDeclaration::Location _location)
 {
-	std::string const functionName = "storage_set_to_zero_" + _type.identifier();
+	// SEISMIC: Cherry-picked fix for TransientStorageClearingHelperCollision (SOL-2026-1)
+	// from upstream commit 12ede4f26 (Solidity 0.8.34).
+	// When both persistent and transient storage variables of the same type are
+	// cleared (via `delete`), the IR codegen must generate distinct helper functions
+	// for each storage domain. Without this prefix, a name collision causes one
+	// domain's clear to use the wrong opcode (sstore vs tstore).
+	// See: https://www.soliditylang.org/blog/2026/02/18/solidity-0.8.34-release-announcement/
+	// See: https://x.com/solidity_lang/status/2024181650155065848
+	// TODO(seismic): Remove this comment block after merging upstream Solidity >= 0.8.34
+	solAssert(
+		_location == VariableDeclaration::Location::Transient ||
+		_location == VariableDeclaration::Location::Unspecified,
+		"Invalid location for the storage_set_to_zero function"
+	);
+
+	if (dynamic_cast<ReferenceType const*>(&_type))
+		solAssert(
+			_location == VariableDeclaration::Location::Unspecified &&
+			_type.dataStoredIn(DataLocation::Storage)
+		);
+
+	std::string const functionName =
+		(_location == VariableDeclaration::Location::Transient ? "transient_"s : "") +
+		"storage_set_to_zero_" +
+		_type.identifier();
 
 	return m_functionCollector.createFunction(functionName, [&]() {
 		if (_type.isValueType())

--- a/test/cmdlineTests/storage_transient_storage_collision_ir_output/args
+++ b/test/cmdlineTests/storage_transient_storage_collision_ir_output/args
@@ -1,0 +1,1 @@
+--ir-optimized --evm-version cancun --debug-info none

--- a/test/cmdlineTests/storage_transient_storage_collision_ir_output/input.sol
+++ b/test/cmdlineTests/storage_transient_storage_collision_ir_output/input.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+pragma solidity >=0.0;
+
+contract C {
+    uint256 transient varTransient;
+    uint256 public varStorage = 0xeeeeeeeeee;
+
+    function foo() external returns (uint256) {
+        varTransient = 0xffffffff;
+        delete varTransient;
+        delete varStorage;
+
+        return varStorage;
+    }
+}

--- a/test/cmdlineTests/storage_transient_storage_collision_ir_output/output
+++ b/test/cmdlineTests/storage_transient_storage_collision_ir_output/output
@@ -1,0 +1,224 @@
+Optimized IR:
+/// @use-src 0:"input.sol"
+object "C_25" {
+    code {
+        {
+            mstore(64, memoryguard(0x80))
+            if callvalue()
+            {
+                revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
+            }
+            constructor_C()
+            let _1 := allocate_unbounded()
+            codecopy(_1, dataoffset("C_25_deployed"), datasize("C_25_deployed"))
+            return(_1, datasize("C_25_deployed"))
+        }
+        function allocate_unbounded() -> memPtr
+        { memPtr := mload(64) }
+        function revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
+        { revert(0, 0) }
+        function shift_left(value) -> newValue
+        { newValue := shl(0, value) }
+        function update_byte_slice_shift(value, toInsert) -> result
+        {
+            let mask := not(0)
+            toInsert := shift_left(toInsert)
+            value := and(value, not(mask))
+            result := or(value, and(toInsert, mask))
+        }
+        function cleanup_rational_by(value) -> cleaned
+        { cleaned := value }
+        function cleanup_uint256(value) -> cleaned
+        { cleaned := value }
+        function identity(value) -> ret
+        { ret := value }
+        function convert_rational_by_to_uint256(value) -> converted
+        {
+            converted := cleanup_uint256(identity(cleanup_rational_by(value)))
+        }
+        function prepare_store_uint256(value) -> ret
+        { ret := value }
+        function update_storage_value_offset_rational_by_to_uint256(slot, value)
+        {
+            let convertedValue := convert_rational_by_to_uint256(value)
+            sstore(slot, update_byte_slice_shift(sload(slot), prepare_store_uint256(convertedValue)))
+        }
+        function constructor_C()
+        {
+            let expr := 0xeeeeeeeeee
+            update_storage_value_offset_rational_by_to_uint256(0x00, expr)
+        }
+    }
+    /// @use-src 0:"input.sol"
+    object "C_25_deployed" {
+        code {
+            {
+                mstore(64, memoryguard(0x80))
+                if iszero(lt(calldatasize(), 4))
+                {
+                    let selector := shift_right_unsigned(calldataload(0))
+                    switch selector
+                    case 0xc2985578 { external_fun_foo() }
+                    case 0xff2558ff { external_fun_varStorage() }
+                    default { }
+                }
+                revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74()
+            }
+            function shift_right_unsigned(value) -> newValue
+            { newValue := shr(224, value) }
+            function allocate_unbounded() -> memPtr
+            { memPtr := mload(64) }
+            function revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
+            { revert(0, 0) }
+            function revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b()
+            { revert(0, 0) }
+            function abi_decode(headStart, dataEnd)
+            {
+                if slt(sub(dataEnd, headStart), 0)
+                {
+                    revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b()
+                }
+            }
+            function cleanup_uint256(value) -> cleaned
+            { cleaned := value }
+            function abi_encode_uint256_to_uint256(value, pos)
+            {
+                mstore(pos, cleanup_uint256(value))
+            }
+            function abi_encode_uint256(headStart, value0) -> tail
+            {
+                tail := add(headStart, 32)
+                abi_encode_uint256_to_uint256(value0, add(headStart, 0))
+            }
+            function external_fun_foo()
+            {
+                if callvalue()
+                {
+                    revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
+                }
+                abi_decode(4, calldatasize())
+                let ret := fun_foo()
+                let memPos := allocate_unbounded()
+                let memEnd := abi_encode_uint256(memPos, ret)
+                return(memPos, sub(memEnd, memPos))
+            }
+            function shift_right_unsigned_dynamic(bits, value) -> newValue
+            { newValue := shr(bits, value) }
+            function cleanup_from_storage_uint256(value) -> cleaned
+            { cleaned := value }
+            function extract_from_storage_value_dynamict_uint256(slot_value, offset) -> value
+            {
+                value := cleanup_from_storage_uint256(shift_right_unsigned_dynamic(mul(offset, 8), slot_value))
+            }
+            function read_from_storage_split_dynamic_uint256(slot, offset) -> value
+            {
+                value := extract_from_storage_value_dynamict_uint256(sload(slot), offset)
+            }
+            function getter_fun_varStorage() -> ret
+            {
+                let slot := 0
+                let offset := 0
+                ret := read_from_storage_split_dynamic_uint256(slot, offset)
+            }
+            function external_fun_varStorage()
+            {
+                if callvalue()
+                {
+                    revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
+                }
+                abi_decode(4, calldatasize())
+                let ret := getter_fun_varStorage()
+                let memPos := allocate_unbounded()
+                let memEnd := abi_encode_uint256(memPos, ret)
+                return(memPos, sub(memEnd, memPos))
+            }
+            function revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74()
+            { revert(0, 0) }
+            function zero_value_for_split_uint256() -> ret
+            { ret := 0 }
+            function cleanup_rational_by(value) -> cleaned
+            { cleaned := value }
+            function identity(value) -> ret
+            { ret := value }
+            function convert_rational_by_to_uint256(value) -> converted
+            {
+                converted := cleanup_uint256(identity(cleanup_rational_by(value)))
+            }
+            function shift_left(value) -> newValue
+            { newValue := shl(0, value) }
+            function update_byte_slice_shift(value, toInsert) -> result
+            {
+                let mask := not(0)
+                toInsert := shift_left(toInsert)
+                value := and(value, not(mask))
+                result := or(value, and(toInsert, mask))
+            }
+            function convert_uint256_to_uint256(value) -> converted
+            {
+                converted := cleanup_uint256(identity(cleanup_uint256(value)))
+            }
+            function prepare_store_uint256(value) -> ret
+            { ret := value }
+            function update_transient_storage_value_offset_uint256_to_uint256(slot, value)
+            {
+                let convertedValue := convert_uint256_to_uint256(value)
+                tstore(slot, update_byte_slice_shift(tload(slot), prepare_store_uint256(convertedValue)))
+            }
+            function shift_left_dynamic(bits, value) -> newValue
+            { newValue := shl(bits, value) }
+            function update_byte_slice_dynamic32(value, shiftBytes, toInsert) -> result
+            {
+                let shiftBits := mul(shiftBytes, 8)
+                let mask := shift_left_dynamic(shiftBits, not(0))
+                toInsert := shift_left_dynamic(shiftBits, toInsert)
+                value := and(value, not(mask))
+                result := or(value, and(toInsert, mask))
+            }
+            function update_transient_storage_value_uint256_to_uint256(slot, offset, value)
+            {
+                let convertedValue := convert_uint256_to_uint256(value)
+                tstore(slot, update_byte_slice_dynamic32(tload(slot), offset, prepare_store_uint256(convertedValue)))
+            }
+            function transient_storage_set_to_zero_uint256(slot, offset)
+            {
+                let zero := zero_value_for_split_uint256()
+                update_transient_storage_value_uint256_to_uint256(slot, offset, zero)
+            }
+            function update_storage_value_uint256_to_uint256(slot, offset, value)
+            {
+                let convertedValue := convert_uint256_to_uint256(value)
+                sstore(slot, update_byte_slice_dynamic32(sload(slot), offset, prepare_store_uint256(convertedValue)))
+            }
+            function storage_set_to_zero_uint256(slot, offset)
+            {
+                let zero := zero_value_for_split_uint256()
+                update_storage_value_uint256_to_uint256(slot, offset, zero)
+            }
+            function shift_right_0_unsigned(value) -> newValue
+            { newValue := shr(0, value) }
+            function extract_from_storage_value_offset_uint256(slot_value) -> value
+            {
+                value := cleanup_from_storage_uint256(shift_right_0_unsigned(slot_value))
+            }
+            function read_from_storage_split_offset_uint256(slot) -> value
+            {
+                value := extract_from_storage_value_offset_uint256(sload(slot))
+            }
+            function fun_foo() -> var
+            {
+                let zero_uint256 := zero_value_for_split_uint256()
+                var := zero_uint256
+                let expr := 0xffffffff
+                let _1 := convert_rational_by_to_uint256(expr)
+                update_transient_storage_value_offset_uint256_to_uint256(0x00, _1)
+                transient_storage_set_to_zero_uint256(0x00, 0)
+                storage_set_to_zero_uint256(0x00, 0)
+                let _2 := read_from_storage_split_offset_uint256(0x00)
+                let expr_1 := _2
+                var := expr_1
+                leave
+            }
+        }
+        data ".metadata" hex"<BYTECODE REMOVED>"
+    }
+}

--- a/test/libsolidity/semanticTests/storage/delete_overlapping_transient_after_inherited_storage_same_value_type.sol
+++ b/test/libsolidity/semanticTests/storage/delete_overlapping_transient_after_inherited_storage_same_value_type.sol
@@ -1,0 +1,25 @@
+contract Base {
+    uint256 public x;
+
+    function deleteX() internal {
+        delete x;
+    }
+}
+
+contract C is Base {
+    uint256 transient t;
+
+    function setAndClear() external {
+        x = 1;
+        t = 2;
+        deleteX();
+        delete t;
+        assert(t == 0);
+    }
+}
+
+// ====
+// EVMVersion: >=cancun
+// ----
+// setAndClear() ->
+// x() -> 0

--- a/test/libsolidity/semanticTests/storage/delete_overlapping_transient_after_storage_array_delete_different_base_type.sol
+++ b/test/libsolidity/semanticTests/storage/delete_overlapping_transient_after_storage_array_delete_different_base_type.sol
@@ -1,0 +1,23 @@
+contract C {
+    bool[3] flags = [true, true, true];
+    uint256 transient temp;
+
+    function setAndClear() external {
+        temp = 0xffffffff;
+        delete flags;
+        delete temp;
+        assert(temp == 0);
+    }
+
+    function getFlags() external returns(bool[3] memory)
+    {
+        return flags;
+    }
+}
+
+// ====
+// EVMVersion: >=cancun
+// ----
+// getFlags() -> true, true, true
+// setAndClear() ->
+// getFlags() -> false, false, false

--- a/test/libsolidity/semanticTests/storage/delete_overlapping_transient_after_storage_array_pop_same_base_type.sol
+++ b/test/libsolidity/semanticTests/storage/delete_overlapping_transient_after_storage_array_pop_same_base_type.sol
@@ -1,0 +1,30 @@
+contract C {
+    uint256[] arr;
+    uint256 transient t;
+
+    function pushArr() external {
+        arr.push(1);
+    }
+
+    function setAndClear() external {
+        t = 2;
+        delete t;
+        assert(t == 0);
+        arr.pop();
+    }
+
+    // Get value at index 0, which should have been cleared after arr.pop()
+    function getArr() external returns (uint256 value) {
+        assembly {
+            mstore(0, arr.slot)
+            value := sload(keccak256(0x00, 0x20))
+        }
+    }
+}
+// ====
+// EVMVersion: >=cancun
+// ----
+// pushArr() ->
+// getArr() -> 1
+// setAndClear() ->
+// getArr() -> 0

--- a/test/libsolidity/semanticTests/storage/delete_overlapping_transient_after_storage_delete_same_value_type.sol
+++ b/test/libsolidity/semanticTests/storage/delete_overlapping_transient_after_storage_delete_same_value_type.sol
@@ -1,0 +1,18 @@
+contract C {
+    uint256 transient varTransient;
+    uint256 public varStorage = 0xeeeeeeeeee;
+
+    function setAndClear() external {
+        varTransient = 0xffffffff;
+        delete varStorage;
+        delete varTransient;
+        assert(varTransient == 0);
+    }
+}
+
+// ====
+// EVMVersion: >=cancun
+// ----
+// varStorage() -> 0xeeeeeeeeee
+// setAndClear() ->
+// varStorage() -> 0

--- a/test/libsolidity/semanticTests/storage/delete_overlapping_transient_after_storage_mapping_delete_same_value_type.sol
+++ b/test/libsolidity/semanticTests/storage/delete_overlapping_transient_after_storage_mapping_delete_same_value_type.sol
@@ -1,0 +1,22 @@
+contract C {
+    mapping(uint256 => uint256) m;
+    uint256 transient t;
+
+    function setAndClear() external {
+        m[0] = 1;
+        t = 2;
+        delete m[0];
+        delete t;
+        assert(t == 0);
+    }
+
+    function getM() external view returns (uint256) {
+        return m[0];
+    }
+}
+
+// ====
+// EVMVersion: >=cancun
+// ----
+// setAndClear() ->
+// getM() -> 0

--- a/test/libsolidity/semanticTests/storage/delete_overlapping_transient_after_storage_struct_delete_same_value_type.sol
+++ b/test/libsolidity/semanticTests/storage/delete_overlapping_transient_after_storage_struct_delete_same_value_type.sol
@@ -1,0 +1,26 @@
+contract C {
+    struct S {
+        uint256 a;
+        address b;
+    }
+
+    S s = S(1, address(0x1234));
+    uint256 transient t;
+
+    function setAndDelete() external {
+        t = 2;
+        delete s;
+        delete t;
+        assert(t == 0);
+    }
+
+    function getS() external view returns (uint256, address) {
+        return (s.a, s.b);
+    }
+}
+// ====
+// EVMVersion: >=cancun
+// ----
+// getS() -> 1, 4660
+// setAndDelete() ->
+// getS() -> 0, 0

--- a/test/libsolidity/semanticTests/storage/delete_overlapping_transient_before_inherited_storage_same_value_type.sol
+++ b/test/libsolidity/semanticTests/storage/delete_overlapping_transient_before_inherited_storage_same_value_type.sol
@@ -1,0 +1,25 @@
+contract Base {
+    uint256 public x;
+
+    function deleteX() internal {
+        delete x;
+    }
+}
+
+contract C is Base {
+    uint256 transient t;
+
+    function setAndClear() external {
+        x = 1;
+        t = 2;
+        delete t;
+        assert(t == 0);
+        deleteX();
+    }
+}
+
+// ====
+// EVMVersion: >=cancun
+// ----
+// setAndClear() ->
+// x() -> 0

--- a/test/libsolidity/semanticTests/storage/delete_overlapping_transient_before_storage_array_delete_different_base_type.sol
+++ b/test/libsolidity/semanticTests/storage/delete_overlapping_transient_before_storage_array_delete_different_base_type.sol
@@ -1,0 +1,23 @@
+contract C {
+    bool[3] flags = [true, true, true];
+    uint256 transient temp;
+
+    function setAndClear() external {
+        temp = 0xffffffff;
+        delete temp;
+        assert(temp == 0);
+        delete flags;
+    }
+
+    function getFlags() external returns(bool[3] memory)
+    {
+        return flags;
+    }
+}
+
+// ====
+// EVMVersion: >=cancun
+// ----
+// getFlags() -> true, true, true
+// setAndClear() ->
+// getFlags() -> false, false, false

--- a/test/libsolidity/semanticTests/storage/delete_overlapping_transient_before_storage_array_partial_assignment_same_base_type.sol
+++ b/test/libsolidity/semanticTests/storage/delete_overlapping_transient_before_storage_array_partial_assignment_same_base_type.sol
@@ -1,0 +1,27 @@
+contract C {
+    uint256[2] small;
+    uint256[4] large;
+    uint256 transient t;
+
+    function setAndClear() external {
+        large = [1,2,3,4];
+        small = [10, 20];
+        t = 99;
+
+        delete t;
+        assert(t == 0);
+        large = small;
+    }
+
+    function getLarge() external view returns (uint256[4] memory) {
+        return large;
+    }
+}
+// ====
+// EVMVersion: >=cancun
+// ----
+// setAndClear() ->
+// gas irOptimized: 124683
+// gas legacy: 127807
+// gas legacyOptimized: 124828
+// getLarge() -> 10, 20, 0, 0

--- a/test/libsolidity/semanticTests/storage/delete_overlapping_transient_before_storage_delete_same_value_type.sol
+++ b/test/libsolidity/semanticTests/storage/delete_overlapping_transient_before_storage_delete_same_value_type.sol
@@ -1,0 +1,18 @@
+contract C {
+    uint256 transient varTransient;
+    uint256 public varStorage = 0xeeeeeeeeee;
+
+    function setAndClear() external {
+        varTransient = 0xffffffff;
+        delete varTransient;
+        assert(varTransient == 0);
+        delete varStorage;
+    }
+}
+
+// ====
+// EVMVersion: >=cancun
+// ----
+// varStorage() -> 0xeeeeeeeeee
+// setAndClear() ->
+// varStorage() -> 0

--- a/test/libsolidity/semanticTests/storage/delete_overlapping_transient_before_storage_mapping_delete_same_value_type.sol
+++ b/test/libsolidity/semanticTests/storage/delete_overlapping_transient_before_storage_mapping_delete_same_value_type.sol
@@ -1,0 +1,22 @@
+contract C {
+    mapping(uint256 => uint256) m;
+    uint256 transient t;
+
+    function setAndClear() external {
+        m[0] = 1;
+        t = 2;
+        delete t;
+        assert(t == 0);
+        delete m[0];
+    }
+
+    function getM() external view returns (uint256) {
+        return m[0];
+    }
+}
+
+// ====
+// EVMVersion: >=cancun
+// ----
+// setAndClear() ->
+// getM() -> 0

--- a/test/libsolidity/semanticTests/storage/delete_overlapping_transient_before_storage_struct_delete_same_value_type.sol
+++ b/test/libsolidity/semanticTests/storage/delete_overlapping_transient_before_storage_struct_delete_same_value_type.sol
@@ -1,0 +1,26 @@
+contract C {
+    struct S {
+        uint256 a;
+        address b;
+    }
+
+    S s = S(1, address(0x1234));
+    uint256 transient t;
+
+    function setAndDelete() external {
+        t = 2;
+        delete t;
+        assert(t == 0);
+        delete s;
+    }
+
+    function getS() external view returns (uint256, address) {
+        return (s.a, s.b);
+    }
+}
+// ====
+// EVMVersion: >=cancun
+// ----
+// getS() -> 1, 4660
+// setAndDelete() ->
+// getS() -> 0, 0


### PR DESCRIPTION
## Summary

- Cherry-picks upstream fix for **TransientStorageClearingHelperCollision** (SOL-2026-1, high severity) from Solidity 0.8.34 commits `ffd11b3cf` + `12ede4f26`
- When contracts clear both persistent and transient storage variables of the same type via `delete`, the IR codegen now generates distinct helper functions (`storage_set_to_zero_<type>` vs `transient_storage_set_to_zero_<type>`) to avoid opcode collision (`sstore` vs `tstore`)
- Adds 12 semantic tests + 1 cmdline IR output test covering the fix

## Test plan

- [ ] Build: `cmake --build build -j$(nproc)`
- [ ] Run semantic tests: `cd build && ctest -R "delete_overlapping_transient" --output-on-failure`
- [ ] Run cmdline test: `cd build && ctest -R "storage_transient_storage_collision_ir_output" --output-on-failure`
- [ ] Verify no regressions in existing transient storage tests

Replaces #207 (rebased to clean branch with only the relevant commits).