### PR TITLE
ci(semantics): use seismic branch of seismic-revm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,6 @@ jobs:
         run: |
           git clone https://github.com/SeismicSystems/seismic-revm.git /tmp/seismic-revm
           cd /tmp/seismic-revm
-          git checkout e962e2174e097e69284cf9cbbbf7bc15e5d718cf
           echo "SEISMIC_REVM_PATH=/tmp/seismic-revm" >> $GITHUB_ENV
           echo "seismic-revm cloned to: /tmp/seismic-revm"
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
this branch now supports `--unsafe-via-ir`: https://github.com/SeismicSystems/seismic-revm/pull/183