### PR TITLE
Add built-in helper functions for Seismic precompiles

### DIFF
--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -72,7 +72,8 @@ int magicVariableToID(std::string const& _name)
 		{"ecdh", -36},
 		{"aes_gcm_encrypt", -37},
 		{"aes_gcm_decrypt", -38},
-		{"hkdf", -39}
+		{"hkdf", -39},
+		{"secp256k1_sign", -40}
 	};
 
 	if (auto id = magicVariables.find(_name); id != magicVariables.end())
@@ -145,6 +146,9 @@ inline std::vector<std::shared_ptr<MagicVariableDeclaration const>> constructMag
 
 	// Seismic HKDF precompile built-in function
 	magicVariableDeclarations.push_back(magicVarDecl("hkdf", TypeProvider::function(strings{"bytes memory"}, strings{"bytes32"}, FunctionType::Kind::SeismicHKDF, StateMutability::View)));
+
+	// Seismic secp256k1 sign precompile built-in function
+	magicVariableDeclarations.push_back(magicVarDecl("secp256k1_sign", TypeProvider::function(strings{"sbytes32", "bytes32"}, strings{"bytes memory"}, FunctionType::Kind::SeismicSecp256k1Sign, StateMutability::View)));
 
 	return magicVariableDeclarations;
 }

--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -71,7 +71,8 @@ int magicVariableToID(std::string const& _name)
 		{"rng256", -35},
 		{"ecdh", -36},
 		{"aes_gcm_encrypt", -37},
-		{"aes_gcm_decrypt", -38}
+		{"aes_gcm_decrypt", -38},
+		{"hkdf", -39}
 	};
 
 	if (auto id = magicVariables.find(_name); id != magicVariables.end())
@@ -141,6 +142,9 @@ inline std::vector<std::shared_ptr<MagicVariableDeclaration const>> constructMag
 	// Seismic AES-GCM encrypt/decrypt precompile built-in functions
 	magicVariableDeclarations.push_back(magicVarDecl("aes_gcm_encrypt", TypeProvider::function(strings{"sbytes32", "uint96", "bytes memory"}, strings{"bytes memory"}, FunctionType::Kind::SeismicAESGCMEncrypt, StateMutability::View)));
 	magicVariableDeclarations.push_back(magicVarDecl("aes_gcm_decrypt", TypeProvider::function(strings{"sbytes32", "uint96", "bytes memory"}, strings{"bytes memory"}, FunctionType::Kind::SeismicAESGCMDecrypt, StateMutability::View)));
+
+	// Seismic HKDF precompile built-in function
+	magicVariableDeclarations.push_back(magicVarDecl("hkdf", TypeProvider::function(strings{"bytes memory"}, strings{"bytes32"}, FunctionType::Kind::SeismicHKDF, StateMutability::View)));
 
 	return magicVariableDeclarations;
 }

--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -68,7 +68,8 @@ int magicVariableToID(std::string const& _name)
 		{"rng32", -32},
 		{"rng64", -33},
 		{"rng128", -34},
-		{"rng256", -35}
+		{"rng256", -35},
+		{"ecdh", -36}
 	};
 
 	if (auto id = magicVariables.find(_name); id != magicVariables.end())
