### PR TITLE
ci: expand semantic tests to cover more optimizer-runs values

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,7 @@ jobs:
           run_config "optimizer runs=1, no IR" --optimize --optimizer-runs 1
           run_config "optimizer runs=1000, no IR" --optimize --optimizer-runs 1000
           run_config "optimizer runs=1000000, no IR" --optimize --optimizer-runs 1000000
+          run_config "optimizer runs=4294967295 (uint32 max), no IR" --optimize --optimizer-runs 4294967295
 
           # With --via-ir
           run_config "no optimizer, --via-ir" --via-ir
@@ -155,6 +156,7 @@ jobs:
           run_config "optimizer runs=1, --via-ir" --via-ir --optimize --optimizer-runs 1
           run_config "optimizer runs=1000, --via-ir" --via-ir --optimize --optimizer-runs 1000
           run_config "optimizer runs=1000000, --via-ir" --via-ir --optimize --optimizer-runs 1000000
+          run_config "optimizer runs=4294967295 (uint32 max), --via-ir" --via-ir --optimize --optimizer-runs 4294967295
 
           if [ "$FAILED" -ne 0 ]; then
             echo "Some configurations failed!"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,15 +144,15 @@ jobs:
 
           # Without --via-ir
           run_config "no optimizer, no IR"
+          run_config "optimizer (default runs=200), no IR" --optimize
           run_config "optimizer runs=1, no IR" --optimize --optimizer-runs 1
-          run_config "optimizer runs=200, no IR" --optimize --optimizer-runs 200
           run_config "optimizer runs=1000, no IR" --optimize --optimizer-runs 1000
           run_config "optimizer runs=1000000, no IR" --optimize --optimizer-runs 1000000
 
           # With --via-ir
           run_config "no optimizer, --via-ir" --via-ir
+          run_config "optimizer (default runs=200), --via-ir" --via-ir --optimize
           run_config "optimizer runs=1, --via-ir" --via-ir --optimize --optimizer-runs 1
-          run_config "optimizer runs=200, --via-ir" --via-ir --optimize --optimizer-runs 200
           run_config "optimizer runs=1000, --via-ir" --via-ir --optimize --optimizer-runs 1000
           run_config "optimizer runs=1000000, --via-ir" --via-ir --optimize --optimizer-runs 1000000
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,14 +147,14 @@ jobs:
           run_config "optimizer runs=1, no IR" --optimize --optimizer-runs 1
           run_config "optimizer runs=200, no IR" --optimize --optimizer-runs 200
           run_config "optimizer runs=1000, no IR" --optimize --optimizer-runs 1000
-          run_config "optimizer runs=10000, no IR" --optimize --optimizer-runs 10000
+          run_config "optimizer runs=1000000, no IR" --optimize --optimizer-runs 1000000
 
           # With --via-ir
           run_config "no optimizer, --via-ir" --via-ir
           run_config "optimizer runs=1, --via-ir" --via-ir --optimize --optimizer-runs 1
           run_config "optimizer runs=200, --via-ir" --via-ir --optimize --optimizer-runs 200
           run_config "optimizer runs=1000, --via-ir" --via-ir --optimize --optimizer-runs 1000
-          run_config "optimizer runs=10000, --via-ir" --via-ir --optimize --optimizer-runs 10000
+          run_config "optimizer runs=1000000, --via-ir" --via-ir --optimize --optimizer-runs 1000000
 
           if [ "$FAILED" -ne 0 ]; then
             echo "Some configurations failed!"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,26 +124,42 @@ jobs:
           }
           EOF
           SCRIPT_EOF
-      - name: Run semantic tests (no optimizer, no IR)
+      - name: Run semantic tests (all configurations)
         run: |
           set -euo pipefail
           eval "$RUN_SEMANTIC_TESTS"
-          run_semantic_tests
-      - name: Run semantic tests (with optimizer, no IR)
-        run: |
-          set -euo pipefail
-          eval "$RUN_SEMANTIC_TESTS"
-          run_semantic_tests --optimize --optimizer-runs 200
-      - name: Run semantic tests (no optimizer, --via-ir)
-        run: |
-          set -euo pipefail
-          eval "$RUN_SEMANTIC_TESTS"
-          run_semantic_tests --via-ir
-      - name: Run semantic tests (with optimizer, --via-ir)
-        run: |
-          set -euo pipefail
-          eval "$RUN_SEMANTIC_TESTS"
-          run_semantic_tests --via-ir --optimize --optimizer-runs 200
+
+          FAILED=0
+          run_config() {
+            local desc="$1"
+            shift
+            echo "========================================="
+            echo "Running: $desc"
+            echo "========================================="
+            if ! run_semantic_tests "$@"; then
+              echo "FAILED: $desc"
+              FAILED=1
+            fi
+          }
+
+          # Without --via-ir
+          run_config "no optimizer, no IR"
+          run_config "optimizer runs=1, no IR" --optimize --optimizer-runs 1
+          run_config "optimizer runs=200, no IR" --optimize --optimizer-runs 200
+          run_config "optimizer runs=1000, no IR" --optimize --optimizer-runs 1000
+          run_config "optimizer runs=10000, no IR" --optimize --optimizer-runs 10000
+
+          # With --via-ir
+          run_config "no optimizer, --via-ir" --via-ir
+          run_config "optimizer runs=1, --via-ir" --via-ir --optimize --optimizer-runs 1
+          run_config "optimizer runs=200, --via-ir" --via-ir --optimize --optimizer-runs 200
+          run_config "optimizer runs=1000, --via-ir" --via-ir --optimize --optimizer-runs 1000
+          run_config "optimizer runs=10000, --via-ir" --via-ir --optimize --optimizer-runs 10000
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "Some configurations failed!"
+            exit 1
+          fi
 
       # Save caches only on push to target branches (after PR merge)
       # Delete old caches first since GitHub caches are immutable


### PR DESCRIPTION
## Summary

Auditor recommendation: test more optimizer-runs configurations to catch optimizer bugs.

Consolidates the 4 separate semantic test CI steps into 1 and expands from 4 to 12 configurations:

| optimizer-runs | no IR | --via-ir |
|---|---|---|
| (none) | ✅ | ✅ |
| default (200) | ✅ | ✅ |
| 1 | ✅ | ✅ |
| 1,000 | ✅ | ✅ |
| 1,000,000 | ✅ | ✅ |
| 4,294,967,295 | ✅ | ✅ |

The default (200) case uses `--optimize` without `--optimizer-runs`, relying on Solidity's built-in default.

### Why these values

- **default (200)** — Solidity default, most common in production (OpenZeppelin)
- **1** — deploy-optimized (proxies, factories)
- **1,000** — moderate runtime optimization (DeFi protocols)
- **1,000,000** — heavy runtime optimization (Uniswap V3)
- **4,294,967,295** — type(uint32).max, maximum optimization (Seaport/OpenSea)

These cover the full spectrum from deployment-cost-minimized to maximum-runtime-optimized, matching real-world production usage.

## Test plan

- [ ] CI runs all 12 configurations successfully