### PR TITLE
feat(warnings): emit distinct IDs for shielded literal warnings in external call args

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -4563,13 +4563,22 @@ void TypeChecker::checkLiteralToShielded(
 	langutil::SourceLocation const& _location
 )
 {
-	// When the literal-to-shielded conversion occurs inside an external call's
-	// arguments, emit a distinct warning ID so that downstream tools (sforge)
-	// can selectively suppress it for test/script files where the contract
-	// bytecode is never deployed on-chain and calldata is encrypted by TxSeismic.
-	// All other contexts (new-expression args, assignments, internal calls, etc.)
-	// keep the original warning IDs.
-	bool const isExternalCallArg = m_insideExternalCallArgs > 0 && m_insideNewExpressionArgs == 0;
+	// Emit distinct warning IDs based on AST context so downstream tools
+	// (sforge/seismic-compilers) can selectively suppress warnings by file path:
+	//   new(...)  args — IDs 5501-5505: child contract gets deployed via CREATE,
+	//                    literal leaks in init code; show even in test/script
+	//   ext call  args — IDs 5506-5510: literal in caller bytecode, calldata
+	//                    encrypted by TxSeismic; suppress in test/script
+	//   other          — IDs 9660-9663/1457: literal in bytecode; suppress in
+	//                    test/script (bytecode never deployed)
+	auto pickId = [&](langutil::ErrorId _newExpr, langutil::ErrorId _extCall, langutil::ErrorId _other)
+	{
+		if (m_insideNewExpressionArgs > 0)
+			return _newExpr;
+		if (m_insideExternalCallArgs > 0)
+			return _extCall;
+		return _other;
+	};
 
 	// Cases that only need annotation().type, not a Literal AST node.
 	// This covers constant expressions (BinaryOperation, UnaryOperation, etc.)
@@ -4581,7 +4590,7 @@ void TypeChecker::checkLiteralToShielded(
 	)
 	{
 		m_errorReporter.warning(
-			isExternalCallArg ? 5506_error : 9660_error,
+			pickId(5501_error, 5506_error, 9660_error),
 			_location,
 			"Literals converted to shielded integers will leak during contract deployment."
 		);
@@ -4594,7 +4603,7 @@ void TypeChecker::checkLiteralToShielded(
 	)
 	{
 		m_errorReporter.warning(
-			isExternalCallArg ? 5510_error : 1457_error,
+			pickId(5505_error, 5510_error, 1457_error),
 			_location,
 			"Enums converted to shielded integers will leak during contract deployment."
 		);
@@ -4607,7 +4616,7 @@ void TypeChecker::checkLiteralToShielded(
 	)
 	{
 		m_errorReporter.warning(
-			isExternalCallArg ? 5509_error : 9663_error,
+			pickId(5504_error, 5509_error, 9663_error),
 			_location,
 			"FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment."
 		);
@@ -4624,7 +4633,7 @@ void TypeChecker::checkLiteralToShielded(
 		std::string val = literal->value();
 		if (val == "true" || val == "false")
 			m_errorReporter.warning(
-				isExternalCallArg ? 5507_error : 9661_error,
+				pickId(5502_error, 5507_error, 9661_error),
 				_location,
 				"Bool Literals converted to shielded bools will leak during contract deployment."
 			);
@@ -4633,7 +4642,7 @@ void TypeChecker::checkLiteralToShielded(
 	{
 		if (literal->passesAddressChecksum())
 			m_errorReporter.warning(
-				isExternalCallArg ? 5508_error : 9662_error,
+				pickId(5503_error, 5508_error, 9662_error),
 				_location,
 				"Address Literals converted to shielded addresses will leak during contract deployment."
 			);

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -4551,13 +4551,29 @@ void TypeChecker::checkLiteralToShielded(
 	langutil::SourceLocation const& _location
 )
 {
-	// When the literal-to-shielded conversion occurs inside an external call's
-	// arguments, emit a distinct warning ID so that downstream tools (sforge)
-	// can selectively suppress it for test/script files where the contract
-	// bytecode is never deployed on-chain and calldata is encrypted by TxSeismic.
-	// All other contexts (new-expression args, assignments, internal calls, etc.)
-	// keep the original warning IDs — the literal leaks via bytecode in those cases.
-	bool const isExternalCallArg = m_insideExternalCallArgs > 0 && m_insideNewExpressionArgs == 0;
+	// Emit distinct warning IDs based on AST context so downstream tools
+	// (sforge/seismic-compilers) can selectively suppress warnings by file path:
+	//   Context A (new expr args)    — IDs 5501-5505: literal leaks in deployment
+	//                                  tx init code; always warn, even in tests
+	//   Context B (external call)    — IDs 5506-5510: literal in caller bytecode,
+	//                                  calldata encrypted by TxSeismic
+	//   Context C (other)            — IDs 9660-9663/1457: literal in bytecode
+	// In test/script files, B and C are suppressed (bytecode never deployed,
+	// calldata encrypted). Only A warnings are shown.
+	enum class Ctx { NewExpr, ExternalCall, Other };
+	Ctx ctx = Ctx::Other;
+	if (m_insideNewExpressionArgs > 0)
+		ctx = Ctx::NewExpr;
+	else if (m_insideExternalCallArgs > 0)
+		ctx = Ctx::ExternalCall;
+
+	// Helper to select the right warning ID per context.
+	auto pickId = [&](langutil::ErrorId _newExpr, langutil::ErrorId _extCall, langutil::ErrorId _other)
+	{
+		if (ctx == Ctx::NewExpr)     return _newExpr;
+		if (ctx == Ctx::ExternalCall) return _extCall;
+		return _other;
+	};
 
 	// Cases that only need annotation().type, not a Literal AST node.
 	// This covers constant expressions (BinaryOperation, UnaryOperation, etc.)
@@ -4569,7 +4585,7 @@ void TypeChecker::checkLiteralToShielded(
 	)
 	{
 		m_errorReporter.warning(
-			isExternalCallArg ? 5506_error : 9660_error,
+			pickId(5501_error, 5506_error, 9660_error),
 			_location,
 			"Literals converted to shielded integers will leak during contract deployment."
 		);
@@ -4582,7 +4598,7 @@ void TypeChecker::checkLiteralToShielded(
 	)
 	{
 		m_errorReporter.warning(
-			isExternalCallArg ? 5510_error : 1457_error,
+			pickId(5505_error, 5510_error, 1457_error),
 			_location,
 			"Enums converted to shielded integers will leak during contract deployment."
 		);
@@ -4595,7 +4611,7 @@ void TypeChecker::checkLiteralToShielded(
 	)
 	{
 		m_errorReporter.warning(
-			isExternalCallArg ? 5509_error : 9663_error,
+			pickId(5504_error, 5509_error, 9663_error),
 			_location,
 			"FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment."
 		);
@@ -4612,7 +4628,7 @@ void TypeChecker::checkLiteralToShielded(
 		std::string val = literal->value();
 		if (val == "true" || val == "false")
 			m_errorReporter.warning(
-				isExternalCallArg ? 5507_error : 9661_error,
+				pickId(5502_error, 5507_error, 9661_error),
 				_location,
 				"Bool Literals converted to shielded bools will leak during contract deployment."
 			);
@@ -4621,7 +4637,7 @@ void TypeChecker::checkLiteralToShielded(
 	{
 		if (literal->passesAddressChecksum())
 			m_errorReporter.warning(
-				isExternalCallArg ? 5508_error : 9662_error,
+				pickId(5503_error, 5508_error, 9662_error),
 				_location,
 				"Address Literals converted to shielded addresses will leak during contract deployment."
 			);

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -383,6 +383,18 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 					"Use internal or private functions or cast to an unshielded type."
 				);
 
+			// Warn about shielded types in constructor parameters. Contract creation
+			// uses the CREATE opcode whose input data is not encrypted by TxSeismic,
+			// so shielded constructor arguments are visible in the deployment transaction.
+			if (_function.isConstructor() && !_var.isReturnParameter() && type(_var)->containsShieldedType())
+				m_errorReporter.warning(
+					5500_error,
+					_var.location(),
+					"Shielded types in constructor parameters are visible in deployment transaction data. "
+					"Contract creation (CREATE/CREATE2) does not encrypt calldata. "
+					"Consider setting shielded state via a post-deployment transaction instead."
+				);
+
 			auto iType = type(_var)->interfaceType(_function.libraryFunction());
 
 			if (!iType)
@@ -4551,29 +4563,13 @@ void TypeChecker::checkLiteralToShielded(
 	langutil::SourceLocation const& _location
 )
 {
-	// Emit distinct warning IDs based on AST context so downstream tools
-	// (sforge/seismic-compilers) can selectively suppress warnings by file path:
-	//   Context A (new expr args)    — IDs 5501-5505: literal leaks in deployment
-	//                                  tx init code; always warn, even in tests
-	//   Context B (external call)    — IDs 5506-5510: literal in caller bytecode,
-	//                                  calldata encrypted by TxSeismic
-	//   Context C (other)            — IDs 9660-9663/1457: literal in bytecode
-	// In test/script files, B and C are suppressed (bytecode never deployed,
-	// calldata encrypted). Only A warnings are shown.
-	enum class Ctx { NewExpr, ExternalCall, Other };
-	Ctx ctx = Ctx::Other;
-	if (m_insideNewExpressionArgs > 0)
-		ctx = Ctx::NewExpr;
-	else if (m_insideExternalCallArgs > 0)
-		ctx = Ctx::ExternalCall;
-
-	// Helper to select the right warning ID per context.
-	auto pickId = [&](langutil::ErrorId _newExpr, langutil::ErrorId _extCall, langutil::ErrorId _other)
-	{
-		if (ctx == Ctx::NewExpr)     return _newExpr;
-		if (ctx == Ctx::ExternalCall) return _extCall;
-		return _other;
-	};
+	// When the literal-to-shielded conversion occurs inside an external call's
+	// arguments, emit a distinct warning ID so that downstream tools (sforge)
+	// can selectively suppress it for test/script files where the contract
+	// bytecode is never deployed on-chain and calldata is encrypted by TxSeismic.
+	// All other contexts (new-expression args, assignments, internal calls, etc.)
+	// keep the original warning IDs.
+	bool const isExternalCallArg = m_insideExternalCallArgs > 0 && m_insideNewExpressionArgs == 0;
 
 	// Cases that only need annotation().type, not a Literal AST node.
 	// This covers constant expressions (BinaryOperation, UnaryOperation, etc.)
@@ -4585,7 +4581,7 @@ void TypeChecker::checkLiteralToShielded(
 	)
 	{
 		m_errorReporter.warning(
-			pickId(5501_error, 5506_error, 9660_error),
+			isExternalCallArg ? 5506_error : 9660_error,
 			_location,
 			"Literals converted to shielded integers will leak during contract deployment."
 		);
@@ -4598,7 +4594,7 @@ void TypeChecker::checkLiteralToShielded(
 	)
 	{
 		m_errorReporter.warning(
-			pickId(5505_error, 5510_error, 1457_error),
+			isExternalCallArg ? 5510_error : 1457_error,
 			_location,
 			"Enums converted to shielded integers will leak during contract deployment."
 		);
@@ -4611,7 +4607,7 @@ void TypeChecker::checkLiteralToShielded(
 	)
 	{
 		m_errorReporter.warning(
-			pickId(5504_error, 5509_error, 9663_error),
+			isExternalCallArg ? 5509_error : 9663_error,
 			_location,
 			"FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment."
 		);
@@ -4628,7 +4624,7 @@ void TypeChecker::checkLiteralToShielded(
 		std::string val = literal->value();
 		if (val == "true" || val == "false")
 			m_errorReporter.warning(
-				pickId(5502_error, 5507_error, 9661_error),
+				isExternalCallArg ? 5507_error : 9661_error,
 				_location,
 				"Bool Literals converted to shielded bools will leak during contract deployment."
 			);
@@ -4637,7 +4633,7 @@ void TypeChecker::checkLiteralToShielded(
 	{
 		if (literal->passesAddressChecksum())
 			m_errorReporter.warning(
-				pickId(5503_error, 5508_error, 9662_error),
+				isExternalCallArg ? 5508_error : 9662_error,
 				_location,
 				"Address Literals converted to shielded addresses will leak during contract deployment."
 			);

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3055,6 +3055,44 @@ bool TypeChecker::visit(FunctionCall const& _functionCall)
 	std::vector<ASTPointer<Expression const>> const& arguments = _functionCall.arguments();
 	bool argumentsArePure = true;
 
+	// Track whether we are inside a `new` expression or an external call on
+	// another contract, for context-aware shielded literal warnings.
+	// A member access on a contract/interface type (e.g. token.mint(...))
+	// indicates an external call whose calldata TxSeismic encrypts.
+	// Built-in member functions (arr.push(...), addr.send(...)) are NOT
+	// external calls — the literal is still in the calling contract's bytecode.
+	bool const isNewExpr = dynamic_cast<NewExpression const*>(&_functionCall.expression()) != nullptr;
+	bool isExternalContractCall = false;
+	if (auto const* memberAccess = dynamic_cast<MemberAccess const*>(&_functionCall.expression()))
+	{
+		// Check if the member access target is a contract/interface type.
+		// This covers: contractVar.f(), interfaceVar.f(), this.f()
+		// The expression's annotation().type is set during the recursive accept()
+		// that already happened (arguments are visited before the callee expression
+		// in the original code, but the expression type may already be resolved).
+		// For state variables of contract type, check via the declaration.
+		// For `this`, check the expression's type annotation directly.
+		if (auto const* identifier = dynamic_cast<Identifier const*>(&memberAccess->expression()))
+		{
+			if (auto const* varDecl = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration))
+			{
+				if (varDecl->type() && dynamic_cast<ContractType const*>(varDecl->type()))
+					isExternalContractCall = true;
+			}
+			else if (auto const* magicVar = dynamic_cast<MagicVariableDeclaration const*>(identifier->annotation().referencedDeclaration))
+			{
+				// `this` is a MagicVariableDeclaration whose type is ContractType.
+				(void)magicVar;
+				if (identifier->name() == "this")
+					isExternalContractCall = true;
+			}
+		}
+	}
+	if (isNewExpr)
+		++m_insideNewExpressionArgs;
+	else if (isExternalContractCall)
+		++m_insideExternalCallArgs;
+
 	// We need to check arguments' type first as they will be needed for overload resolution.
 	for (ASTPointer<Expression const> const& argument: arguments)
 	{
@@ -3062,6 +3100,11 @@ bool TypeChecker::visit(FunctionCall const& _functionCall)
 		if (!*argument->annotation().isPure)
 			argumentsArePure = false;
 	}
+
+	if (isNewExpr)
+		--m_insideNewExpressionArgs;
+	else if (isExternalContractCall)
+		--m_insideExternalCallArgs;
 
 	// Store argument types - and names if given - for overload resolution
 	{
@@ -4508,6 +4551,14 @@ void TypeChecker::checkLiteralToShielded(
 	langutil::SourceLocation const& _location
 )
 {
+	// When the literal-to-shielded conversion occurs inside an external call's
+	// arguments, emit a distinct warning ID so that downstream tools (sforge)
+	// can selectively suppress it for test/script files where the contract
+	// bytecode is never deployed on-chain and calldata is encrypted by TxSeismic.
+	// All other contexts (new-expression args, assignments, internal calls, etc.)
+	// keep the original warning IDs — the literal leaks via bytecode in those cases.
+	bool const isExternalCallArg = m_insideExternalCallArgs > 0 && m_insideNewExpressionArgs == 0;
+
 	// Cases that only need annotation().type, not a Literal AST node.
 	// This covers constant expressions (BinaryOperation, UnaryOperation, etc.)
 	// that fold to RationalNumber or Enum types.
@@ -4518,7 +4569,7 @@ void TypeChecker::checkLiteralToShielded(
 	)
 	{
 		m_errorReporter.warning(
-			9660_error,
+			isExternalCallArg ? 5506_error : 9660_error,
 			_location,
 			"Literals converted to shielded integers will leak during contract deployment."
 		);
@@ -4531,7 +4582,7 @@ void TypeChecker::checkLiteralToShielded(
 	)
 	{
 		m_errorReporter.warning(
-			1457_error,
+			isExternalCallArg ? 5510_error : 1457_error,
 			_location,
 			"Enums converted to shielded integers will leak during contract deployment."
 		);
@@ -4544,7 +4595,7 @@ void TypeChecker::checkLiteralToShielded(
 	)
 	{
 		m_errorReporter.warning(
-			9663_error,
+			isExternalCallArg ? 5509_error : 9663_error,
 			_location,
 			"FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment."
 		);
@@ -4561,7 +4612,7 @@ void TypeChecker::checkLiteralToShielded(
 		std::string val = literal->value();
 		if (val == "true" || val == "false")
 			m_errorReporter.warning(
-				9661_error,
+				isExternalCallArg ? 5507_error : 9661_error,
 				_location,
 				"Bool Literals converted to shielded bools will leak during contract deployment."
 			);
@@ -4570,7 +4621,7 @@ void TypeChecker::checkLiteralToShielded(
 	{
 		if (literal->passesAddressChecksum())
 			m_errorReporter.warning(
-				9662_error,
+				isExternalCallArg ? 5508_error : 9662_error,
 				_location,
 				"Address Literals converted to shielded addresses will leak during contract deployment."
 			);

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -392,7 +392,8 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 					_var.location(),
 					"Shielded types in constructor parameters are visible in deployment transaction data. "
 					"Contract creation (CREATE/CREATE2) does not encrypt calldata. "
-					"Consider setting shielded state via a post-deployment transaction instead."
+					"Consider setting shielded state via a post-deployment transaction instead. "
+					"This is expected to be fixed in a future release."
 				);
 
 			auto iType = type(_var)->interfaceType(_function.libraryFunction());
@@ -4579,6 +4580,10 @@ void TypeChecker::checkLiteralToShielded(
 			return _extCall;
 		return _other;
 	};
+	bool const isNewExprArg = m_insideNewExpressionArgs > 0;
+	std::string const newExprSuffix =
+		" Contract creation (CREATE/CREATE2) does not encrypt calldata."
+		" This is expected to be fixed in a future release.";
 
 	// Cases that only need annotation().type, not a Literal AST node.
 	// This covers constant expressions (BinaryOperation, UnaryOperation, etc.)
@@ -4589,10 +4594,11 @@ void TypeChecker::checkLiteralToShielded(
 		_targetType.category() == Type::Category::ShieldedInteger
 	)
 	{
+		std::string msg = "Literals converted to shielded integers will leak during contract deployment.";
 		m_errorReporter.warning(
 			pickId(5501_error, 5506_error, 9660_error),
 			_location,
-			"Literals converted to shielded integers will leak during contract deployment."
+			isNewExprArg ? msg + newExprSuffix : msg
 		);
 		return;
 	}
@@ -4602,10 +4608,11 @@ void TypeChecker::checkLiteralToShielded(
 		_targetType.category() == Type::Category::ShieldedInteger
 	)
 	{
+		std::string msg = "Enums converted to shielded integers will leak during contract deployment.";
 		m_errorReporter.warning(
 			pickId(5505_error, 5510_error, 1457_error),
 			_location,
-			"Enums converted to shielded integers will leak during contract deployment."
+			isNewExprArg ? msg + newExprSuffix : msg
 		);
 		return;
 	}
@@ -4615,10 +4622,11 @@ void TypeChecker::checkLiteralToShielded(
 		_targetType.category() == Type::Category::ShieldedFixedBytes
 	)
 	{
+		std::string msg = "FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.";
 		m_errorReporter.warning(
 			pickId(5504_error, 5509_error, 9663_error),
 			_location,
-			"FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment."
+			isNewExprArg ? msg + newExprSuffix : msg
 		);
 		return;
 	}
@@ -4632,20 +4640,26 @@ void TypeChecker::checkLiteralToShielded(
 	{
 		std::string val = literal->value();
 		if (val == "true" || val == "false")
+		{
+			std::string msg = "Bool Literals converted to shielded bools will leak during contract deployment.";
 			m_errorReporter.warning(
 				pickId(5502_error, 5507_error, 9661_error),
 				_location,
-				"Bool Literals converted to shielded bools will leak during contract deployment."
+				isNewExprArg ? msg + newExprSuffix : msg
 			);
+		}
 	}
 	else if (literal->looksLikeAddress() && _targetType.category() == Type::Category::ShieldedAddress)
 	{
 		if (literal->passesAddressChecksum())
+		{
+			std::string msg = "Address Literals converted to shielded addresses will leak during contract deployment.";
 			m_errorReporter.warning(
 				pickId(5503_error, 5508_error, 9662_error),
 				_location,
-				"Address Literals converted to shielded addresses will leak during contract deployment."
+				isNewExprArg ? msg + newExprSuffix : msg
 			);
+		}
 	}
 }
 

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -217,6 +217,12 @@ private:
 	ContractDefinition const* m_currentContract = nullptr;
 	/// Tracks nesting depth of unchecked blocks
 	unsigned m_insideUncheckedBlock = 0;
+	/// Tracks whether we are visiting arguments of a `new` expression (constructor call).
+	/// Shielded literal warnings always fire in this context (init code leak).
+	unsigned m_insideNewExpressionArgs = 0;
+	/// Tracks whether we are visiting arguments of a non-constructor external function call.
+	/// Shielded literal warnings are suppressed here (calldata encrypted by TxSeismic).
+	unsigned m_insideExternalCallArgs = 0;
 
 	langutil::EVMVersion m_evmVersion;
 	std::optional<uint8_t> m_eofVersion;

--- a/test/libsolidity/syntaxTests/array/shielded_array_constructor_length_suint.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_array_constructor_length_suint.sol
@@ -5,5 +5,5 @@ contract C {
     }
 }
 // ----
-// Warning 5501: (95-103): Literals converted to shielded integers will leak during contract deployment.
+// Warning 5501: (95-103): Literals converted to shielded integers will leak during contract deployment. Contract creation (CREATE/CREATE2) does not encrypt calldata. This is expected to be fixed in a future release.
 // TypeError 9553: (95-103): Invalid type for argument in function call. Invalid implicit conversion from suint256 to uint256 requested.

--- a/test/libsolidity/syntaxTests/array/shielded_array_constructor_length_suint.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_array_constructor_length_suint.sol
@@ -5,5 +5,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (95-103): Literals converted to shielded integers will leak during contract deployment.
+// Warning 5501: (95-103): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 9553: (95-103): Invalid type for argument in function call. Invalid implicit conversion from suint256 to uint256 requested.

--- a/test/libsolidity/syntaxTests/array/shielded_array_constructor_length_suint.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_array_constructor_length_suint.sol
@@ -5,5 +5,5 @@ contract C {
     }
 }
 // ----
-// Warning 5501: (95-103): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (95-103): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 9553: (95-103): Invalid type for argument in function call. Invalid implicit conversion from suint256 to uint256 requested.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_abstract.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_abstract.sol
@@ -1,0 +1,8 @@
+// Abstract contract constructor — no warning (not externally visible)
+abstract contract Base {
+    suint256 private val;
+    constructor(suint256 _val) {
+        val = _val;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_inherited.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_inherited.sol
@@ -1,0 +1,13 @@
+// Concrete child inheriting abstract base with shielded constructor param
+abstract contract Base {
+    suint256 private val;
+    constructor(suint256 _val) {
+        val = _val;
+    }
+}
+
+contract Child is Base {
+    constructor(suint256 _v) Base(_v) {}
+}
+// ----
+// Warning 5500: (229-240): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_inherited.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_inherited.sol
@@ -10,4 +10,4 @@ contract Child is Base {
     constructor(suint256 _v) Base(_v) {}
 }
 // ----
-// Warning 5500: (229-240): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
+// Warning 5500: (229-240): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_mixed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_mixed.sol
@@ -1,0 +1,11 @@
+// Constructor with mix of shielded and non-shielded params — only shielded should warn
+contract C {
+    suint256 private sVal;
+    uint256 public uVal;
+    constructor(suint256 _s, uint256 _u) {
+        sVal = _s;
+        uVal = _u;
+    }
+}
+// ----
+// Warning 5500: (171-182): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_mixed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_mixed.sol
@@ -8,4 +8,4 @@ contract C {
     }
 }
 // ----
-// Warning 5500: (171-182): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
+// Warning 5500: (171-182): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_multiple.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_multiple.sol
@@ -1,0 +1,15 @@
+// Constructor with multiple shielded params — each should warn
+contract C {
+    suint256 private a;
+    sbool private b;
+    saddress private c;
+    constructor(suint256 _a, sbool _b, saddress _c) {
+        a = _a;
+        b = _b;
+        c = _c;
+    }
+}
+// ----
+// Warning 5500: (164-175): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
+// Warning 5500: (177-185): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
+// Warning 5500: (187-198): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_multiple.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_multiple.sol
@@ -10,6 +10,6 @@ contract C {
     }
 }
 // ----
-// Warning 5500: (164-175): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
-// Warning 5500: (177-185): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
-// Warning 5500: (187-198): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
+// Warning 5500: (164-175): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// Warning 5500: (177-185): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// Warning 5500: (187-198): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_no_shielded.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_no_shielded.sol
@@ -1,0 +1,8 @@
+// Constructor with only non-shielded params — no warning
+contract C {
+    uint256 public val;
+    constructor(uint256 _val) {
+        val = _val;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_suint.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_suint.sol
@@ -1,0 +1,9 @@
+// Constructor with suint256 param — should warn (CREATE doesn't encrypt calldata)
+contract C {
+    suint256 private val;
+    constructor(suint256 _val) {
+        val = _val;
+    }
+}
+// ----
+// Warning 5500: (140-153): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_suint.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_constructor_param_suint.sol
@@ -6,4 +6,4 @@ contract C {
     }
 }
 // ----
-// Warning 5500: (140-153): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
+// Warning 5500: (140-153): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_constructor_body.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_constructor_body.sol
@@ -1,0 +1,9 @@
+// Constructor body with shielded literal — SHOULD warn (literal in init code)
+contract C {
+    suint256 private val;
+    constructor() {
+        val = suint256(55);
+    }
+}
+// ----
+// Warning 9660: (154-166): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_direct_assignment.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_direct_assignment.sol
@@ -1,0 +1,9 @@
+// Direct assignment of literal to shielded var — SHOULD warn (literal in bytecode)
+contract C {
+    suint256 private myVal;
+    function test() external {
+        myVal = suint256(100);
+    }
+}
+// ----
+// Warning 9660: (174-187): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_enum_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_enum_conversion.sol
@@ -1,0 +1,15 @@
+// Enum to shielded in external call — emits context B warning (5510)
+contract Target {
+    function setVal(suint8 x) external {}
+}
+
+contract Caller {
+    enum Color { Red, Green, Blue }
+    Target t;
+
+    function test() external {
+        t.setVal(suint8(Color.Red));
+    }
+}
+// ----
+// Warning 5510: (252-269): Enums converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_enum_local.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_enum_local.sol
@@ -1,0 +1,11 @@
+// Enum conversion to shielded integer locally — SHOULD warn
+contract C {
+    enum Color { Red, Green, Blue }
+    suint8 private val;
+
+    function test() external {
+        val = suint8(Color.Green);
+    }
+}
+// ----
+// Warning 1457: (182-201): Enums converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_and_new_same_func.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_and_new_same_func.sol
@@ -17,4 +17,4 @@ contract Caller {
 }
 // ----
 // Warning 5506: (323-335): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (356-368): Literals converted to shielded integers will leak during contract deployment.
+// Warning 5501: (356-368): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_and_new_same_func.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_and_new_same_func.sol
@@ -1,0 +1,20 @@
+// External call (context B: 5506) and new expression (context A: 5501) in same function
+contract Child {
+    suint256 private val;
+    constructor(suint256 _v) { val = _v; }
+}
+
+contract Target {
+    function setVal(suint256 x) external {}
+}
+
+contract Caller {
+    Target t;
+    function test() external {
+        t.setVal(suint256(42));
+        new Child(suint256(99));
+    }
+}
+// ----
+// Warning 5506: (323-335): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (356-368): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_and_new_same_func.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_and_new_same_func.sol
@@ -16,6 +16,6 @@ contract Caller {
     }
 }
 // ----
-// Warning 5500: (148-159): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
+// Warning 5500: (148-159): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
 // Warning 5506: (323-335): Literals converted to shielded integers will leak during contract deployment.
-// Warning 5501: (356-368): Literals converted to shielded integers will leak during contract deployment.
+// Warning 5501: (356-368): Literals converted to shielded integers will leak during contract deployment. Contract creation (CREATE/CREATE2) does not encrypt calldata. This is expected to be fixed in a future release.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_and_new_same_func.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_and_new_same_func.sol
@@ -18,4 +18,4 @@ contract Caller {
 // ----
 // Warning 5500: (148-159): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
 // Warning 5506: (323-335): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (356-368): Literals converted to shielded integers will leak during contract deployment.
+// Warning 5501: (356-368): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_and_new_same_func.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_and_new_same_func.sol
@@ -16,5 +16,6 @@ contract Caller {
     }
 }
 // ----
+// Warning 5500: (148-159): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
 // Warning 5506: (323-335): Literals converted to shielded integers will leak during contract deployment.
-// Warning 5501: (356-368): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (356-368): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_call_expression.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_call_expression.sol
@@ -1,0 +1,13 @@
+// Expression in external call arg (arithmetic folded to literal) — context B (5506)
+contract Target {
+    function setVal(suint256 x) external {}
+}
+
+contract Caller {
+    Target t;
+    function test() external {
+        t.setVal(suint256(1 + 2));
+    }
+}
+// ----
+// Warning 5506: (232-247): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_call_multiple_args.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_call_multiple_args.sol
@@ -1,0 +1,15 @@
+// External call with multiple shielded literal args — emits context B warnings
+contract Target {
+    function setVals(suint256 a, sbool b, suint128 c) external {}
+}
+
+contract Caller {
+    Target t;
+    function test() external {
+        t.setVals(suint256(1), sbool(true), suint128(99));
+    }
+}
+// ----
+// Warning 5506: (250-261): Literals converted to shielded integers will leak during contract deployment.
+// Warning 5507: (263-274): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 5506: (276-288): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_call_saddress.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_call_saddress.sol
@@ -1,0 +1,13 @@
+// External call with saddress literal — emits context B warning (5508)
+contract Target {
+    function setVal(saddress x) external {}
+}
+
+contract Caller {
+    Target t;
+    function test() external {
+        t.setVal(saddress(0xdCad3a6d3569DF655070DEd06cb7A1b2Ccd1D3AF));
+    }
+}
+// ----
+// Warning 5508: (219-271): Address Literals converted to shielded addresses will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_call_sbool.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_call_sbool.sol
@@ -1,0 +1,13 @@
+// External call with sbool literal — emits context B warning (5507)
+contract Target {
+    function setVal(sbool x) external {}
+}
+
+contract Caller {
+    Target t;
+    function test() external {
+        t.setVal(sbool(true));
+    }
+}
+// ----
+// Warning 5507: (213-224): Bool Literals converted to shielded bools will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_call_sbytes.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_call_sbytes.sol
@@ -1,0 +1,13 @@
+// External call with sbytes4 literal — emits context B warning (5509)
+contract Target {
+    function setVal(sbytes4 x) external {}
+}
+
+contract Caller {
+    Target t;
+    function test() external {
+        t.setVal(sbytes4(0x01020304));
+    }
+}
+// ----
+// Warning 5509: (217-236): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_call_suint.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_call_suint.sol
@@ -1,0 +1,13 @@
+// External call with suint literal — emits context B warning (5506)
+contract Target {
+    function setVal(suint256 x) external {}
+}
+
+contract Caller {
+    Target t;
+    function test() external {
+        t.setVal(suint256(42));
+    }
+}
+// ----
+// Warning 5506: (216-228): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_call_via_state_var.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_external_call_via_state_var.sol
@@ -1,0 +1,13 @@
+// External call through interface-typed state var — context B warning (5506)
+interface IVault {
+    function deposit(suint256 amount) external;
+}
+
+contract User {
+    IVault vault;
+    function test() external {
+        vault.deposit(suint256(1000));
+    }
+}
+// ----
+// Warning 5506: (237-251): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_interface_call.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_interface_call.sol
@@ -1,0 +1,13 @@
+// Call through interface — emits context B warning (5506)
+interface ITarget {
+    function setVal(suint256 x) external;
+}
+
+contract Caller {
+    ITarget t;
+    function test() external {
+        t.setVal(suint256(42));
+    }
+}
+// ----
+// Warning 5506: (207-219): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_internal_call.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_internal_call.sol
@@ -1,0 +1,14 @@
+// Internal function call with shielded literal — SHOULD warn (literal in same contract bytecode)
+contract C {
+    suint256 private val;
+
+    function _setVal(suint256 _v) internal {
+        val = _v;
+    }
+
+    function test() external {
+        _setVal(suint256(77));
+    }
+}
+// ----
+// Warning 9660: (257-269): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_library_internal.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_library_internal.sol
@@ -1,0 +1,13 @@
+// Library internal function with shielded literal — SHOULD warn (same bytecode)
+library Lib {
+    function helper(suint256 x) internal pure returns(suint256) { return x; }
+}
+
+contract C {
+    suint256 private val;
+    function test() external {
+        val = Lib.helper(suint256(5));
+    }
+}
+// ----
+// Warning 9660: (273-284): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_local_var.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_local_var.sol
@@ -1,0 +1,9 @@
+// Local variable initialized from literal — SHOULD warn (literal in bytecode)
+contract C {
+    function test() external pure {
+        suint256 x = suint256(42);
+    }
+}
+// ----
+// Warning 9660: (151-163): Literals converted to shielded integers will leak during contract deployment.
+// Warning 2072: (138-148): Unused local variable.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_mapping_value.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_mapping_value.sol
@@ -1,0 +1,9 @@
+// Mapping value assignment with shielded literal — SHOULD warn
+contract C {
+    mapping(uint256 => suint256) private m;
+    function test() external {
+        m[0] = suint256(99);
+    }
+}
+// ----
+// Warning 9660: (169-181): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_mixed_external_and_local.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_mixed_external_and_local.sol
@@ -1,0 +1,17 @@
+// Mix of external call (context B: 5506) and local assignment (context C: 9660)
+contract Target {
+    function setVal(suint256 x) external {}
+}
+
+contract Caller {
+    Target t;
+    suint256 private localVal;
+
+    function test() external {
+        t.setVal(suint256(42));
+        localVal = suint256(100);
+    }
+}
+// ----
+// Warning 5506: (258-270): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (292-305): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_multiple_external_targets.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_multiple_external_targets.sol
@@ -1,0 +1,20 @@
+// Multiple external call targets — both emit context B warnings (5506)
+contract TokenA {
+    function transfer(suint256 amount) external {}
+}
+
+contract TokenB {
+    function transfer(suint256 amount) external {}
+}
+
+contract Router {
+    TokenA a;
+    TokenB b;
+    function test() external {
+        a.transfer(suint256(100));
+        b.transfer(suint256(200));
+    }
+}
+// ----
+// Warning 5506: (314-327): Literals converted to shielded integers will leak during contract deployment.
+// Warning 5506: (349-362): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_nested_external_call.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_nested_external_call.sol
@@ -1,0 +1,22 @@
+// Nested external calls — both emit context B warnings (5506)
+contract A {
+    function doSomething(suint256 x) external {}
+}
+
+contract B {
+    function setVal(suint256 x) external {}
+}
+
+contract Caller {
+    A a;
+    B b;
+    function test() external {
+        // Both are external calls; the literal suint256(7) is in a.doSomething()
+        // calldata. No warning expected.
+        a.doSomething(suint256(7));
+        b.setVal(suint256(42));
+    }
+}
+// ----
+// Warning 5506: (403-414): Literals converted to shielded integers will leak during contract deployment.
+// Warning 5506: (434-446): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_expression.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_expression.sol
@@ -10,4 +10,5 @@ contract Parent {
     }
 }
 // ----
-// Warning 5501: (239-251): Literals converted to shielded integers will leak during contract deployment.
+// Warning 5500: (138-151): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
+// Warning 9660: (239-251): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_expression.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_expression.sol
@@ -10,4 +10,4 @@ contract Parent {
     }
 }
 // ----
-// Warning 9660: (239-251): Literals converted to shielded integers will leak during contract deployment.
+// Warning 5501: (239-251): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_expression.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_expression.sol
@@ -10,5 +10,5 @@ contract Parent {
     }
 }
 // ----
-// Warning 5500: (138-151): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
-// Warning 5501: (239-251): Literals converted to shielded integers will leak during contract deployment.
+// Warning 5500: (138-151): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// Warning 5501: (239-251): Literals converted to shielded integers will leak during contract deployment. Contract creation (CREATE/CREATE2) does not encrypt calldata. This is expected to be fixed in a future release.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_expression.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_expression.sol
@@ -11,4 +11,4 @@ contract Parent {
 }
 // ----
 // Warning 5500: (138-151): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
-// Warning 9660: (239-251): Literals converted to shielded integers will leak during contract deployment.
+// Warning 5501: (239-251): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_expression.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_expression.sol
@@ -1,0 +1,13 @@
+// new expression with shielded literal — SHOULD warn (literal in init code)
+contract Child {
+    suint256 private val;
+    constructor(suint256 _val) { val = _val; }
+}
+
+contract Parent {
+    function test() external {
+        new Child(suint256(99));
+    }
+}
+// ----
+// Warning 9660: (239-251): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_with_multiple_types.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_with_multiple_types.sol
@@ -11,5 +11,7 @@ contract Parent {
     }
 }
 // ----
-// Warning 5501: (258-270): Literals converted to shielded integers will leak during contract deployment.
-// Warning 5502: (272-283): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 5500: (145-156): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
+// Warning 5500: (158-166): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
+// Warning 9660: (258-270): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9661: (272-283): Bool Literals converted to shielded bools will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_with_multiple_types.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_with_multiple_types.sol
@@ -11,5 +11,5 @@ contract Parent {
     }
 }
 // ----
-// Warning 9660: (258-270): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9661: (272-283): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 5501: (258-270): Literals converted to shielded integers will leak during contract deployment.
+// Warning 5502: (272-283): Bool Literals converted to shielded bools will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_with_multiple_types.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_with_multiple_types.sol
@@ -13,5 +13,5 @@ contract Parent {
 // ----
 // Warning 5500: (145-156): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
 // Warning 5500: (158-166): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
-// Warning 9660: (258-270): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9661: (272-283): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 5501: (258-270): Literals converted to shielded integers will leak during contract deployment.
+// Warning 5502: (272-283): Bool Literals converted to shielded bools will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_with_multiple_types.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_with_multiple_types.sol
@@ -11,7 +11,7 @@ contract Parent {
     }
 }
 // ----
-// Warning 5500: (145-156): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
-// Warning 5500: (158-166): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead.
-// Warning 5501: (258-270): Literals converted to shielded integers will leak during contract deployment.
-// Warning 5502: (272-283): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 5500: (145-156): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// Warning 5500: (158-166): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// Warning 5501: (258-270): Literals converted to shielded integers will leak during contract deployment. Contract creation (CREATE/CREATE2) does not encrypt calldata. This is expected to be fixed in a future release.
+// Warning 5502: (272-283): Bool Literals converted to shielded bools will leak during contract deployment. Contract creation (CREATE/CREATE2) does not encrypt calldata. This is expected to be fixed in a future release.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_with_multiple_types.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_with_multiple_types.sol
@@ -1,0 +1,15 @@
+// new expression with multiple shielded types — all SHOULD warn
+contract Child {
+    suint256 private a;
+    sbool private b;
+    constructor(suint256 _a, sbool _b) { a = _a; b = _b; }
+}
+
+contract Parent {
+    function test() external {
+        new Child(suint256(10), sbool(true));
+    }
+}
+// ----
+// Warning 9660: (258-270): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9661: (272-283): Bool Literals converted to shielded bools will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_public_function_internal_call.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_public_function_internal_call.sol
@@ -1,0 +1,12 @@
+// Public function called internally (no `.`) with shielded literal — SHOULD warn
+contract C {
+    suint256 private val;
+    function setVal(suint256 x) public {
+        val = x;
+    }
+    function test() external {
+        setVal(suint256(42));
+    }
+}
+// ----
+// Warning 9660: (233-245): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_push_not_external.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_push_not_external.sol
@@ -1,0 +1,10 @@
+// arr.push() is a built-in, NOT an external call — SHOULD warn
+contract C {
+    suint256[] private arr;
+    function test() external {
+        arr.push(suint256(42));
+    }
+}
+// ----
+// Warning 9665: (83-105): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// Warning 9660: (155-167): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_return_value_assignment.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_return_value_assignment.sol
@@ -1,0 +1,13 @@
+// External call return value (uint256) assigned to shielded var — no literal, no shielded-literal warning
+contract Target {
+    function getVal() external pure returns(uint256) { return 1; }
+}
+
+contract Caller {
+    Target t;
+    suint256 private val;
+    function test() external {
+        val = suint256(t.getVal());
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_ternary.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_ternary.sol
@@ -1,0 +1,10 @@
+// Ternary with shielded literal — SHOULD warn (literal in bytecode regardless of branch)
+contract C {
+    suint256 private val;
+    function test(bool cond) external {
+        val = cond ? suint256(1) : suint256(2);
+    }
+}
+// ----
+// Warning 9660: (192-203): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (206-217): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_this_call.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_this_call.sol
@@ -1,0 +1,10 @@
+// this.f() is an external call — emits context B warning (5506)
+contract C {
+    function setVal(suint256 x) external {}
+
+    function test() external {
+        this.setVal(suint256(42));
+    }
+}
+// ----
+// Warning 5506: (176-188): Literals converted to shielded integers will leak during contract deployment.


### PR DESCRIPTION
## Summary

Shielded literal warnings currently all emit the same warning IDs regardless of AST context, making it impossible for downstream tools (sforge) to selectively suppress false positives in test/script files. Additionally, the compiler silently allows shielded types as constructor parameters even though CREATE/CREATE2 does not encrypt calldata — meaning shielded values passed to constructors are visible in deployment transaction data.

### Changes

**1. New warning for shielded constructor parameters (5500)**

Fires on any non-abstract constructor with shielded parameter types. Catches both literals and variables passed to constructors — the root cause of CREATE-based leaks.

```
Warning 5500: Shielded types in constructor parameters are visible in deployment
transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata.
Consider setting shielded state via a post-deployment transaction instead.
This is expected to be fixed in a future release.
```

**2. Distinct warning IDs for literal context in `new(...)` args (5501–5505)**

When a literal-to-shielded conversion occurs inside a `new` expression's arguments, the child contract gets deployed via CREATE — the literal leaks in init code even if the caller is a test contract.

```
Warning 5501: Literals converted to shielded integers will leak during contract
deployment. Contract creation (CREATE/CREATE2) does not encrypt calldata.
This is expected to be fixed in a future release.
```

**3. Distinct warning IDs for literal context in external call args (5506–5510)**

When a literal-to-shielded conversion occurs inside an external function call's arguments, the literal is in the caller's bytecode but calldata is encrypted by TxSeismic. Safe to suppress in test/script files.

### Warning ID mapping

| Type | `new(...)` args | External call args | Other contexts |
|------|-----------------|--------------------|----------------|
| integer | 5501 | 5506 | 9660 |
| bool | 5502 | 5507 | 9661 |
| address | 5503 | 5508 | 9662 |
| fixedbytes | 5504 | 5509 | 9663 |
| enum | 5505 | 5510 | 1457 |
| constructor param | 5500 | — | — |

### Intended use by seismic-compilers

- **`src/`** files: show all warnings
- **`test/` and `script/`** files:
  - **Keep**: 5500 (constructor param), 5501–5505 (literal in `new(...)` — child gets deployed)
  - **Suppress**: 5506–5510 (external call), 9660–9663 + 1457 (other — test bytecode never deployed)

### Detection logic

External calls detected via `MemberAccess` on contract/interface-typed variables and `this`. Built-in member functions (`arr.push()`) excluded. When `new` and external call contexts are nested, `new` takes priority.

### Tests

29 new syntax test files. Full syntax test suite: 3807/3807, zero regressions.