@@ -131,6 +132,9 @@ inline std::vector<std::shared_ptr<MagicVariableDeclaration const>> constructMag
 	magicVariableDeclarations.push_back(magicVarDecl("rng64",  TypeProvider::function(strings{}, strings{"suint64"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
 	magicVariableDeclarations.push_back(magicVarDecl("rng128", TypeProvider::function(strings{}, strings{"suint128"}, FunctionType::Kind::SeismicRNG, StateMutability::View)));
 	magicVariableDeclarations.push_back(magicVarDecl("rng256", TypeProvider::function(strings{}, strings{"suint256"}, FunctionType::Kind::SeismicRNG, StateMutability::View)));
+
+	// Seismic ECDH precompile built-in function
+	magicVariableDeclarations.push_back(magicVarDecl("ecdh", TypeProvider::function(strings{"sbytes32", "bytes memory"}, strings{"bytes32"}, FunctionType::Kind::SeismicECDH, StateMutability::View)));
 
 	return magicVariableDeclarations;
 }

--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -69,7 +69,9 @@ int magicVariableToID(std::string const& _name)
 		{"rng64", -33},
 		{"rng128", -34},
 		{"rng256", -35},
-		{"ecdh", -36}
+		{"ecdh", -36},
+		{"aes_gcm_encrypt", -37},
+		{"aes_gcm_decrypt", -38}
 	};
 
 	if (auto id = magicVariables.find(_name); id != magicVariables.end())
@@ -135,6 +137,10 @@ inline std::vector<std::shared_ptr<MagicVariableDeclaration const>> constructMag
 
 	// Seismic ECDH precompile built-in function
 	magicVariableDeclarations.push_back(magicVarDecl("ecdh", TypeProvider::function(strings{"sbytes32", "bytes memory"}, strings{"bytes32"}, FunctionType::Kind::SeismicECDH, StateMutability::View)));
+
+	// Seismic AES-GCM encrypt/decrypt precompile built-in functions
+	magicVariableDeclarations.push_back(magicVarDecl("aes_gcm_encrypt", TypeProvider::function(strings{"sbytes32", "uint96", "bytes memory"}, strings{"bytes memory"}, FunctionType::Kind::SeismicAESGCMEncrypt, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("aes_gcm_decrypt", TypeProvider::function(strings{"sbytes32", "uint96", "bytes memory"}, strings{"bytes memory"}, FunctionType::Kind::SeismicAESGCMDecrypt, StateMutability::View)));
 
 	return magicVariableDeclarations;
 }

--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -62,7 +62,13 @@ int magicVariableToID(std::string const& _name)
 		{"tx", -26},
 		{"type", -27},
 		{"this", -28},
-		{"blobhash", -29}
+		{"blobhash", -29},
+		{"rng8", -30},
+		{"rng16", -31},
+		{"rng32", -32},
+		{"rng64", -33},
+		{"rng128", -34},
+		{"rng256", -35}
 	};
 
 	if (auto id = magicVariables.find(_name); id != magicVariables.end())
@@ -117,6 +123,14 @@ inline std::vector<std::shared_ptr<MagicVariableDeclaration const>> constructMag
 		magicVariableDeclarations.push_back(
 			magicVarDecl("blobhash", TypeProvider::function(strings{"uint256"}, strings{"bytes32"}, FunctionType::Kind::BlobHash, StateMutability::View))
 		);
+
+	// Seismic RNG precompile built-in functions
+	magicVariableDeclarations.push_back(magicVarDecl("rng8",   TypeProvider::function(strings{}, strings{"suint8"},   FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("rng16",  TypeProvider::function(strings{}, strings{"suint16"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("rng32",  TypeProvider::function(strings{}, strings{"suint32"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("rng64",  TypeProvider::function(strings{}, strings{"suint64"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("rng128", TypeProvider::function(strings{}, strings{"suint128"}, FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("rng256", TypeProvider::function(strings{}, strings{"suint256"}, FunctionType::Kind::SeismicRNG, StateMutability::View)));
 
 	return magicVariableDeclarations;
 }

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3409,6 +3409,7 @@ std::string FunctionType::richIdentifier() const
 	case Kind::ABIDecode: id += "abidecode"; break;
 	case Kind::BlobHash: id += "blobhash"; break;
 	case Kind::MetaType: id += "metatype"; break;
+	case Kind::SeismicRNG: id += "seismicrng"; break;
 	}
 	id += "_" + stateMutabilityToString(m_stateMutability);
 	id += identifierList(m_parameterTypes) + "returns" + identifierList(m_returnParameterTypes);
@@ -3923,6 +3924,7 @@ bool FunctionType::isBareCall() const
 	case Kind::ECRecover:
 	case Kind::SHA256:
 	case Kind::RIPEMD160:
+	case Kind::SeismicRNG:
 		return true;
 	default:
 		return false;
@@ -4117,6 +4119,7 @@ bool FunctionType::padArguments() const
 	case Kind::RIPEMD160:
 	case Kind::KECCAK256:
 	case Kind::ABIEncodePacked:
+	case Kind::SeismicRNG:
 		return false;
 	default:
 		return true;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3411,6 +3411,8 @@ std::string FunctionType::richIdentifier() const
 	case Kind::MetaType: id += "metatype"; break;
 	case Kind::SeismicRNG: id += "seismicrng"; break;
 	case Kind::SeismicECDH: id += "seismicecdh"; break;
+	case Kind::SeismicAESGCMEncrypt: id += "seismicaesgcmencrypt"; break;
+	case Kind::SeismicAESGCMDecrypt: id += "seismicaesgcmdecrypt"; break;
 	}
 	id += "_" + stateMutabilityToString(m_stateMutability);
 	id += identifierList(m_parameterTypes) + "returns" + identifierList(m_returnParameterTypes);
@@ -3927,6 +3929,8 @@ bool FunctionType::isBareCall() const
 	case Kind::RIPEMD160:
 	case Kind::SeismicRNG:
 	case Kind::SeismicECDH:
+	case Kind::SeismicAESGCMEncrypt:
+	case Kind::SeismicAESGCMDecrypt:
 		return true;
 	default:
 		return false;
@@ -4123,6 +4127,8 @@ bool FunctionType::padArguments() const
 	case Kind::ABIEncodePacked:
 	case Kind::SeismicRNG:
 	case Kind::SeismicECDH:
+	case Kind::SeismicAESGCMEncrypt:
+	case Kind::SeismicAESGCMDecrypt:
 		return false;
 	default:
 		return true;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3410,6 +3410,7 @@ std::string FunctionType::richIdentifier() const
 	case Kind::BlobHash: id += "blobhash"; break;
 	case Kind::MetaType: id += "metatype"; break;
 	case Kind::SeismicRNG: id += "seismicrng"; break;
+	case Kind::SeismicECDH: id += "seismicecdh"; break;
 	}
 	id += "_" + stateMutabilityToString(m_stateMutability);
 	id += identifierList(m_parameterTypes) + "returns" + identifierList(m_returnParameterTypes);
@@ -3925,6 +3926,7 @@ bool FunctionType::isBareCall() const
 	case Kind::SHA256:
 	case Kind::RIPEMD160:
 	case Kind::SeismicRNG:
+	case Kind::SeismicECDH:
 		return true;
 	default:
 		return false;
@@ -4120,6 +4122,7 @@ bool FunctionType::padArguments() const
 	case Kind::KECCAK256:
 	case Kind::ABIEncodePacked:
 	case Kind::SeismicRNG:
+	case Kind::SeismicECDH:
 		return false;
 	default:
 		return true;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3414,6 +3414,7 @@ std::string FunctionType::richIdentifier() const
 	case Kind::SeismicAESGCMEncrypt: id += "seismicaesgcmencrypt"; break;
 	case Kind::SeismicAESGCMDecrypt: id += "seismicaesgcmdecrypt"; break;
 	case Kind::SeismicHKDF: id += "seismichkdf"; break;
+	case Kind::SeismicSecp256k1Sign: id += "seismicsecp256k1sign"; break;
 	}
 	id += "_" + stateMutabilityToString(m_stateMutability);
 	id += identifierList(m_parameterTypes) + "returns" + identifierList(m_returnParameterTypes);
@@ -3933,6 +3934,7 @@ bool FunctionType::isBareCall() const
 	case Kind::SeismicAESGCMEncrypt:
 	case Kind::SeismicAESGCMDecrypt:
 	case Kind::SeismicHKDF:
+	case Kind::SeismicSecp256k1Sign:
 		return true;
 	default:
 		return false;
@@ -4132,6 +4134,7 @@ bool FunctionType::padArguments() const
 	case Kind::SeismicAESGCMEncrypt:
 	case Kind::SeismicAESGCMDecrypt:
 	case Kind::SeismicHKDF:
+	case Kind::SeismicSecp256k1Sign:
 		return false;
 	default:
 		return true;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3413,6 +3413,7 @@ std::string FunctionType::richIdentifier() const
 	case Kind::SeismicECDH: id += "seismicecdh"; break;
 	case Kind::SeismicAESGCMEncrypt: id += "seismicaesgcmencrypt"; break;
 	case Kind::SeismicAESGCMDecrypt: id += "seismicaesgcmdecrypt"; break;
+	case Kind::SeismicHKDF: id += "seismichkdf"; break;
 	}
 	id += "_" + stateMutabilityToString(m_stateMutability);
 	id += identifierList(m_parameterTypes) + "returns" + identifierList(m_returnParameterTypes);
@@ -3931,6 +3932,7 @@ bool FunctionType::isBareCall() const
 	case Kind::SeismicECDH:
 	case Kind::SeismicAESGCMEncrypt:
 	case Kind::SeismicAESGCMDecrypt:
+	case Kind::SeismicHKDF:
 		return true;
 	default:
 		return false;
@@ -4129,6 +4131,7 @@ bool FunctionType::padArguments() const
 	case Kind::SeismicECDH:
 	case Kind::SeismicAESGCMEncrypt:
 	case Kind::SeismicAESGCMDecrypt:
+	case Kind::SeismicHKDF:
 		return false;
 	default:
 		return true;

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1435,6 +1435,7 @@ public:
 		/// Cannot be called.
 		Declaration,
 		SeismicRNG,             ///< STATICCALL to RNG precompile (0x64)
+		SeismicECDH,            ///< STATICCALL to ECDH precompile (0x65)
 	};
 	struct Options
 	{

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1436,6 +1436,8 @@ public:
 		Declaration,
 		SeismicRNG,             ///< STATICCALL to RNG precompile (0x64)
 		SeismicECDH,            ///< STATICCALL to ECDH precompile (0x65)
+		SeismicAESGCMEncrypt,   ///< STATICCALL to AES-GCM encrypt precompile (0x66)
+		SeismicAESGCMDecrypt,   ///< STATICCALL to AES-GCM decrypt precompile (0x67)
 	};
 	struct Options
 	{

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1439,6 +1439,7 @@ public:
 		SeismicAESGCMEncrypt,   ///< STATICCALL to AES-GCM encrypt precompile (0x66)
 		SeismicAESGCMDecrypt,   ///< STATICCALL to AES-GCM decrypt precompile (0x67)
 		SeismicHKDF,            ///< STATICCALL to HKDF precompile (0x68)
+		SeismicSecp256k1Sign,   ///< STATICCALL to secp256k1 sign precompile (0x69)
 	};
 	struct Options
 	{

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1434,6 +1434,7 @@ public:
 		/// (i.e. when accessed directly via the name of the containing contract).
 		/// Cannot be called.
 		Declaration,
+		SeismicRNG,             ///< STATICCALL to RNG precompile (0x64)
 	};
 	struct Options
 	{

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1438,6 +1438,7 @@ public:
 		SeismicECDH,            ///< STATICCALL to ECDH precompile (0x65)
 		SeismicAESGCMEncrypt,   ///< STATICCALL to AES-GCM encrypt precompile (0x66)
 		SeismicAESGCMDecrypt,   ///< STATICCALL to AES-GCM decrypt precompile (0x67)
+		SeismicHKDF,            ///< STATICCALL to HKDF precompile (0x68)
 	};
 	struct Options
 	{

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1075,6 +1075,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		case FunctionType::Kind::SeismicECDH:
 		case FunctionType::Kind::SeismicAESGCMEncrypt:
 		case FunctionType::Kind::SeismicAESGCMDecrypt:
+		case FunctionType::Kind::SeismicHKDF:
 		{
 			_functionCall.expression().accept(*this);
 			static std::map<FunctionType::Kind, u256> const contractAddresses{
@@ -1083,7 +1084,8 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				{FunctionType::Kind::RIPEMD160, 3},
 				{FunctionType::Kind::SeismicECDH, 0x65},
 				{FunctionType::Kind::SeismicAESGCMEncrypt, 0x66},
-				{FunctionType::Kind::SeismicAESGCMDecrypt, 0x67}
+				{FunctionType::Kind::SeismicAESGCMDecrypt, 0x67},
+				{FunctionType::Kind::SeismicHKDF, 0x68}
 			};
 			m_context << contractAddresses.at(function.kind());
 			for (unsigned i = function.sizeOnStack(); i > 0; --i)

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1076,6 +1076,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		case FunctionType::Kind::SeismicAESGCMEncrypt:
 		case FunctionType::Kind::SeismicAESGCMDecrypt:
 		case FunctionType::Kind::SeismicHKDF:
+		case FunctionType::Kind::SeismicSecp256k1Sign:
 		{
 			_functionCall.expression().accept(*this);
 			static std::map<FunctionType::Kind, u256> const contractAddresses{
@@ -1085,7 +1086,8 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				{FunctionType::Kind::SeismicECDH, 0x65},
 				{FunctionType::Kind::SeismicAESGCMEncrypt, 0x66},
 				{FunctionType::Kind::SeismicAESGCMDecrypt, 0x67},
-				{FunctionType::Kind::SeismicHKDF, 0x68}
+				{FunctionType::Kind::SeismicHKDF, 0x68},
+				{FunctionType::Kind::SeismicSecp256k1Sign, 0x69}
 			};
 			m_context << contractAddresses.at(function.kind());
 			for (unsigned i = function.sizeOnStack(); i > 0; --i)
@@ -3057,7 +3059,8 @@ void ExpressionCompiler::appendExternalFunctionCall(
 	}
 	else if (
 		funKind == FunctionType::Kind::SeismicAESGCMEncrypt ||
-		funKind == FunctionType::Kind::SeismicAESGCMDecrypt
+		funKind == FunctionType::Kind::SeismicAESGCMDecrypt ||
+		funKind == FunctionType::Kind::SeismicSecp256k1Sign
 	)
 	{
 		// Precompile returns raw bytes; wrap into a bytes memory array.

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1072,12 +1072,14 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		case FunctionType::Kind::ECRecover:
 		case FunctionType::Kind::SHA256:
 		case FunctionType::Kind::RIPEMD160:
+		case FunctionType::Kind::SeismicECDH:
 		{
 			_functionCall.expression().accept(*this);
 			static std::map<FunctionType::Kind, u256> const contractAddresses{
 				{FunctionType::Kind::ECRecover, 1},
 				{FunctionType::Kind::SHA256, 2},
-				{FunctionType::Kind::RIPEMD160, 3}
+				{FunctionType::Kind::RIPEMD160, 3},
+				{FunctionType::Kind::SeismicECDH, 0x65}
 			};
 			m_context << contractAddresses.at(function.kind());
 			for (unsigned i = function.sizeOnStack(); i > 0; --i)

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1073,13 +1073,17 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		case FunctionType::Kind::SHA256:
 		case FunctionType::Kind::RIPEMD160:
 		case FunctionType::Kind::SeismicECDH:
+		case FunctionType::Kind::SeismicAESGCMEncrypt:
+		case FunctionType::Kind::SeismicAESGCMDecrypt:
 		{
 			_functionCall.expression().accept(*this);
 			static std::map<FunctionType::Kind, u256> const contractAddresses{
 				{FunctionType::Kind::ECRecover, 1},
 				{FunctionType::Kind::SHA256, 2},
 				{FunctionType::Kind::RIPEMD160, 3},
-				{FunctionType::Kind::SeismicECDH, 0x65}
+				{FunctionType::Kind::SeismicECDH, 0x65},
+				{FunctionType::Kind::SeismicAESGCMEncrypt, 0x66},
+				{FunctionType::Kind::SeismicAESGCMDecrypt, 0x67}
 			};
 			m_context << contractAddresses.at(function.kind());
 			for (unsigned i = function.sizeOnStack(); i > 0; --i)
@@ -3048,6 +3052,14 @@ void ExpressionCompiler::appendExternalFunctionCall(
 		m_context << u256(32);
 		utils().fetchFreeMemoryPointer();
 		m_context << Instruction::SUB << Instruction::MLOAD;
+	}
+	else if (
+		funKind == FunctionType::Kind::SeismicAESGCMEncrypt ||
+		funKind == FunctionType::Kind::SeismicAESGCMDecrypt
+	)
+	{
+		// Precompile returns raw bytes; wrap into a bytes memory array.
+		utils().returnDataToArray();
 	}
 	else if (!returnTypes.empty())
 	{

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1086,6 +1086,50 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			appendExternalFunctionCall(function, arguments, false);
 			break;
 		}
+		case FunctionType::Kind::SeismicRNG:
+		{
+			solAssert(!_functionCall.annotation().tryCall, "");
+			solAssert(function.returnParameterTypes().size() == 1);
+
+			auto const& retType = *function.returnParameterTypes()[0];
+			auto const* shieldedType = dynamic_cast<ShieldedIntegerType const*>(&retType);
+			solAssert(shieldedType);
+			unsigned byteWidth = shieldedType->numBits() / 8;
+			unsigned shiftBits = (32 - byteWidth) * 8;
+
+			// Store uint32(byteWidth) big-endian at the free memory pointer
+			utils().fetchFreeMemoryPointer();
+			// Stack: fmp
+			m_context << u256(byteWidth) << u256(224) << Instruction::SHL;
+			// Stack: fmp shl_val
+			m_context << Instruction::DUP2 << Instruction::MSTORE;
+			// Stack: fmp (stored shl_val at fmp)
+
+			// Clear output scratch space at memory[0]
+			m_context << u256(0) << u256(0) << Instruction::MSTORE;
+
+			// STATICCALL(gas, 0x64, fmp, 4, 0, byteWidth)
+			m_context << u256(byteWidth) << u256(0); // retSize, retOffset
+			m_context << u256(4); // argSize
+			m_context << Instruction::DUP4; // argOffset = fmp
+			m_context << u256(0x64); // precompile address
+			m_context << Instruction::GAS;
+			m_context << Instruction::STATICCALL;
+
+			// Check success, revert on failure
+			m_context << Instruction::ISZERO;
+			m_context.appendConditionalRevert(true);
+
+			// Pop the saved fmp
+			m_context << Instruction::POP;
+
+			// Load result from memory[0] and shift right to right-align
+			m_context << u256(0) << Instruction::MLOAD;
+			if (shiftBits > 0)
+				m_context << u256(shiftBits) << Instruction::SHR;
+
+			break;
+		}
 		case FunctionType::Kind::ArrayPush:
 		{
 			solAssert(function.hasBoundFirstArgument(), "");

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1770,6 +1770,50 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		appendCode() << templ.render();
 		break;
 	}
+	case FunctionType::Kind::SeismicECDH:
+	{
+		solAssert(!_functionCall.annotation().tryCall);
+		solAssert(!functionType->valueSet());
+		solAssert(!functionType->gasSet());
+		solAssert(!functionType->hasBoundFirstArgument());
+
+		TypePointers argumentTypes;
+		std::vector<std::string> argumentStrings;
+		for (auto const& arg: arguments)
+		{
+			argumentTypes.emplace_back(&type(*arg));
+			argumentStrings += IRVariable(*arg).stackSlots();
+		}
+
+		Whiskers templ(R"(
+			let <pos> := <allocateUnbounded>()
+			let <end> := <encodeArgs>(<pos> <argumentString>)
+			mstore(0, 0)
+			<?eof>
+				let <success> := iszero(extstaticcall(0x65, <pos>, sub(<end>, <pos>)))
+			<!eof>
+				let <success> := staticcall(gas(), 0x65, <pos>, sub(<end>, <pos>), 0, 32)
+			</eof>
+			if iszero(<success>) { <forwardingRevert>() }
+			<?eof>
+				if eq(returndatasize(), 32) { returndatacopy(0, 0, 32) }
+			</eof>
+			let <retVar> := mload(0)
+		)");
+		auto const eof = m_context.eofVersion().has_value();
+		templ("allocateUnbounded", m_utils.allocateUnboundedFunction());
+		templ("pos", m_context.newYulVariable());
+		templ("end", m_context.newYulVariable());
+		templ("encodeArgs", m_context.abiFunctions().tupleEncoderPacked(argumentTypes, parameterTypes));
+		templ("argumentString", joinHumanReadablePrefixed(argumentStrings));
+		templ("eof", eof);
+		templ("success", m_context.newYulVariable());
+		templ("retVar", IRVariable(_functionCall).commaSeparatedList());
+		templ("forwardingRevert", m_utils.forwardingRevertFunction());
+
+		appendCode() << templ.render();
+		break;
+	}
 	default:
 		solUnimplemented("FunctionKind " + toString(static_cast<int>(functionType->kind())) + " not yet implemented");
 	}

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1728,6 +1728,48 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 
 		break;
 	}
+	case FunctionType::Kind::SeismicRNG:
+	{
+		solAssert(!_functionCall.annotation().tryCall);
+		solAssert(!functionType->valueSet());
+		solAssert(!functionType->gasSet());
+		solAssert(!functionType->hasBoundFirstArgument());
+		solAssert(functionType->returnParameterTypes().size() == 1);
+
+		auto const& retType = *functionType->returnParameterTypes()[0];
+		auto const* shieldedType = dynamic_cast<ShieldedIntegerType const*>(&retType);
+		solAssert(shieldedType);
+		unsigned byteWidth = shieldedType->numBits() / 8;
+		unsigned shiftBits = (32 - byteWidth) * 8;
+
+		Whiskers templ(R"(
+			let <pos> := <allocateUnbounded>()
+			mstore(<pos>, shl(224, <byteWidth>))
+			mstore(0, 0)
+			<?eof>
+				let <success> := iszero(extstaticcall(0x64, <pos>, 4))
+			<!eof>
+				let <success> := staticcall(gas(), 0x64, <pos>, 4, 0, <byteWidth>)
+			</eof>
+			if iszero(<success>) { <forwardingRevert>() }
+			<?eof>
+				if gt(returndatasize(), 0) { returndatacopy(0, 0, <byteWidth>) }
+			</eof>
+			let <retVar> := <shr>(mload(0))
+		)");
+		auto const eof = m_context.eofVersion().has_value();
+		templ("allocateUnbounded", m_utils.allocateUnboundedFunction());
+		templ("pos", m_context.newYulVariable());
+		templ("byteWidth", std::to_string(byteWidth));
+		templ("eof", eof);
+		templ("success", m_context.newYulVariable());
+		templ("shr", m_utils.shiftRightFunction(shiftBits));
+		templ("retVar", IRVariable(_functionCall).commaSeparatedList());
+		templ("forwardingRevert", m_utils.forwardingRevertFunction());
+
+		appendCode() << templ.render();
+		break;
+	}
 	default:
 		solUnimplemented("FunctionKind " + toString(static_cast<int>(functionType->kind())) + " not yet implemented");
 	}

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1814,6 +1814,56 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		appendCode() << templ.render();
 		break;
 	}
+	case FunctionType::Kind::SeismicAESGCMEncrypt:
+	case FunctionType::Kind::SeismicAESGCMDecrypt:
+	{
+		solAssert(!_functionCall.annotation().tryCall);
+		solAssert(!functionType->valueSet());
+		solAssert(!functionType->gasSet());
+		solAssert(!functionType->hasBoundFirstArgument());
+
+		unsigned address = functionType->kind() == FunctionType::Kind::SeismicAESGCMEncrypt ? 0x66 : 0x67;
+
+		TypePointers argumentTypes;
+		std::vector<std::string> argumentStrings;
+		for (auto const& arg: arguments)
+		{
+			argumentTypes.emplace_back(&type(*arg));
+			argumentStrings += IRVariable(*arg).stackSlots();
+		}
+
+		Whiskers templ(R"(
+			let <pos> := <allocateUnbounded>()
+			let <end> := <encodeArgs>(<pos> <argumentString>)
+			<?eof>
+				let <success> := iszero(extstaticcall(<address>, <pos>, sub(<end>, <pos>)))
+			<!eof>
+				let <success> := staticcall(gas(), <address>, <pos>, sub(<end>, <pos>), 0, 0)
+			</eof>
+			if iszero(<success>) { <forwardingRevert>() }
+			let <retVar> := <allocateUnbounded>()
+			let <rdsize> := returndatasize()
+			mstore(<retVar>, <rdsize>)
+			returndatacopy(add(<retVar>, 0x20), 0, <rdsize>)
+			<finalizeAllocation>(<retVar>, add(<rdsize>, 0x20))
+		)");
+		auto const eof = m_context.eofVersion().has_value();
+		templ("allocateUnbounded", m_utils.allocateUnboundedFunction());
+		templ("pos", m_context.newYulVariable());
+		templ("end", m_context.newYulVariable());
+		templ("encodeArgs", m_context.abiFunctions().tupleEncoderPacked(argumentTypes, parameterTypes));
+		templ("argumentString", joinHumanReadablePrefixed(argumentStrings));
+		templ("address", toString(address));
+		templ("eof", eof);
+		templ("success", m_context.newYulVariable());
+		templ("rdsize", m_context.newYulVariable());
+		templ("retVar", IRVariable(_functionCall).commaSeparatedList());
+		templ("forwardingRevert", m_utils.forwardingRevertFunction());
+		templ("finalizeAllocation", m_utils.finalizeAllocationFunction());
+
+		appendCode() << templ.render();
+		break;
+	}
 	default:
 		solUnimplemented("FunctionKind " + toString(static_cast<int>(functionType->kind())) + " not yet implemented");
 	}

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1864,6 +1864,50 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		appendCode() << templ.render();
 		break;
 	}
+	case FunctionType::Kind::SeismicHKDF:
+	{
+		solAssert(!_functionCall.annotation().tryCall);
+		solAssert(!functionType->valueSet());
+		solAssert(!functionType->gasSet());
+		solAssert(!functionType->hasBoundFirstArgument());
+
+		TypePointers argumentTypes;
+		std::vector<std::string> argumentStrings;
+		for (auto const& arg: arguments)
+		{
+			argumentTypes.emplace_back(&type(*arg));
+			argumentStrings += IRVariable(*arg).stackSlots();
+		}
+
+		Whiskers templ(R"(
+			let <pos> := <allocateUnbounded>()
+			let <end> := <encodeArgs>(<pos> <argumentString>)
+			mstore(0, 0)
+			<?eof>
+				let <success> := iszero(extstaticcall(0x68, <pos>, sub(<end>, <pos>)))
+			<!eof>
+				let <success> := staticcall(gas(), 0x68, <pos>, sub(<end>, <pos>), 0, 32)
+			</eof>
+			if iszero(<success>) { <forwardingRevert>() }
+			<?eof>
+				if eq(returndatasize(), 32) { returndatacopy(0, 0, 32) }
+			</eof>
+			let <retVar> := mload(0)
+		)");
+		auto const eof = m_context.eofVersion().has_value();
+		templ("allocateUnbounded", m_utils.allocateUnboundedFunction());
+		templ("pos", m_context.newYulVariable());
+		templ("end", m_context.newYulVariable());
+		templ("encodeArgs", m_context.abiFunctions().tupleEncoderPacked(argumentTypes, parameterTypes));
+		templ("argumentString", joinHumanReadablePrefixed(argumentStrings));
+		templ("eof", eof);
+		templ("success", m_context.newYulVariable());
+		templ("retVar", IRVariable(_functionCall).commaSeparatedList());
+		templ("forwardingRevert", m_utils.forwardingRevertFunction());
+
+		appendCode() << templ.render();
+		break;
+	}
 	default:
 		solUnimplemented("FunctionKind " + toString(static_cast<int>(functionType->kind())) + " not yet implemented");
 	}

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1908,6 +1908,52 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		appendCode() << templ.render();
 		break;
 	}
+	case FunctionType::Kind::SeismicSecp256k1Sign:
+	{
+		solAssert(!_functionCall.annotation().tryCall);
+		solAssert(!functionType->valueSet());
+		solAssert(!functionType->gasSet());
+		solAssert(!functionType->hasBoundFirstArgument());
+
+		TypePointers argumentTypes;
+		std::vector<std::string> argumentStrings;
+		for (auto const& arg: arguments)
+		{
+			argumentTypes.emplace_back(&type(*arg));
+			argumentStrings += IRVariable(*arg).stackSlots();
+		}
+
+		Whiskers templ(R"(
+			let <pos> := <allocateUnbounded>()
+			let <end> := <encodeArgs>(<pos> <argumentString>)
+			<?eof>
+				let <success> := iszero(extstaticcall(0x69, <pos>, sub(<end>, <pos>)))
+			<!eof>
+				let <success> := staticcall(gas(), 0x69, <pos>, sub(<end>, <pos>), 0, 0)
+			</eof>
+			if iszero(<success>) { <forwardingRevert>() }
+			let <retVar> := <allocateUnbounded>()
+			let <rdsize> := returndatasize()
+			mstore(<retVar>, <rdsize>)
+			returndatacopy(add(<retVar>, 0x20), 0, <rdsize>)
+			<finalizeAllocation>(<retVar>, add(<rdsize>, 0x20))
+		)");
+		auto const eof = m_context.eofVersion().has_value();
+		templ("allocateUnbounded", m_utils.allocateUnboundedFunction());
+		templ("pos", m_context.newYulVariable());
+		templ("end", m_context.newYulVariable());
+		templ("encodeArgs", m_context.abiFunctions().tupleEncoderPacked(argumentTypes, parameterTypes));
+		templ("argumentString", joinHumanReadablePrefixed(argumentStrings));
+		templ("eof", eof);
+		templ("success", m_context.newYulVariable());
+		templ("rdsize", m_context.newYulVariable());
+		templ("retVar", IRVariable(_functionCall).commaSeparatedList());
+		templ("forwardingRevert", m_utils.forwardingRevertFunction());
+		templ("finalizeAllocation", m_utils.finalizeAllocationFunction());
+
+		appendCode() << templ.render();
+		break;
+	}
 	default:
 		solUnimplemented("FunctionKind " + toString(static_cast<int>(functionType->kind())) + " not yet implemented");
 	}

--- a/test/libsolidity/semanticTests/seismic_builtins/aes_gcm_builtins.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/aes_gcm_builtins.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract AESGCMBuiltins {
+    // Test encrypt then decrypt round-trip
+    function testRoundTrip() public view returns (bool) {
+        sbytes32 key = sbytes32(hex"00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+        uint96 nonce = 17;
+        bytes memory plaintext = hex"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f";
+
+        bytes memory ciphertext = aes_gcm_encrypt(key, nonce, plaintext);
+        bytes memory decrypted = aes_gcm_decrypt(key, nonce, ciphertext);
+
+        return keccak256(decrypted) == keccak256(plaintext);
+    }
+
+    // Verify the built-in encrypt matches raw staticcall
+    function testEncryptMatchesRawPrecompile() public view returns (bool) {
+        sbytes32 key = sbytes32(hex"00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+        uint96 nonce = 17;
+        bytes memory plaintext = hex"0102030405060708090a0b0c0d0e0f10";
+
+        bytes memory builtinResult = aes_gcm_encrypt(key, nonce, plaintext);
+
+        // Raw staticcall
+        (bool success, bytes memory rawResult) = address(0x66).staticcall(abi.encodePacked(bytes32(key), nonce, plaintext));
+        require(success);
+
+        return keccak256(builtinResult) == keccak256(rawResult);
+    }
+}
+// ====
+// EVMVersion: >=mercury
+// ====
+// ----
+// testRoundTrip() -> true
+// testEncryptMatchesRawPrecompile() -> true

--- a/test/libsolidity/semanticTests/seismic_builtins/derive_sym_key_builtin.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/derive_sym_key_builtin.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ECDHBuiltin {
+    // Verify the built-in matches the raw staticcall approach
+    function testMatchesRawPrecompile() public view returns (bool) {
+        sbytes32 sk = sbytes32(hex"7e38022030c40773cc561c1cc9c0053e48b0be2cee33c13495f096942ea176ef");
+        bytes memory pk = hex"02555d7b94d8afc4afdf5a03e9da73a408b6d19c865036bae833864d2353e85a25";
+
+        bytes32 builtinResult = ecdh(sk, pk);
+
+        // Raw staticcall
+        (bool success, bytes memory output) = address(0x65).staticcall(abi.encodePacked(bytes32(sk), pk));
+        require(success);
+        bytes32 rawResult;
+        assembly { rawResult := mload(add(output, 32)) }
+
+        return builtinResult == rawResult;
+    }
+
+    // Verify ECDH shared secret: sk1*pk2 == sk2*pk1
+    function testECDHSymmetry() public view returns (bool) {
+        sbytes32 sk1 = sbytes32(hex"7e38022030c40773cc561c1cc9c0053e48b0be2cee33c13495f096942ea176ef");
+        bytes memory pk1 = hex"03f176e697b5b0c4799f1816f5fe114263d1c01a84ad296129f994278499f0842e";
+        sbytes32 sk2 = sbytes32(hex"adbed354135e517bc881d55fa60c455737d1ba98d446c0866cec3837e13d9906");
+        bytes memory pk2 = hex"02555d7b94d8afc4afdf5a03e9da73a408b6d19c865036bae833864d2353e85a25";
+
+        bytes32 resultA = ecdh(sk1, pk2);
+        bytes32 resultB = ecdh(sk2, pk1);
+        return resultA == resultB;
+    }
+}
+// ====
+// EVMVersion: >=mercury
+// ====
+// ----
+// testMatchesRawPrecompile() -> true
+// testECDHSymmetry() -> true

--- a/test/libsolidity/semanticTests/seismic_builtins/hkdf_builtin.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/hkdf_builtin.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract HKDFBuiltin {
+    // Verify the built-in matches the raw staticcall approach
+    function testMatchesRawPrecompile() public view returns (bool) {
+        bytes memory input = hex"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+
+        bytes32 builtinResult = hkdf(input);
+
+        // Raw staticcall
+        (bool success, bytes memory output) = address(0x68).staticcall(input);
+        require(success);
+        bytes32 rawResult;
+        assembly { rawResult := mload(add(output, 32)) }
+
+        return builtinResult == rawResult;
+    }
+
+    // Test deterministic output
+    function testDeterministic() public view returns (bool) {
+        bytes memory input = hex"deadbeef";
+        bytes32 a = hkdf(input);
+        bytes32 b = hkdf(input);
+        return a == b;
+    }
+}
+// ====
+// EVMVersion: >=mercury
+// ====
+// ----
+// testMatchesRawPrecompile() -> true
+// testDeterministic() -> true

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_builtins.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_builtins.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract RngBuiltins {
+    // Each test verifies the rng call succeeds and the result looks random.
+    // For N-bit types (N >= 30): check val in [2^(N-30), max - 2^(N-30)].
+    // P(false positive) ≈ 2 * 2^(-30) ≈ 2e-9 per test.
+    // For smaller types: combine multiple samples.
+
+    function testRng256() public view returns (bool) {
+        uint256 val = uint256(rng256());
+        return val >= 2**226 && val <= type(uint256).max - 2**226;
+    }
+
+    function testRng128() public view returns (bool) {
+        uint128 val = uint128(rng128());
+        return val >= 2**98 && val <= type(uint128).max - 2**98;
+    }
+
+    function testRng64() public view returns (bool) {
+        uint64 val = uint64(rng64());
+        return val >= 2**34 && val <= type(uint64).max - 2**34;
+    }
+
+    function testRng32() public view returns (bool) {
+        uint32 val = uint32(rng32());
+        return val >= 4 && val <= type(uint32).max - 4;
+    }
+
+    function testRng16() public view returns (bool) {
+        // 16 bits: two samples, check not all-zero and not all-ones.
+        // P(false positive) ≈ 2 * (1/2^16)^2 ≈ 5e-10.
+        uint16 a = uint16(rng16());
+        uint16 b = uint16(rng16());
+        return (a | b) > 0 && (a & b) < type(uint16).max;
+    }
+
+    function testRng8() public view returns (bool) {
+        // 8 bits: four samples, check not all-zero and not all-ones.
+        // P(false positive) ≈ 2 * (1/2^8)^4 ≈ 5e-10.
+        uint8 a = uint8(rng8());
+        uint8 b = uint8(rng8());
+        uint8 c = uint8(rng8());
+        uint8 d = uint8(rng8());
+        return (a | b | c | d) > 0 && (a & b & c & d) < type(uint8).max;
+    }
+}
+// ====
+// EVMVersion: >=mercury
+// ====
+// ----
+// testRng256() -> true
+// testRng128() -> true
+// testRng64() -> true
+// testRng32() -> true
+// testRng16() -> true
+// testRng8() -> true

--- a/test/libsolidity/semanticTests/seismic_builtins/secp256k1_sign_builtin.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/secp256k1_sign_builtin.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Secp256k1SignBuiltin {
+    // Verify the built-in matches the raw staticcall approach
+    function testMatchesRawPrecompile() public view returns (bool) {
+        sbytes32 sk = sbytes32(bytes32(uint256(1)));
+        bytes32 msgHash = keccak256("hello");
+
+        bytes memory builtinResult = secp256k1_sign(sk, msgHash);
+
+        // Raw staticcall
+        bytes memory input = abi.encodePacked(bytes32(sk), msgHash);
+        (bool success, bytes memory rawResult) = address(0x69).staticcall(input);
+        require(success);
+
+        return keccak256(builtinResult) == keccak256(rawResult);
+    }
+
+    // Test deterministic output
+    function testDeterministic() public view returns (bool) {
+        sbytes32 sk = sbytes32(bytes32(uint256(42)));
+        bytes32 msgHash = keccak256("test");
+        bytes memory a = secp256k1_sign(sk, msgHash);
+        bytes memory b = secp256k1_sign(sk, msgHash);
+        return keccak256(a) == keccak256(b);
+    }
+}
+// ====
+// EVMVersion: >=mercury
+// ====
+// ----
+// testMatchesRawPrecompile() -> true
+// testDeterministic() -> true

--- a/test/libsolidity/syntaxTests/seismic_builtins/aes_gcm_type_check.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/aes_gcm_type_check.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract C {
+    function f() internal view {
+        sbytes32 key = sbytes32(bytes32(0));
+        uint96 nonce = 0;
+        bytes memory data = new bytes(16);
+        bytes memory encrypted = aes_gcm_encrypt(key, nonce, data);
+        bytes memory decrypted = aes_gcm_decrypt(key, nonce, encrypted);
+        decrypted;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/derive_sym_key_type_check.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/derive_sym_key_type_check.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract C {
+    function f() internal view {
+        sbytes32 sk = sbytes32(bytes32(0));
+        bytes memory pk = new bytes(33);
+        bytes32 result = ecdh(sk, pk);
+        result;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/hkdf_type_check.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/hkdf_type_check.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract C {
+    function f() internal view {
+        bytes memory input = new bytes(32);
+        bytes32 result = hkdf(input);
+        result;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_type_check.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_type_check.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract C {
+    function f() public view {
+        suint8 a = rng8();
+        suint16 b = rng16();
+        suint32 c = rng32();
+        suint64 d = rng64();
+        suint128 e = rng128();
+        suint256 g = rng256();
+        a; b; c; d; e; g;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_view_not_pure.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_view_not_pure.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract C {
+    function f() internal pure returns (suint256) {
+        return rng256();
+    }
+}
+// ----
+// TypeError 2527: (137-145): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".

--- a/test/libsolidity/syntaxTests/seismic_builtins/secp256k1_sign_type_check.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/secp256k1_sign_type_check.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract C {
+    function f() internal view {
+        sbytes32 sk = sbytes32(bytes32(uint256(1)));
+        bytes32 msgHash = keccak256("hello");
+        bytes memory result = secp256k1_sign(sk, msgHash);
+        result;
+    }
+}
+// ----


### PR DESCRIPTION
## Summary
- Add ergonomic built-in functions for Seismic precompiles (RNG, ECDH, AES, HKDF, secp256k1)
- Each precompile gets a simple function name instead of requiring manual staticcall boilerplate
- Includes both IR (Yul) and legacy codegen paths

## Precompiles
| Built-in | Address | Status |
|----------|---------|--------|
| `rng8()` .. `rng256()` | 0x64 | Done |
| `ecdh(sbytes32, bytes memory)` | 0x65 | Done |
| `aes_gcm_encrypt(sbytes32, uint96, bytes memory)` | 0x66 | Done |
| `aes_gcm_decrypt(sbytes32, uint96, bytes memory)` | 0x67 | Done |
| `hkdf(bytes memory)` | 0x68 | Done |
| `secp256k1_sign(sbytes32, bytes32)` | 0x69 | Done |

## Test plan
- [x] Syntax tests pass for all precompiles
- [ ] Semantic tests (require seismic-revm)
- [ ] Optimizer tests

Replaces #208 (rebased to clean branch with only the relevant commits).