### PR TITLE
feat: shielded number literal suffix `s` for suint/sint

### DIFF
--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -1017,6 +1017,15 @@ Token Scanner::scanNumber(char _charSeen)
 			return setError(ScannerError::IllegalExponent);
 		scanDecimalDigits();
 	}
+	// Check for shielded literal suffix 's'.
+	// Only treat as suffix if 's' is not followed by an identifier character
+	// (so that e.g. `1seconds` still errors as expected).
+	if (m_char == 's' && (m_source.isPastEndOfInput(1) || !isIdentifierPart(m_source.get(1))))
+	{
+		advance(); // consume the 's'
+		literal.complete();
+		return Token::ShieldedNumber;
+	}
 	// The source character immediately following a numeric literal must
 	// not be an identifier start or a decimal digit; see ECMA-262
 	// section 7.8.3, page 17 (note that we read only one decimal digit

--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -233,6 +233,7 @@ namespace solidity::langutil
 	K(TrueLiteral, "true", 0)                                          \
 	K(FalseLiteral, "false", 0)                                        \
 	T(Number, nullptr, 0)                                              \
+	T(ShieldedNumber, nullptr, 0)                                      \
 	T(StringLiteral, nullptr, 0)                                       \
 	T(UnicodeStringLiteral, nullptr, 0)                                \
 	T(HexStringLiteral, nullptr, 0)                                    \

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -285,7 +285,7 @@ bool SyntaxChecker::visit(Literal const& _literal)
 			"Contains invalid UTF-8 sequence at position " + toString(invalidSequence) + "."
 		);
 
-	if (_literal.token() != Token::Number)
+	if (_literal.token() != Token::Number && _literal.token() != Token::ShieldedNumber)
 		return true;
 
 	ASTString const& value = _literal.value();

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -4275,6 +4275,14 @@ void TypeChecker::endVisit(Literal const& _literal)
 			"You can use an expression of the form \"0x1234 * 1 days\" instead."
 		);
 
+	if (_literal.token() == Token::ShieldedNumber)
+		m_errorReporter.warning(
+			9660_error,
+			_literal.location(),
+			"Shielded number literals are converted to shielded integers whose values "
+			"will be visible in contract creation code during deployment."
+		);
+
 	if (_literal.subDenomination() == Literal::SubDenomination::Year)
 		m_errorReporter.typeError(
 			4820_error,

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -4277,10 +4277,9 @@ void TypeChecker::endVisit(Literal const& _literal)
 
 	if (_literal.token() == Token::ShieldedNumber)
 		m_errorReporter.warning(
-			9660_error,
+			9667_error,
 			_literal.location(),
-			"Shielded number literals are converted to shielded integers whose values "
-			"will be visible in contract creation code during deployment."
+			"Shielded number literals will leak during contract deployment."
 		);
 
 	if (_literal.subDenomination() == Literal::SubDenomination::Year)

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -1030,7 +1030,7 @@ ASTString Literal::valueWithoutUnderscores() const
 
 bool Literal::isHexNumber() const
 {
-	if (token() != Token::Number)
+	if (token() != Token::Number && token() != Token::ShieldedNumber)
 		return false;
 	return boost::starts_with(value(), "0x");
 }

--- a/libsolidity/ast/ASTJsonExporter.cpp
+++ b/libsolidity/ast/ASTJsonExporter.cpp
@@ -1128,6 +1128,8 @@ std::string ASTJsonExporter::literalTokenKind(Token _token)
 	{
 	case Token::Number:
 		return "number";
+	case Token::ShieldedNumber:
+		return "shieldedNumber";
 	case Token::StringLiteral:
 		return "string";
 	case Token::UnicodeStringLiteral:

--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -1164,6 +1164,8 @@ Token ASTJsonImporter::literalTokenKind(Json const& _node)
 	Token tok;
 	if (_node["kind"].get<std::string>() == "number")
 		tok = Token::Number;
+	else if (_node["kind"].get<std::string>() == "shieldedNumber")
+		tok = Token::ShieldedNumber;
 	else if (_node["kind"].get<std::string>() == "string")
 		tok = Token::StringLiteral;
 	else if (_node["kind"].get<std::string>() == "unicodeString")

--- a/libsolidity/ast/TypeProvider.cpp
+++ b/libsolidity/ast/TypeProvider.cpp
@@ -521,6 +521,7 @@ Type const* TypeProvider::forLiteral(Literal const& _literal)
 	case Token::FalseLiteral:
 		return boolean();
 	case Token::Number:
+	case Token::ShieldedNumber:
 		return rationalNumber(_literal);
 	case Token::StringLiteral:
 	case Token::UnicodeStringLiteral:
@@ -533,7 +534,8 @@ Type const* TypeProvider::forLiteral(Literal const& _literal)
 
 RationalNumberType const* TypeProvider::rationalNumber(Literal const& _literal)
 {
-	solAssert(_literal.token() == Token::Number, "");
+	solAssert(_literal.token() == Token::Number || _literal.token() == Token::ShieldedNumber, "");
+	bool isShielded = _literal.token() == Token::ShieldedNumber;
 	std::tuple<bool, rational> validLiteral = RationalNumberType::isValidLiteral(_literal);
 	if (std::get<0>(validLiteral))
 	{
@@ -545,7 +547,7 @@ RationalNumberType const* TypeProvider::rationalNumber(Literal const& _literal)
 				compatibleBytesType = fixedBytes(static_cast<unsigned>(digitCount / 2));
 		}
 
-		return rationalNumber(std::get<1>(validLiteral), compatibleBytesType);
+		return rationalNumber(std::get<1>(validLiteral), compatibleBytesType, isShielded);
 	}
 	return nullptr;
 }
@@ -657,9 +659,9 @@ FunctionType const* TypeProvider::function(
 	);
 }
 
-RationalNumberType const* TypeProvider::rationalNumber(rational const& _value, Type const* _compatibleBytesType)
+RationalNumberType const* TypeProvider::rationalNumber(rational const& _value, Type const* _compatibleBytesType, bool _shielded)
 {
-	return createAndGet<RationalNumberType>(_value, _compatibleBytesType);
+	return createAndGet<RationalNumberType>(_value, _compatibleBytesType, _shielded);
 }
 
 ArrayType const* TypeProvider::array(DataLocation _location, bool _isString)

--- a/libsolidity/ast/TypeProvider.h
+++ b/libsolidity/ast/TypeProvider.h
@@ -194,7 +194,8 @@ public:
 
 	static RationalNumberType const* rationalNumber(
 		rational const& _value,
-		Type const* _compatibleBytesType = nullptr
+		Type const* _compatibleBytesType = nullptr,
+		bool _shielded = false
 	);
 
 	static ContractType const* contract(ContractDefinition const& _contract, bool _isSuper = false);

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1136,13 +1136,26 @@ BoolResult RationalNumberType::isImplicitlyConvertibleTo(Type const& _convertTo)
 	{
 	case Category::Integer:
 	{
+		if (m_shielded)
+			return BoolResult::err("Shielded number literal cannot be implicitly converted to non-shielded type.");
 		if (isFractional())
 			return false;
 		IntegerType const& targetType = dynamic_cast<IntegerType const&>(_convertTo);
 		return fitsIntegerType(m_value.numerator(), targetType);
 	}
+	case Category::ShieldedInteger:
+	{
+		if (!m_shielded)
+			return false;
+		if (isFractional())
+			return false;
+		ShieldedIntegerType const& targetType = dynamic_cast<ShieldedIntegerType const&>(_convertTo);
+		return fitsIntegerType(m_value.numerator(), targetType);
+	}
 	case Category::FixedPoint:
 	{
+		if (m_shielded)
+			return BoolResult::err("Shielded number literal cannot be implicitly converted to non-shielded type.");
 		FixedPointType const& targetType = dynamic_cast<FixedPointType const&>(_convertTo);
 		// Store a negative number into an unsigned.
 		if (isNegative() && !targetType.isSigned())
@@ -1156,6 +1169,8 @@ BoolResult RationalNumberType::isImplicitlyConvertibleTo(Type const& _convertTo)
 		return fitsIntoBits(value.numerator(), targetType.numBits(), targetType.isSigned());
 	}
 	case Category::FixedBytes:
+		if (m_shielded)
+			return BoolResult::err("Shielded number literal cannot be implicitly converted to non-shielded type.");
 		return (m_value == rational(0)) || (m_compatibleBytesType && *m_compatibleBytesType == _convertTo);
 	default:
 		return false;
@@ -1204,7 +1219,7 @@ BoolResult RationalNumberType::isExplicitlyConvertibleTo(Type const& _convertTo)
 TypeResult RationalNumberType::unaryOperatorResult(Token _operator) const
 {
 	if (std::optional<rational> value = ConstantEvaluator::evaluateUnaryOperator(_operator, m_value))
-		return TypeResult{TypeProvider::rationalNumber(*value)};
+		return TypeResult{TypeProvider::rationalNumber(*value, nullptr, m_shielded)};
 	else
 		return nullptr;
 }
@@ -1277,7 +1292,11 @@ TypeResult RationalNumberType::binaryOperatorResult(Token _operator, Type const*
 		if (value->numerator() != 0 && std::max(boost::multiprecision::msb(abs(value->numerator())), boost::multiprecision::msb(abs(value->denominator()))) > 4096)
 			return TypeResult::err("Precision of rational constants is limited to 4096 bits.");
 
-		return TypeResult{TypeProvider::rationalNumber(*value)};
+		// Mixed shielded/non-shielded arithmetic between rationals is not allowed.
+		if (m_shielded != other.m_shielded)
+			return nullptr;
+
+		return TypeResult{TypeProvider::rationalNumber(*value, nullptr, m_shielded)};
 	}
 	else
 		return nullptr;
@@ -1289,10 +1308,11 @@ std::string RationalNumberType::richIdentifier() const
 	// but let just make it deterministic here.
 	bigint numerator = abs(m_value.numerator());
 	bigint denominator = abs(m_value.denominator());
+	std::string prefix = m_shielded ? "t_shielded_rational_" : "t_rational_";
 	if (m_value < 0)
-		return "t_rational_minus_" + numerator.str() + "_by_" + denominator.str();
+		return prefix + "minus_" + numerator.str() + "_by_" + denominator.str();
 	else
-		return "t_rational_" + numerator.str() + "_by_" + denominator.str();
+		return prefix + numerator.str() + "_by_" + denominator.str();
 }
 
 bool RationalNumberType::operator==(Type const& _other) const
@@ -1300,7 +1320,7 @@ bool RationalNumberType::operator==(Type const& _other) const
 	if (_other.category() != category())
 		return false;
 	RationalNumberType const& other = dynamic_cast<RationalNumberType const&>(_other);
-	return m_value == other.m_value;
+	return m_value == other.m_value && m_shielded == other.m_shielded;
 }
 
 std::string RationalNumberType::bigintToReadableString(bigint const& _num)
@@ -1316,12 +1336,13 @@ std::string RationalNumberType::bigintToReadableString(bigint const& _num)
 
 std::string RationalNumberType::toString(bool) const
 {
+	std::string prefix = m_shielded ? "shielded_" : "";
 	if (!isFractional())
-		return "int_const " + bigintToReadableString(m_value.numerator());
+		return prefix + "int_const " + bigintToReadableString(m_value.numerator());
 
 	std::string numerator = bigintToReadableString(m_value.numerator());
 	std::string denominator = bigintToReadableString(m_value.denominator());
-	return "rational_const " + numerator + " / " + denominator;
+	return prefix + "rational_const " + numerator + " / " + denominator;
 }
 
 u256 RationalNumberType::literalValue(Literal const*) const
@@ -1356,7 +1377,7 @@ u256 RationalNumberType::literalValue(Literal const*) const
 Type const* RationalNumberType::mobileType() const
 {
 	if (!isFractional())
-		return integerType();
+		return m_shielded ? static_cast<Type const*>(shieldedIntegerType()) : integerType();
 	else
 		return fixedPointType();
 }
@@ -1374,6 +1395,22 @@ IntegerType const* RationalNumberType::integerType() const
 		return TypeProvider::integer(
 			std::max(numberEncodingSize(value), 1u) * 8,
 			negative ? IntegerType::Modifier::Signed : IntegerType::Modifier::Unsigned
+		);
+}
+
+ShieldedIntegerType const* RationalNumberType::shieldedIntegerType() const
+{
+	solAssert(!isFractional(), "shieldedIntegerType() called for fractional number.");
+	bigint value = m_value.numerator();
+	bool negative = (value < 0);
+	if (negative)
+		value = ((0 - value) - 1) << 1;
+	if (value > u256(-1))
+		return nullptr;
+	else
+		return TypeProvider::shieldedInteger(
+			std::max(numberEncodingSize(value), 1u) * 8,
+			negative ? ShieldedIntegerType::Modifier::Signed : ShieldedIntegerType::Modifier::Unsigned
 		);
 }
 

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -656,8 +656,8 @@ private:
 class RationalNumberType: public Type
 {
 public:
-	explicit RationalNumberType(rational _value, Type const* _compatibleBytesType = nullptr):
-		m_value(std::move(_value)), m_compatibleBytesType(_compatibleBytesType)
+	explicit RationalNumberType(rational _value, Type const* _compatibleBytesType = nullptr, bool _shielded = false):
+		m_value(std::move(_value)), m_compatibleBytesType(_compatibleBytesType), m_shielded(_shielded)
 	{}
 
 	Category category() const override { return Category::RationalNumber; }
@@ -683,6 +683,8 @@ public:
 
 	/// @returns the smallest integer type that can hold the value or an empty pointer if not possible.
 	IntegerType const* integerType() const;
+	/// @returns the smallest shielded integer type that can hold the value or an empty pointer if not possible.
+	ShieldedIntegerType const* shieldedIntegerType() const;
 	/// @returns the smallest fixed type that can hold the value or incurs the least precision loss,
 	/// unless the value was truncated, then a suitable type will be chosen to indicate such event.
 	/// If the integer part does not fit, returns an empty pointer.
@@ -697,6 +699,9 @@ public:
 	/// @returns true if the value is zero.
 	bool isZero() const { return m_value == 0; }
 
+	/// @returns true if the literal was written with the shielded suffix (e.g. 1s).
+	bool isShielded() const { return m_shielded; }
+
 	/// @returns true if the literal is a valid integer.
 	static std::tuple<bool, rational> isValidLiteral(Literal const& _literal);
 
@@ -706,6 +711,9 @@ private:
 	/// Bytes type to which the rational can be implicitly converted.
 	/// Empty for all rationals that are not directly parsed from hex literals.
 	Type const* m_compatibleBytesType;
+
+	/// Whether this rational was written with the shielded suffix (e.g. 1s).
+	bool m_shielded = false;
 
 	/// @returns true if the literal is a valid rational number.
 	static std::tuple<bool, rational> parseRational(std::string const& _value);

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -2379,6 +2379,7 @@ ASTPointer<Expression> Parser::parseLiteral()
 	case Token::TrueLiteral:
 	case Token::FalseLiteral:
 	case Token::Number:
+	case Token::ShieldedNumber:
 	{
 		nodeFactory.markEndPosition();
 		advance();
@@ -2414,6 +2415,12 @@ ASTPointer<Expression> Parser::parseLiteral()
 		return nodeFactory.createNode<Literal>(initialToken, std::move(value), subDenomination);
 	}
 
+	if (initialToken == Token::ShieldedNumber && (
+		TokenTraits::isEtherSubdenomination(m_scanner->currentToken()) ||
+		TokenTraits::isTimeSubdenomination(m_scanner->currentToken())
+	))
+		fatalParserError(9832_error, "Shielded number literals cannot be used with unit denominations.");
+
 	return nodeFactory.createNode<Literal>(initialToken, std::move(value), Literal::SubDenomination::None);
 }
 
@@ -2429,6 +2436,7 @@ ASTPointer<Expression> Parser::parsePrimaryExpression()
 	case Token::TrueLiteral:
 	case Token::FalseLiteral:
 	case Token::Number:
+	case Token::ShieldedNumber:
 	case Token::StringLiteral:
 	case Token::UnicodeStringLiteral:
 	case Token::HexStringLiteral:

--- a/test/libsolidity/semanticTests/shielded_literal_all_arithmetic.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_all_arithmetic.sol
@@ -1,0 +1,71 @@
+// Comprehensive arithmetic test covering all operations with shielded literals
+contract C {
+    suint256 private x;
+
+    function testAdd() public returns (uint256) {
+        x = 100s + 200s;
+        return uint(x);
+    }
+
+    function testSub() public returns (uint256) {
+        x = 200s - 100s;
+        return uint(x);
+    }
+
+    function testMul() public returns (uint256) {
+        x = 100s * 200s;
+        return uint(x);
+    }
+
+    function testDiv() public returns (uint256) {
+        x = 200s / 100s;
+        return uint(x);
+    }
+
+    function testMod() public returns (uint256) {
+        x = 201s % 100s;
+        return uint(x);
+    }
+
+    function testExp() public returns (uint256) {
+        x = 3s ** 4s;
+        return uint(x);
+    }
+
+    function testShiftLeft() public returns (uint256) {
+        x = 1s << 10s;
+        return uint(x);
+    }
+
+    function testShiftRight() public returns (uint256) {
+        x = 1024s >> 5s;
+        return uint(x);
+    }
+
+    function testBitAnd() public returns (uint256) {
+        x = 0x0Cs & 0x0As;
+        return uint(x);
+    }
+
+    function testBitOr() public returns (uint256) {
+        x = 0x0Cs | 0x0As;
+        return uint(x);
+    }
+
+    function testBitXor() public returns (uint256) {
+        x = 0x0Cs ^ 0x0As;
+        return uint(x);
+    }
+}
+// ----
+// testAdd() -> 300
+// testSub() -> 100
+// testMul() -> 20000
+// testDiv() -> 2
+// testMod() -> 1
+// testExp() -> 81
+// testShiftLeft() -> 1024
+// testShiftRight() -> 32
+// testBitAnd() -> 8
+// testBitOr() -> 14
+// testBitXor() -> 6

--- a/test/libsolidity/semanticTests/shielded_literal_array_ops.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_array_ops.sol
@@ -1,0 +1,28 @@
+contract C {
+    suint256[] private arr;
+    suint8[3] private fixed_arr;
+
+    function testPush() public returns (uint256) {
+        arr.push(42s);
+        return uint(arr[0]);
+    }
+
+    function testMultiplePush() public returns (uint256, uint256, uint256) {
+        arr.push(10s);
+        arr.push(20s);
+        arr.push(30s);
+        // arr[0] is 42 from testPush; indices 1,2,3 are from this call
+        return (uint(arr[1]), uint(arr[2]), uint(arr[3]));
+    }
+
+    function testFixedArray() public returns (uint256, uint256, uint256) {
+        fixed_arr[0] = 1s;
+        fixed_arr[1] = 2s;
+        fixed_arr[2] = 255s;
+        return (uint(uint8(fixed_arr[0])), uint(uint8(fixed_arr[1])), uint(uint8(fixed_arr[2])));
+    }
+}
+// ----
+// testPush() -> 42
+// testMultiplePush() -> 10, 20, 30
+// testFixedArray() -> 1, 2, 255

--- a/test/libsolidity/semanticTests/shielded_literal_bitwise_ops.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_bitwise_ops.sol
@@ -1,0 +1,36 @@
+contract C {
+    suint256 private x;
+
+    function testAnd() public returns (uint256) {
+        x = 0xFFs & 0x0Fs;
+        return uint(x);
+    }
+
+    function testOr() public returns (uint256) {
+        x = 0xF0s | 0x0Fs;
+        return uint(x);
+    }
+
+    function testXor() public returns (uint256) {
+        x = 0xFFs ^ 0x0Fs;
+        return uint(x);
+    }
+
+    function testNot() public returns (uint256) {
+        // ~0s is shielded_int_const -1 (same as ~0 being int_const -1 upstream)
+        // Must use typed NOT: ~suint8(0s) to get 255
+        suint8 a = ~suint8(0s);
+        return uint(uint8(a));
+    }
+
+    function testChained() public returns (uint256) {
+        x = (0xFFs & 0xF0s) | 0x0Fs;
+        return uint(x);
+    }
+}
+// ----
+// testAnd() -> 0x0f
+// testOr() -> 0xff
+// testXor() -> 0xf0
+// testNot() -> 0xff
+// testChained() -> 0xff

--- a/test/libsolidity/semanticTests/shielded_literal_comparison_ops.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_comparison_ops.sol
@@ -1,0 +1,50 @@
+contract C {
+    function testEq() public pure returns (bool) {
+        sbool r = (42s == 42s);
+        return bool(r);
+    }
+
+    function testNeq() public pure returns (bool) {
+        sbool r = (1s != 2s);
+        return bool(r);
+    }
+
+    function testLt() public pure returns (bool) {
+        sbool r = (1s < 2s);
+        return bool(r);
+    }
+
+    function testGt() public pure returns (bool) {
+        sbool r = (2s > 1s);
+        return bool(r);
+    }
+
+    function testLte() public pure returns (bool) {
+        sbool r = (1s <= 1s);
+        return bool(r);
+    }
+
+    function testGte() public pure returns (bool) {
+        sbool r = (2s >= 1s);
+        return bool(r);
+    }
+
+    function testLtFalse() public pure returns (bool) {
+        sbool r = (2s < 1s);
+        return bool(r);
+    }
+
+    function testEqFalse() public pure returns (bool) {
+        sbool r = (1s == 2s);
+        return bool(r);
+    }
+}
+// ----
+// testEq() -> true
+// testNeq() -> true
+// testLt() -> true
+// testGt() -> true
+// testLte() -> true
+// testGte() -> true
+// testLtFalse() -> false
+// testEqFalse() -> false

--- a/test/libsolidity/semanticTests/shielded_literal_constructor.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_constructor.sol
@@ -1,0 +1,20 @@
+contract C {
+    suint256 private x;
+    sint256 private y;
+
+    constructor() {
+        x = 42s;
+        y = -100s;
+    }
+
+    function getX() public returns (uint256) {
+        return uint(x);
+    }
+
+    function getY() public returns (int256) {
+        return int(y);
+    }
+}
+// ----
+// getX() -> 42
+// getY() -> -100

--- a/test/libsolidity/semanticTests/shielded_literal_control_flow.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_control_flow.sol
@@ -1,0 +1,31 @@
+contract C {
+    suint256 private x;
+
+    function testIfElse() public returns (uint256) {
+        x = 10s;
+        if (x == 10s) {
+            x = 20s;
+        } else {
+            x = 30s;
+        }
+        return uint(x);
+    }
+
+    function testTernary(bool cond) public returns (uint256) {
+        x = cond ? 100s : 200s;
+        return uint(x);
+    }
+
+    function testLoop() public returns (uint256) {
+        x = 0s;
+        for (suint256 i = 0s; i < 5s; i = i + 1s) {
+            x = x + 10s;
+        }
+        return uint(x);
+    }
+}
+// ----
+// testIfElse() -> 20
+// testTernary(bool): true -> 100
+// testTernary(bool): false -> 200
+// testLoop() -> 50

--- a/test/libsolidity/semanticTests/shielded_literal_double_negation.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_double_negation.sol
@@ -1,0 +1,22 @@
+contract C {
+    sint256 private x;
+
+    function testNeg() public returns (int256) {
+        x = -42s;
+        return int(x);
+    }
+
+    function testDoubleNeg() public returns (int256) {
+        x = -(-42s);
+        return int(x);
+    }
+
+    function testTripleNeg() public returns (int256) {
+        x = -(-(-42s));
+        return int(x);
+    }
+}
+// ----
+// testNeg() -> -42
+// testDoubleNeg() -> 42
+// testTripleNeg() -> -42

--- a/test/libsolidity/semanticTests/shielded_literal_exponentiation.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_exponentiation.sol
@@ -1,0 +1,34 @@
+contract C {
+    suint256 private x;
+
+    function testPow() public returns (uint256) {
+        x = 2s ** 8s;
+        return uint(x);
+    }
+
+    function testPowZero() public returns (uint256) {
+        x = 2s ** 0s;
+        return uint(x);
+    }
+
+    function testPowOne() public returns (uint256) {
+        x = 2s ** 1s;
+        return uint(x);
+    }
+
+    function testPowLarge() public returns (uint256) {
+        x = 10s ** 18s;
+        return uint(x);
+    }
+
+    function testZeroPowZero() public returns (uint256) {
+        x = 0s ** 0s;
+        return uint(x);
+    }
+}
+// ----
+// testPow() -> 256
+// testPowZero() -> 1
+// testPowOne() -> 2
+// testPowLarge() -> 1000000000000000000
+// testZeroPowZero() -> 1

--- a/test/libsolidity/semanticTests/shielded_literal_function_args.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_function_args.sol
@@ -1,0 +1,28 @@
+contract C {
+    function add(suint256 a, suint256 b) internal pure returns (suint256) {
+        return a + b;
+    }
+
+    function sub(sint256 a, sint256 b) internal pure returns (sint256) {
+        return a - b;
+    }
+
+    function testAdd() public returns (uint256) {
+        suint256 r = add(10s, 20s);
+        return uint(r);
+    }
+
+    function testSub() public returns (int256) {
+        sint256 r = sub(10s, 20s);
+        return int(r);
+    }
+
+    function testNested() public returns (uint256) {
+        suint256 r = add(add(1s, 2s), add(3s, 4s));
+        return uint(r);
+    }
+}
+// ----
+// testAdd() -> 30
+// testSub() -> -10
+// testNested() -> 10

--- a/test/libsolidity/semanticTests/shielded_literal_hex_ops.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_hex_ops.sol
@@ -1,0 +1,28 @@
+contract C {
+    suint256 private x;
+
+    function testHexAssign() public returns (uint256) {
+        x = 0xCAFEs;
+        return uint(x);
+    }
+
+    function testHexArith() public returns (uint256) {
+        x = 0xFFs + 1s;
+        return uint(x);
+    }
+
+    function testHexBitwise() public returns (uint256) {
+        x = 0xAAs | 0x55s;
+        return uint(x);
+    }
+
+    function testHexUnderscore() public returns (uint256) {
+        x = 0xDE_ADs;
+        return uint(x);
+    }
+}
+// ----
+// testHexAssign() -> 0xCAFE
+// testHexArith() -> 256
+// testHexBitwise() -> 0xFF
+// testHexUnderscore() -> 0xDEAD

--- a/test/libsolidity/semanticTests/shielded_literal_mapping_ops.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_mapping_ops.sol
@@ -1,0 +1,32 @@
+contract C {
+    mapping(uint256 => suint256) private m;
+
+    function testSet() public returns (uint256) {
+        m[0] = 42s;
+        return uint(m[0]);
+    }
+
+    function testMultiple() public returns (uint256, uint256, uint256) {
+        m[0] = 100s;
+        m[1] = 200s;
+        m[2] = 0xDEADs;
+        return (uint(m[0]), uint(m[1]), uint(m[2]));
+    }
+
+    function testOverwrite() public returns (uint256) {
+        m[0] = 42s;
+        m[0] = 99s;
+        return uint(m[0]);
+    }
+
+    function testZero() public returns (uint256) {
+        m[0] = 42s;
+        m[0] = 0s;
+        return uint(m[0]);
+    }
+}
+// ----
+// testSet() -> 42
+// testMultiple() -> 100, 200, 0xDEAD
+// testOverwrite() -> 99
+// testZero() -> 0

--- a/test/libsolidity/semanticTests/shielded_literal_mixed_width_assign.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_mixed_width_assign.sol
@@ -1,0 +1,25 @@
+contract C {
+    suint8 private a;
+    suint16 private b;
+    suint32 private c;
+    suint256 private d;
+
+    // Same literal value assigned to different widths
+    function testSameValue() public returns (uint256, uint256, uint256, uint256) {
+        a = 42s;
+        b = 42s;
+        c = 42s;
+        d = 42s;
+        return (uint(uint8(a)), uint(uint16(b)), uint(uint32(c)), uint(d));
+    }
+
+    // Width-specific max values
+    function testMaxValues() public returns (uint256, uint256) {
+        a = 255s;
+        b = 65535s;
+        return (uint(uint8(a)), uint(uint16(b)));
+    }
+}
+// ----
+// testSameValue() -> 42, 42, 42, 42
+// testMaxValues() -> 255, 65535

--- a/test/libsolidity/semanticTests/shielded_literal_modulo.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_modulo.sol
@@ -1,0 +1,28 @@
+contract C {
+    suint256 private x;
+
+    function testMod() public returns (uint256) {
+        x = 10s % 3s;
+        return uint(x);
+    }
+
+    function testModExact() public returns (uint256) {
+        x = 9s % 3s;
+        return uint(x);
+    }
+
+    function testModLarge() public returns (uint256) {
+        x = 1000000s % 7s;
+        return uint(x);
+    }
+
+    function testModOne() public returns (uint256) {
+        x = 42s % 1s;
+        return uint(x);
+    }
+}
+// ----
+// testMod() -> 1
+// testModExact() -> 0
+// testModLarge() -> 1
+// testModOne() -> 0

--- a/test/libsolidity/semanticTests/shielded_literal_nested_expr.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_nested_expr.sol
@@ -1,0 +1,29 @@
+contract C {
+    suint256 private x;
+    sint256 private y;
+
+    function testNested1() public returns (uint256) {
+        x = (1s + 2s) * 3s;
+        return uint(x);
+    }
+
+    function testNested2() public returns (uint256) {
+        x = 10s - (2s * 3s);
+        return uint(x);
+    }
+
+    function testNested3() public returns (uint256) {
+        x = (100s / 10s) + (50s % 7s);
+        return uint(x);
+    }
+
+    function testSignedNested() public returns (int256) {
+        y = (-10s + 5s) * 2s;
+        return int(y);
+    }
+}
+// ----
+// testNested1() -> 9
+// testNested2() -> 4
+// testNested3() -> 11
+// testSignedNested() -> -10

--- a/test/libsolidity/semanticTests/shielded_literal_scientific.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_scientific.sol
@@ -1,0 +1,28 @@
+contract C {
+    suint256 private x;
+
+    function testE0() public returns (uint256) {
+        x = 1e0s;
+        return uint(x);
+    }
+
+    function testE1() public returns (uint256) {
+        x = 1e1s;
+        return uint(x);
+    }
+
+    function testE18() public returns (uint256) {
+        x = 1e18s;
+        return uint(x);
+    }
+
+    function testCoefficient() public returns (uint256) {
+        x = 5e3s;
+        return uint(x);
+    }
+}
+// ----
+// testE0() -> 1
+// testE1() -> 10
+// testE18() -> 1000000000000000000
+// testCoefficient() -> 5000

--- a/test/libsolidity/semanticTests/shielded_literal_shift_ops.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_shift_ops.sol
@@ -1,0 +1,28 @@
+contract C {
+    suint256 private x;
+
+    function testLeftShift() public returns (uint256) {
+        x = 1s << 8s;
+        return uint(x);
+    }
+
+    function testRightShift() public returns (uint256) {
+        x = 256s >> 4s;
+        return uint(x);
+    }
+
+    function testShiftZero() public returns (uint256) {
+        x = 42s << 0s;
+        return uint(x);
+    }
+
+    function testLargeShift() public returns (uint256) {
+        x = 1s << 255s;
+        return uint(x);
+    }
+}
+// ----
+// testLeftShift() -> 256
+// testRightShift() -> 16
+// testShiftZero() -> 42
+// testLargeShift() -> 0x8000000000000000000000000000000000000000000000000000000000000000

--- a/test/libsolidity/semanticTests/shielded_literal_sint.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_sint.sol
@@ -1,0 +1,35 @@
+contract C {
+    sint256 private x;
+    sint8 private y;
+
+    function setNegative() public returns (int256) {
+        x = -42s;
+        return int(x);
+    }
+
+    function setPositive() public returns (int256) {
+        x = 100s;
+        return int(x);
+    }
+
+    function setSmallNegative() public returns (int256) {
+        y = -128s;
+        return int(int8(y));
+    }
+
+    function setSmallPositive() public returns (int256) {
+        y = 127s;
+        return int(int8(y));
+    }
+
+    function negativeArithmetic() public returns (int256) {
+        x = -10s + -20s;
+        return int(x);
+    }
+}
+// ----
+// setNegative() -> -42
+// setPositive() -> 100
+// setSmallNegative() -> -128
+// setSmallPositive() -> 127
+// negativeArithmetic() -> -30

--- a/test/libsolidity/semanticTests/shielded_literal_sint_boundary.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_sint_boundary.sol
@@ -1,0 +1,43 @@
+contract C {
+    sint8 private a;
+    sint16 private b;
+    sint32 private c;
+    sint64 private d;
+
+    function testInt8() public returns (int256, int256) {
+        a = -128s;
+        int256 lo = int(int8(a));
+        a = 127s;
+        int256 hi = int(int8(a));
+        return (lo, hi);
+    }
+
+    function testInt16() public returns (int256, int256) {
+        b = -32768s;
+        int256 lo = int(int16(b));
+        b = 32767s;
+        int256 hi = int(int16(b));
+        return (lo, hi);
+    }
+
+    function testInt32() public returns (int256, int256) {
+        c = -2147483648s;
+        int256 lo = int(int32(c));
+        c = 2147483647s;
+        int256 hi = int(int32(c));
+        return (lo, hi);
+    }
+
+    function testInt64() public returns (int256, int256) {
+        d = -9223372036854775808s;
+        int256 lo = int(int64(d));
+        d = 9223372036854775807s;
+        int256 hi = int(int64(d));
+        return (lo, hi);
+    }
+}
+// ----
+// testInt8() -> -128, 127
+// testInt16() -> -32768, 32767
+// testInt32() -> -2147483648, 2147483647
+// testInt64() -> -9223372036854775808, 9223372036854775807

--- a/test/libsolidity/semanticTests/shielded_literal_storage_init.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_storage_init.sol
@@ -1,0 +1,21 @@
+contract C {
+    suint256 private x = 42s;
+    suint8 private y = 255s;
+    sint256 private z = -100s;
+
+    function getX() public returns (uint256) {
+        return uint(x);
+    }
+
+    function getY() public returns (uint256) {
+        return uint(uint8(y));
+    }
+
+    function getZ() public returns (int256) {
+        return int(z);
+    }
+}
+// ----
+// getX() -> 42
+// getY() -> 255
+// getZ() -> -100

--- a/test/libsolidity/semanticTests/shielded_literal_struct_ops.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_struct_ops.sol
@@ -1,0 +1,29 @@
+contract C {
+    struct Data {
+        suint256 value;
+        sint256 signed_value;
+    }
+
+    Data private d;
+
+    function testFieldAssign() public returns (uint256, int256) {
+        d.value = 42s;
+        d.signed_value = -10s;
+        return (uint(d.value), int(d.signed_value));
+    }
+
+    function testConstructor() public returns (uint256, int256) {
+        Data memory local = Data(100s, -50s);
+        return (uint(local.value), int(local.signed_value));
+    }
+
+    function testUpdate() public returns (uint256) {
+        d.value = 10s;
+        d.value = 20s;
+        return uint(d.value);
+    }
+}
+// ----
+// testFieldAssign() -> 42, -10
+// testConstructor() -> 100, -50
+// testUpdate() -> 20

--- a/test/libsolidity/semanticTests/shielded_literal_suint.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_suint.sol
@@ -1,0 +1,42 @@
+contract C {
+    suint256 private x;
+    suint8 private y;
+
+    function setAndGet() public returns (uint256, uint256) {
+        x = 42s;
+        y = 255s;
+        return (uint(x), uint(y));
+    }
+
+    function arithmetic() public returns (uint256) {
+        x = 10s + 20s;
+        return uint(x);
+    }
+
+    function hexLiteral() public returns (uint256) {
+        x = 0xDEADs;
+        return uint(x);
+    }
+
+    function underscoreLiteral() public returns (uint256) {
+        x = 1_000s;
+        return uint(x);
+    }
+
+    function scientificLiteral() public returns (uint256) {
+        x = 1e5s;
+        return uint(x);
+    }
+
+    function zero() public returns (uint256) {
+        x = 0s;
+        return uint(x);
+    }
+}
+// ----
+// setAndGet() -> 42, 255
+// arithmetic() -> 30
+// hexLiteral() -> 0xDEAD
+// underscoreLiteral() -> 1000
+// scientificLiteral() -> 100000
+// zero() -> 0

--- a/test/libsolidity/semanticTests/shielded_literal_suint_boundary.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_suint_boundary.sol
@@ -1,0 +1,60 @@
+contract C {
+    suint8 private a;
+    suint16 private b;
+    suint32 private c;
+    suint64 private d;
+    suint128 private e;
+    suint256 private f;
+
+    function testUint8() public returns (uint256, uint256) {
+        a = 0s;
+        uint256 lo = uint(uint8(a));
+        a = 255s;
+        uint256 hi = uint(uint8(a));
+        return (lo, hi);
+    }
+
+    function testUint16() public returns (uint256, uint256) {
+        b = 0s;
+        uint256 lo = uint(uint16(b));
+        b = 65535s;
+        uint256 hi = uint(uint16(b));
+        return (lo, hi);
+    }
+
+    function testUint32() public returns (uint256, uint256) {
+        c = 0s;
+        uint256 lo = uint(uint32(c));
+        c = 4294967295s;
+        uint256 hi = uint(uint32(c));
+        return (lo, hi);
+    }
+
+    function testUint64() public returns (uint256, uint256) {
+        d = 0s;
+        uint256 lo = uint(uint64(d));
+        d = 18446744073709551615s;
+        uint256 hi = uint(uint64(d));
+        return (lo, hi);
+    }
+
+    function testUint128() public returns (uint256, uint256) {
+        e = 0s;
+        uint256 lo = uint(uint128(e));
+        e = 340282366920938463463374607431768211455s;
+        uint256 hi = uint(uint128(e));
+        return (lo, hi);
+    }
+
+    function testUint256Max() public returns (uint256) {
+        f = 115792089237316195423570985008687907853269984665640564039457584007913129639935s;
+        return uint(f);
+    }
+}
+// ----
+// testUint8() -> 0, 255
+// testUint16() -> 0, 65535
+// testUint32() -> 0, 4294967295
+// testUint64() -> 0, 18446744073709551615
+// testUint128() -> 0, 340282366920938463463374607431768211455
+// testUint256Max() -> 115792089237316195423570985008687907853269984665640564039457584007913129639935

--- a/test/libsolidity/semanticTests/shielded_literal_ternary_runtime.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_ternary_runtime.sol
@@ -1,0 +1,23 @@
+contract C {
+    suint256 private x;
+
+    function testTrue() public returns (uint256) {
+        x = true ? 42s : 0s;
+        return uint(x);
+    }
+
+    function testFalse() public returns (uint256) {
+        x = false ? 42s : 99s;
+        return uint(x);
+    }
+
+    function testDynamic(bool cond) public returns (uint256) {
+        x = cond ? 1s : 2s;
+        return uint(x);
+    }
+}
+// ----
+// testTrue() -> 42
+// testFalse() -> 99
+// testDynamic(bool): true -> 1
+// testDynamic(bool): false -> 2

--- a/test/libsolidity/semanticTests/shielded_literal_unchecked.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_unchecked.sol
@@ -1,0 +1,32 @@
+contract C {
+    suint8 private a;
+    sint8 private b;
+
+    function testUncheckedOverflow() public returns (uint256) {
+        unchecked {
+            a = 255s;
+            a = a + suint8(1s);
+        }
+        return uint(uint8(a));
+    }
+
+    function testUncheckedUnderflow() public returns (uint256) {
+        unchecked {
+            a = 0s;
+            a = a - suint8(1s);
+        }
+        return uint(uint8(a));
+    }
+
+    function testUncheckedSignedOverflow() public returns (int256) {
+        unchecked {
+            b = 127s;
+            b = b + sint8(1s);
+        }
+        return int(int8(b));
+    }
+}
+// ----
+// testUncheckedOverflow() -> 0
+// testUncheckedUnderflow() -> 255
+// testUncheckedSignedOverflow() -> -128

--- a/test/libsolidity/semanticTests/shielded_literal_underscore.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_underscore.sol
@@ -1,0 +1,22 @@
+contract C {
+    suint256 private x;
+
+    function testUnderscore() public returns (uint256) {
+        x = 1_000s;
+        return uint(x);
+    }
+
+    function testMultipleUnderscores() public returns (uint256) {
+        x = 1_000_000_000s;
+        return uint(x);
+    }
+
+    function testHexUnderscore() public returns (uint256) {
+        x = 0xFF_FFs;
+        return uint(x);
+    }
+}
+// ----
+// testUnderscore() -> 1000
+// testMultipleUnderscores() -> 1000000000
+// testHexUnderscore() -> 0xFFFF

--- a/test/libsolidity/semanticTests/shielded_literal_zero_arithmetic.sol
+++ b/test/libsolidity/semanticTests/shielded_literal_zero_arithmetic.sol
@@ -1,0 +1,34 @@
+contract C {
+    suint256 private x;
+
+    function testAddZero() public returns (uint256) {
+        x = 42s + 0s;
+        return uint(x);
+    }
+
+    function testSubZero() public returns (uint256) {
+        x = 42s - 0s;
+        return uint(x);
+    }
+
+    function testMulZero() public returns (uint256) {
+        x = 42s * 0s;
+        return uint(x);
+    }
+
+    function testMulByOne() public returns (uint256) {
+        x = 42s * 1s;
+        return uint(x);
+    }
+
+    function testPowZero() public returns (uint256) {
+        x = 42s ** 0s;
+        return uint(x);
+    }
+}
+// ----
+// testAddZero() -> 42
+// testSubZero() -> 42
+// testMulZero() -> 0
+// testMulByOne() -> 42
+// testPowZero() -> 1

--- a/test/libsolidity/syntaxTests/types/shielded_literal_abi_encode_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_abi_encode_fail.sol
@@ -1,0 +1,9 @@
+contract C {
+    function test() internal {
+        // abi.encode with shielded literal should fail
+        bytes memory b = abi.encode(42s);
+    }
+}
+// ----
+// Warning 9660: (136-139): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 3648: (136-139): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_abi_encode_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_abi_encode_fail.sol
@@ -5,5 +5,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (136-139): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (136-139): Shielded number literals will leak during contract deployment.
 // TypeError 3648: (136-139): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_address_length_hex.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_address_length_hex.sol
@@ -8,5 +8,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (227-270): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (227-270): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (227-270): Type address is not implicitly convertible to expected type suint256.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_address_length_hex.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_address_length_hex.sol
@@ -1,0 +1,12 @@
+// Bug: 40-hex-digit shielded literal should NOT trigger address-related warnings
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        // 40 hex digits (same length as address) with s suffix
+        x = 0x1234567890123456789012345678901234567890s;
+    }
+}
+// ----
+// Warning 9660: (227-270): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (227-270): Type address is not implicitly convertible to expected type suint256.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_all_sint_widths.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_all_sint_widths.sol
@@ -1,0 +1,38 @@
+contract C {
+    sint8 private a;
+    sint16 private b;
+    sint32 private c;
+    sint64 private d;
+    sint128 private e;
+    sint256 private f;
+
+    function test() internal {
+        // Test max positive for each width
+        a = 127s;
+        b = 32767s;
+        c = 2147483647s;
+        d = 9223372036854775807s;
+        e = 170141183460469231731687303715884105727s;
+        f = 57896044618658097711785492504343953926634992332820282019728792003956564819967s;
+        // Test min negative for each width
+        a = -128s;
+        b = -32768s;
+        c = -2147483648s;
+        d = -9223372036854775808s;
+        e = -170141183460469231731687303715884105728s;
+        f = -57896044618658097711785492504343953926634992332820282019728792003956564819968s;
+    }
+}
+// ----
+// Warning 9660: (234-238): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (252-258): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (272-283): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (297-317): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (331-371): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (385-463): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (522-526): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (541-547): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (562-573): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (588-608): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (623-663): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (678-756): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_all_sint_widths.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_all_sint_widths.sol
@@ -24,15 +24,15 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (234-238): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (252-258): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (272-283): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (297-317): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (331-371): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (385-463): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (522-526): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (541-547): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (562-573): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (588-608): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (623-663): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (678-756): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (234-238): Shielded number literals will leak during contract deployment.
+// Warning 9667: (252-258): Shielded number literals will leak during contract deployment.
+// Warning 9667: (272-283): Shielded number literals will leak during contract deployment.
+// Warning 9667: (297-317): Shielded number literals will leak during contract deployment.
+// Warning 9667: (331-371): Shielded number literals will leak during contract deployment.
+// Warning 9667: (385-463): Shielded number literals will leak during contract deployment.
+// Warning 9667: (522-526): Shielded number literals will leak during contract deployment.
+// Warning 9667: (541-547): Shielded number literals will leak during contract deployment.
+// Warning 9667: (562-573): Shielded number literals will leak during contract deployment.
+// Warning 9667: (588-608): Shielded number literals will leak during contract deployment.
+// Warning 9667: (623-663): Shielded number literals will leak during contract deployment.
+// Warning 9667: (678-756): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_all_suint_widths.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_all_suint_widths.sol
@@ -1,0 +1,25 @@
+contract C {
+    suint8 private a;
+    suint16 private b;
+    suint32 private c;
+    suint64 private d;
+    suint128 private e;
+    suint256 private f;
+
+    function test() internal {
+        // Test max value for each width
+        a = 255s;
+        b = 65535s;
+        c = 4294967295s;
+        d = 18446744073709551615s;
+        e = 340282366920938463463374607431768211455s;
+        f = 115792089237316195423570985008687907853269984665640564039457584007913129639935s;
+    }
+}
+// ----
+// Warning 9660: (237-241): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (255-261): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (275-286): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (300-321): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (335-375): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (389-468): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_all_suint_widths.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_all_suint_widths.sol
@@ -17,9 +17,9 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (237-241): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (255-261): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (275-286): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (300-321): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (335-375): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (389-468): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (237-241): Shielded number literals will leak during contract deployment.
+// Warning 9667: (255-261): Shielded number literals will leak during contract deployment.
+// Warning 9667: (275-286): Shielded number literals will leak during contract deployment.
+// Warning 9667: (300-321): Shielded number literals will leak during contract deployment.
+// Warning 9667: (335-375): Shielded number literals will leak during contract deployment.
+// Warning 9667: (389-468): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_arithmetic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_arithmetic.sol
@@ -18,15 +18,15 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (124-126): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (129-131): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (168-171): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (174-177): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (217-219): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (222-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (258-261): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (264-266): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (298-301): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (304-306): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (346-348): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (352-354): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (124-126): Shielded number literals will leak during contract deployment.
+// Warning 9667: (129-131): Shielded number literals will leak during contract deployment.
+// Warning 9667: (168-171): Shielded number literals will leak during contract deployment.
+// Warning 9667: (174-177): Shielded number literals will leak during contract deployment.
+// Warning 9667: (217-219): Shielded number literals will leak during contract deployment.
+// Warning 9667: (222-224): Shielded number literals will leak during contract deployment.
+// Warning 9667: (258-261): Shielded number literals will leak during contract deployment.
+// Warning 9667: (264-266): Shielded number literals will leak during contract deployment.
+// Warning 9667: (298-301): Shielded number literals will leak during contract deployment.
+// Warning 9667: (304-306): Shielded number literals will leak during contract deployment.
+// Warning 9667: (346-348): Shielded number literals will leak during contract deployment.
+// Warning 9667: (352-354): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_arithmetic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_arithmetic.sol
@@ -1,0 +1,32 @@
+contract C {
+    suint256 private x;
+    sint256 private y;
+
+    function test() internal {
+        // Addition
+        x = 1s + 2s;
+        // Subtraction
+        y = 10s - 20s;
+        // Multiplication
+        x = 3s * 4s;
+        // Division
+        x = 10s / 2s;
+        // Modulo
+        x = 10s % 3s;
+        // Exponentiation
+        x = 2s ** 8s;
+    }
+}
+// ----
+// Warning 9660: (124-126): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (129-131): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (168-171): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (174-177): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (217-219): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (222-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (258-261): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (264-266): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (298-301): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (304-306): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (346-348): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (352-354): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_array_element.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_array_element.sol
@@ -1,0 +1,21 @@
+contract C {
+    suint256[] private arr;
+    suint8[3] private fixed_arr;
+
+    function test() internal {
+        // Push shielded literal to dynamic array
+        arr.push(42s);
+        arr.push(0s);
+        // Assign to fixed array element
+        fixed_arr[0] = 1s;
+        fixed_arr[1] = 2s;
+        fixed_arr[2] = 255s;
+    }
+}
+// ----
+// Warning 9665: (17-39): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// Warning 9660: (173-176): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (196-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (265-267): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (292-294): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (319-323): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_array_element.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_array_element.sol
@@ -14,8 +14,8 @@ contract C {
 }
 // ----
 // Warning 9665: (17-39): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
-// Warning 9660: (173-176): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (196-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (265-267): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (292-294): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (319-323): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (173-176): Shielded number literals will leak during contract deployment.
+// Warning 9667: (196-198): Shielded number literals will leak during contract deployment.
+// Warning 9667: (265-267): Shielded number literals will leak during contract deployment.
+// Warning 9667: (292-294): Shielded number literals will leak during contract deployment.
+// Warning 9667: (319-323): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_assign_to_var_expression.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_assign_to_var_expression.sol
@@ -1,0 +1,22 @@
+contract C {
+    suint256 private x;
+    sint256 private y;
+
+    function test() internal {
+        // Assignment with compound expressions
+        x = 42s;
+        x = x + 1s;
+        x = x * 2s;
+        y = -1s;
+        y = y - 1s;
+    }
+}
+// ----
+// Warning 9660: (152-155): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (173-175): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 4282: (169-175): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.
+// Warning 9660: (193-195): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 4282: (189-195): Shielded integer multiplication can leak information. A revert due to overflow reveals range information about the operands.
+// Warning 9660: (210-212): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (230-232): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 4282: (226-232): Shielded integer subtraction can leak information. A revert due to overflow reveals range information about the operands.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_assign_to_var_expression.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_assign_to_var_expression.sol
@@ -12,11 +12,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (152-155): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (173-175): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (152-155): Shielded number literals will leak during contract deployment.
+// Warning 9667: (173-175): Shielded number literals will leak during contract deployment.
 // Warning 4282: (169-175): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.
-// Warning 9660: (193-195): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (193-195): Shielded number literals will leak during contract deployment.
 // Warning 4282: (189-195): Shielded integer multiplication can leak information. A revert due to overflow reveals range information about the operands.
-// Warning 9660: (210-212): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (230-232): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (210-212): Shielded number literals will leak during contract deployment.
+// Warning 9667: (230-232): Shielded number literals will leak during contract deployment.
 // Warning 4282: (226-232): Shielded integer subtraction can leak information. A revert due to overflow reveals range information about the operands.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_basic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_basic.sol
@@ -1,0 +1,33 @@
+contract C {
+    suint256 private x;
+    suint8 private y;
+    sint8 private z;
+
+    function f() internal {
+        // Basic shielded literal assignment
+        x = 42s;
+        y = 255s;
+        z = -1s;
+
+        // Hex shielded literal
+        x = 0x1As;
+
+        // Underscore shielded literal
+        x = 1_000s;
+
+        // Scientific notation shielded literal
+        x = 1e5s;
+
+        // Shielded arithmetic
+        x = 1s + 2s;
+    }
+}
+// ----
+// Warning 9660: (166-169): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (183-187): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (202-204): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (251-256): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (310-316): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (379-383): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (429-431): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (434-436): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_basic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_basic.sol
@@ -23,11 +23,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (166-169): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (183-187): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (202-204): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (251-256): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (310-316): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (379-383): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (429-431): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (434-436): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (166-169): Shielded number literals will leak during contract deployment.
+// Warning 9667: (183-187): Shielded number literals will leak during contract deployment.
+// Warning 9667: (202-204): Shielded number literals will leak during contract deployment.
+// Warning 9667: (251-256): Shielded number literals will leak during contract deployment.
+// Warning 9667: (310-316): Shielded number literals will leak during contract deployment.
+// Warning 9667: (379-383): Shielded number literals will leak during contract deployment.
+// Warning 9667: (429-431): Shielded number literals will leak during contract deployment.
+// Warning 9667: (434-436): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_bitwise.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_bitwise.sol
@@ -1,0 +1,29 @@
+contract C {
+    suint256 private x;
+    suint8 private y;
+
+    function test() internal {
+        // Bitwise AND
+        x = 0xFFs & 0x0Fs;
+        // Bitwise OR
+        x = 0xF0s | 0x0Fs;
+        // Bitwise XOR
+        x = 0xFFs ^ 0x0Fs;
+        // Chained bitwise
+        x = (0xFFs & 0xF0s) | 0x0Fs;
+        // Bitwise on small types
+        y = 0xF0s & 0x0Fs;
+    }
+}
+// ----
+// Warning 9660: (126-131): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (134-139): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (175-180): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (183-188): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (225-230): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (233-238): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (280-285): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (288-293): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (297-302): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (350-355): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (358-363): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_bitwise.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_bitwise.sol
@@ -16,14 +16,14 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (126-131): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (134-139): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (175-180): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (183-188): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (225-230): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (233-238): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (280-285): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (288-293): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (297-302): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (350-355): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (358-363): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (126-131): Shielded number literals will leak during contract deployment.
+// Warning 9667: (134-139): Shielded number literals will leak during contract deployment.
+// Warning 9667: (175-180): Shielded number literals will leak during contract deployment.
+// Warning 9667: (183-188): Shielded number literals will leak during contract deployment.
+// Warning 9667: (225-230): Shielded number literals will leak during contract deployment.
+// Warning 9667: (233-238): Shielded number literals will leak during contract deployment.
+// Warning 9667: (280-285): Shielded number literals will leak during contract deployment.
+// Warning 9667: (288-293): Shielded number literals will leak during contract deployment.
+// Warning 9667: (297-302): Shielded number literals will leak during contract deployment.
+// Warning 9667: (350-355): Shielded number literals will leak during contract deployment.
+// Warning 9667: (358-363): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_bitwise_not.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_bitwise_not.sol
@@ -1,0 +1,14 @@
+contract C {
+    suint8 private a;
+    sint8 private b;
+
+    function test() internal {
+        // Bitwise NOT on shielded literal
+        a = ~0s;
+        b = ~0s;
+    }
+}
+// ----
+// Warning 9660: (144-146): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (143-146): Type shielded_int_const -1 is not implicitly convertible to expected type suint8. Cannot implicitly convert signed literal to unsigned type.
+// Warning 9660: (161-163): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_bitwise_not.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_bitwise_not.sol
@@ -9,6 +9,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (144-146): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (144-146): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (143-146): Type shielded_int_const -1 is not implicitly convertible to expected type suint8. Cannot implicitly convert signed literal to unsigned type.
-// Warning 9660: (161-163): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (161-163): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_comparison.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_comparison.sol
@@ -1,0 +1,34 @@
+contract C {
+    function test() internal {
+        suint256 private_x;
+        sbool private_r;
+
+        // Equality
+        private_r = (1s == 1s);
+        // Inequality
+        private_r = (1s != 2s);
+        // Less than
+        private_r = (1s < 2s);
+        // Greater than
+        private_r = (2s > 1s);
+        // Less than or equal
+        private_r = (1s <= 1s);
+        // Greater than or equal
+        private_r = (2s >= 1s);
+    }
+}
+// ----
+// Warning 9660: (139-141): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (145-147): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (193-195): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (199-201): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (246-248): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (251-253): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (301-303): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (306-308): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (362-364): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (368-370): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (427-429): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (433-435): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 2072: (52-70): Unused local variable.
+// Warning 2018: (17-443): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/types/shielded_literal_comparison.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_comparison.sol
@@ -18,17 +18,17 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (139-141): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (145-147): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (193-195): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (199-201): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (246-248): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (251-253): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (301-303): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (306-308): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (362-364): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (368-370): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (427-429): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (433-435): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (139-141): Shielded number literals will leak during contract deployment.
+// Warning 9667: (145-147): Shielded number literals will leak during contract deployment.
+// Warning 9667: (193-195): Shielded number literals will leak during contract deployment.
+// Warning 9667: (199-201): Shielded number literals will leak during contract deployment.
+// Warning 9667: (246-248): Shielded number literals will leak during contract deployment.
+// Warning 9667: (251-253): Shielded number literals will leak during contract deployment.
+// Warning 9667: (301-303): Shielded number literals will leak during contract deployment.
+// Warning 9667: (306-308): Shielded number literals will leak during contract deployment.
+// Warning 9667: (362-364): Shielded number literals will leak during contract deployment.
+// Warning 9667: (368-370): Shielded number literals will leak during contract deployment.
+// Warning 9667: (427-429): Shielded number literals will leak during contract deployment.
+// Warning 9667: (433-435): Shielded number literals will leak during contract deployment.
 // Warning 2072: (52-70): Unused local variable.
 // Warning 2018: (17-443): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/types/shielded_literal_comparison_result_type.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_comparison_result_type.sol
@@ -12,12 +12,12 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (215-217): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (220-222): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (238-240): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (244-246): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (262-264): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (268-270): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (350-352): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (355-357): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (215-217): Shielded number literals will leak during contract deployment.
+// Warning 9667: (220-222): Shielded number literals will leak during contract deployment.
+// Warning 9667: (238-240): Shielded number literals will leak during contract deployment.
+// Warning 9667: (244-246): Shielded number literals will leak during contract deployment.
+// Warning 9667: (262-264): Shielded number literals will leak during contract deployment.
+// Warning 9667: (268-270): Shielded number literals will leak during contract deployment.
+// Warning 9667: (350-352): Shielded number literals will leak during contract deployment.
+// Warning 9667: (355-357): Shielded number literals will leak during contract deployment.
 // TypeError 9574: (340-358): Type sbool is not implicitly convertible to expected type bool.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_comparison_result_type.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_comparison_result_type.sol
@@ -1,0 +1,23 @@
+// Test: comparison of shielded literals should produce sbool, not bool
+contract C {
+    sbool private r;
+
+    function test() internal {
+        // Comparison of shielded literals should produce sbool
+        r = (1s < 2s);
+        r = (1s == 1s);
+        r = (1s != 2s);
+        // Assigning comparison result to bool should fail
+        bool b = (1s < 2s);
+    }
+}
+// ----
+// Warning 9660: (215-217): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (220-222): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (238-240): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (244-246): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (262-264): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (268-270): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (350-352): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (355-357): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 9574: (340-358): Type sbool is not implicitly convertible to expected type bool.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_constant_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_constant_fail.sol
@@ -1,0 +1,6 @@
+contract C {
+    // Shielded types cannot be constant
+    suint256 private constant X = 42s;
+}
+// ----
+// DeclarationError 7491: (58-91): Shielded objects cannot be set to constant or immutable.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_constructor_init.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_constructor_init.sol
@@ -1,0 +1,12 @@
+contract C {
+    suint256 private x;
+    sint256 private y;
+
+    constructor() {
+        x = 42s;
+        y = -100s;
+    }
+}
+// ----
+// Warning 9660: (93-96): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (111-115): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_constructor_init.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_constructor_init.sol
@@ -8,5 +8,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (93-96): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (111-115): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (93-96): Shielded number literals will leak during contract deployment.
+// Warning 9667: (111-115): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_cross_assign_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_cross_assign_fail.sol
@@ -1,0 +1,16 @@
+contract C {
+    saddress private a;
+    sbool private b;
+
+    function test() internal {
+        // Cannot assign shielded number literal to saddress
+        a = 0s;
+        // Cannot assign shielded number literal to sbool
+        b = 1s;
+    }
+}
+// ----
+// Warning 9660: (163-165): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (163-165): Type shielded_int_const 0 is not implicitly convertible to expected type saddress.
+// Warning 9660: (237-239): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (237-239): Type shielded_int_const 1 is not implicitly convertible to expected type sbool.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_cross_assign_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_cross_assign_fail.sol
@@ -10,7 +10,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (163-165): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (163-165): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (163-165): Type shielded_int_const 0 is not implicitly convertible to expected type saddress.
-// Warning 9660: (237-239): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (237-239): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (237-239): Type shielded_int_const 1 is not implicitly convertible to expected type sbool.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_division_by_zero.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_division_by_zero.sol
@@ -7,6 +7,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (132-134): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (137-139): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (132-134): Shielded number literals will leak during contract deployment.
+// Warning 9667: (137-139): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (132-139): Built-in binary operator / cannot be applied to types shielded_int_const 1 and shielded_int_const 0.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_division_by_zero.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_division_by_zero.sol
@@ -1,0 +1,12 @@
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        // Division by zero with shielded literals
+        x = 1s / 0s;
+    }
+}
+// ----
+// Warning 9660: (132-134): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (137-139): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 2271: (132-139): Built-in binary operator / cannot be applied to types shielded_int_const 1 and shielded_int_const 0.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_double_negation.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_double_negation.sol
@@ -10,5 +10,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (134-137): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (199-202): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (134-137): Shielded number literals will leak during contract deployment.
+// Warning 9667: (199-202): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_double_negation.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_double_negation.sol
@@ -1,0 +1,14 @@
+contract C {
+    suint256 private x;
+    sint256 private y;
+
+    function test() internal {
+        // Double negation
+        y = -(-42s);
+        // Should be equivalent to positive
+        x = -(-42s);
+    }
+}
+// ----
+// Warning 9660: (134-137): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (199-202): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_event_emit_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_event_emit_fail.sol
@@ -7,5 +7,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (186-189): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (186-189): Shielded number literals will leak during contract deployment.
 // TypeError 9553: (186-189): Invalid type for argument in function call. Invalid implicit conversion from shielded_int_const 42 to uint256 requested. Shielded number literal cannot be implicitly converted to non-shielded type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_event_emit_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_event_emit_fail.sol
@@ -1,0 +1,11 @@
+contract C {
+    event Log(uint256 value);
+
+    function test() internal {
+        // Emitting shielded literal in event should fail (shielded types can't be in events)
+        emit Log(42s);
+    }
+}
+// ----
+// Warning 9660: (186-189): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 9553: (186-189): Invalid type for argument in function call. Invalid implicit conversion from shielded_int_const 42 to uint256 requested. Shielded number literal cannot be implicitly converted to non-shielded type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_exp_limit_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_exp_limit_fail.sol
@@ -1,0 +1,12 @@
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        // Exponentiation resulting in value too large
+        x = 2s ** 256s;
+    }
+}
+// ----
+// Warning 9660: (136-138): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (142-146): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (136-146): Type shielded_int_const 1157...(70 digits omitted)...9936 is not implicitly convertible to expected type suint256. Literal is too large to fit in suint256.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_exp_limit_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_exp_limit_fail.sol
@@ -7,6 +7,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (136-138): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (142-146): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (136-138): Shielded number literals will leak during contract deployment.
+// Warning 9667: (142-146): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (136-146): Type shielded_int_const 1157...(70 digits omitted)...9936 is not implicitly convertible to expected type suint256. Literal is too large to fit in suint256.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_exp_limit_fine.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_exp_limit_fine.sol
@@ -10,11 +10,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (121-123): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (127-131): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (145-148): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (152-155): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (169-171): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (175-177): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (191-193): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (197-199): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (121-123): Shielded number literals will leak during contract deployment.
+// Warning 9667: (127-131): Shielded number literals will leak during contract deployment.
+// Warning 9667: (145-148): Shielded number literals will leak during contract deployment.
+// Warning 9667: (152-155): Shielded number literals will leak during contract deployment.
+// Warning 9667: (169-171): Shielded number literals will leak during contract deployment.
+// Warning 9667: (175-177): Shielded number literals will leak during contract deployment.
+// Warning 9667: (191-193): Shielded number literals will leak during contract deployment.
+// Warning 9667: (197-199): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_exp_limit_fine.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_exp_limit_fine.sol
@@ -1,0 +1,20 @@
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        // Exponentiation within bounds
+        x = 2s ** 255s;
+        x = 10s ** 77s;
+        x = 2s ** 0s;
+        x = 0s ** 0s;
+    }
+}
+// ----
+// Warning 9660: (121-123): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (127-131): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (145-148): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (152-155): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (169-171): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (175-177): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (191-193): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (197-199): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_exp_with_shielded_var.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_exp_with_shielded_var.sol
@@ -12,7 +12,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (193-195): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (261-263): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (321-323): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (193-195): Shielded number literals will leak during contract deployment.
+// Warning 9667: (261-263): Shielded number literals will leak during contract deployment.
+// Warning 9667: (321-323): Shielded number literals will leak during contract deployment.
 // Warning 3817: (321-331): Shielded integer exponentiation will leak the exponent value through gas cost.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_exp_with_shielded_var.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_exp_with_shielded_var.sol
@@ -1,0 +1,18 @@
+// Test: exponentiation with shielded variable base and shielded literal exponent
+contract C {
+    suint256 private x;
+    suint256 private base;
+
+    function test() internal {
+        base = 2s;
+        // Shielded var ** shielded literal
+        x = base ** 8s;
+        // Shielded literal ** shielded var
+        x = 2s ** base;
+    }
+}
+// ----
+// Warning 9660: (193-195): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (261-263): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (321-323): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 3817: (321-331): Shielded integer exponentiation will leak the exponent value through gas cost.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_explicit_cast.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_explicit_cast.sol
@@ -12,9 +12,9 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (160-163): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (160-163): Shielded number literals will leak during contract deployment.
 // Warning 9660: (153-164): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (224-227): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (224-227): Shielded number literals will leak during contract deployment.
 // Warning 9660: (215-228): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (339-342): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (339-342): Shielded number literals will leak during contract deployment.
 // TypeError 9640: (331-343): Explicit type conversion not allowed from "shielded_int_const 42" to "uint256".

--- a/test/libsolidity/syntaxTests/types/shielded_literal_explicit_cast.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_explicit_cast.sol
@@ -1,0 +1,20 @@
+contract C {
+    suint8 private a;
+    suint256 private b;
+
+    function test() internal {
+        // Explicit cast to smaller shielded type
+        a = suint8(42s);
+        // Explicit cast to suint256
+        b = suint256(42s);
+        // Explicit cast of shielded literal to non-shielded (should this work?)
+        uint256 c = uint256(42s);
+    }
+}
+// ----
+// Warning 9660: (160-163): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (153-164): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (224-227): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (215-228): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (339-342): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 9640: (331-343): Explicit type conversion not allowed from "shielded_int_const 42" to "uint256".

--- a/test/libsolidity/syntaxTests/types/shielded_literal_explicit_cast_to_unshielded.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_explicit_cast_to_unshielded.sol
@@ -8,11 +8,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (136-139): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (136-139): Shielded number literals will leak during contract deployment.
 // TypeError 9640: (128-140): Explicit type conversion not allowed from "shielded_int_const 42" to "uint256".
-// Warning 9660: (166-170): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (166-170): Shielded number literals will leak during contract deployment.
 // TypeError 9640: (160-171): Explicit type conversion not allowed from "shielded_int_const 255" to "uint8".
-// Warning 9660: (200-203): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (200-203): Shielded number literals will leak during contract deployment.
 // TypeError 9640: (192-204): Explicit type conversion not allowed from "shielded_int_const -42" to "int256".
-// Warning 9660: (229-233): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (229-233): Shielded number literals will leak during contract deployment.
 // TypeError 9640: (223-234): Explicit type conversion not allowed from "shielded_int_const -128" to "int8".

--- a/test/libsolidity/syntaxTests/types/shielded_literal_explicit_cast_to_unshielded.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_explicit_cast_to_unshielded.sol
@@ -1,0 +1,18 @@
+contract C {
+    function test() internal {
+        // Explicit cast of shielded literal to unshielded type
+        uint256 a = uint256(42s);
+        uint8 b = uint8(255s);
+        int256 c = int256(-42s);
+        int8 d = int8(-128s);
+    }
+}
+// ----
+// Warning 9660: (136-139): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 9640: (128-140): Explicit type conversion not allowed from "shielded_int_const 42" to "uint256".
+// Warning 9660: (166-170): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 9640: (160-171): Explicit type conversion not allowed from "shielded_int_const 255" to "uint8".
+// Warning 9660: (200-203): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 9640: (192-204): Explicit type conversion not allowed from "shielded_int_const -42" to "int256".
+// Warning 9660: (229-233): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 9640: (223-234): Explicit type conversion not allowed from "shielded_int_const -128" to "int8".

--- a/test/libsolidity/syntaxTests/types/shielded_literal_fractional_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_fractional_fail.sol
@@ -1,0 +1,10 @@
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        x = 1.5s;
+    }
+}
+// ----
+// Warning 9660: (81-85): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 2326: (81-85): Type shielded_rational_const 3 / 2 is not implicitly convertible to expected type suint256. Try converting to type ufixed8x1 or use an explicit conversion.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_fractional_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_fractional_fail.sol
@@ -6,5 +6,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (81-85): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (81-85): Shielded number literals will leak during contract deployment.
 // TypeError 2326: (81-85): Type shielded_rational_const 3 / 2 is not implicitly convertible to expected type suint256. Try converting to type ufixed8x1 or use an explicit conversion.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_function_arg.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_function_arg.sol
@@ -9,8 +9,8 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (247-250): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (253-256): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (247-250): Shielded number literals will leak during contract deployment.
+// Warning 9667: (253-256): Shielded number literals will leak during contract deployment.
 // Warning 5667: (53-62): Unused function parameter. Remove or comment out the variable name to silence this warning.
 // Warning 2072: (219-229): Unused local variable.
 // Warning 2018: (128-264): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/types/shielded_literal_function_arg.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_function_arg.sol
@@ -1,0 +1,16 @@
+contract C {
+    function acceptShielded(suint256 a, sint256 b) internal pure returns (suint256) {
+        return a;
+    }
+
+    function test() internal {
+        // Pass shielded literals as function arguments
+        suint256 r = acceptShielded(42s, -10s);
+    }
+}
+// ----
+// Warning 9660: (247-250): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (253-256): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 5667: (53-62): Unused function parameter. Remove or comment out the variable name to silence this warning.
+// Warning 2072: (219-229): Unused local variable.
+// Warning 2018: (128-264): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/types/shielded_literal_hex_boundary_8bit.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_hex_boundary_8bit.sol
@@ -1,0 +1,16 @@
+contract C {
+    suint8 private a;
+
+    function test() internal {
+        // Hex values at suint8 boundary
+        a = 0x00s;
+        a = 0x7Fs;
+        a = 0x80s;
+        a = 0xFFs;
+    }
+}
+// ----
+// Warning 9660: (120-125): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (139-144): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (158-163): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (177-182): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_hex_boundary_8bit.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_hex_boundary_8bit.sol
@@ -10,7 +10,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (120-125): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (139-144): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (158-163): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (177-182): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (120-125): Shielded number literals will leak during contract deployment.
+// Warning 9667: (139-144): Shielded number literals will leak during contract deployment.
+// Warning 9667: (158-163): Shielded number literals will leak during contract deployment.
+// Warning 9667: (177-182): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_hex_various.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_hex_various.sol
@@ -19,11 +19,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (190-195): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (209-214): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (228-233): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (247-254): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (268-279): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (293-312): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (354-358): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (394-401): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (190-195): Shielded number literals will leak during contract deployment.
+// Warning 9667: (209-214): Shielded number literals will leak during contract deployment.
+// Warning 9667: (228-233): Shielded number literals will leak during contract deployment.
+// Warning 9667: (247-254): Shielded number literals will leak during contract deployment.
+// Warning 9667: (268-279): Shielded number literals will leak during contract deployment.
+// Warning 9667: (293-312): Shielded number literals will leak during contract deployment.
+// Warning 9667: (354-358): Shielded number literals will leak during contract deployment.
+// Warning 9667: (394-401): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_hex_various.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_hex_various.sol
@@ -1,0 +1,29 @@
+contract C {
+    suint8 private a;
+    suint16 private b;
+    suint32 private c;
+    suint256 private d;
+
+    function test() internal {
+        // Various hex shielded literals
+        a = 0x00s;
+        a = 0xffs;
+        a = 0xFFs;
+        b = 0xABCDs;
+        c = 0xDEADBEEFs;
+        d = 0x1234567890ABCDEFs;
+        // Single hex digit
+        a = 0x1s;
+        // Mixed case
+        b = 0xAbCds;
+    }
+}
+// ----
+// Warning 9660: (190-195): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (209-214): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (228-233): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (247-254): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (268-279): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (293-312): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (354-358): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (394-401): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_huge_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_huge_fail.sol
@@ -7,5 +7,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (132-211): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (132-211): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (132-211): Type shielded_int_const 1157...(70 digits omitted)...9936 is not implicitly convertible to expected type suint256. Literal is too large to fit in suint256.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_huge_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_huge_fail.sol
@@ -1,0 +1,11 @@
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        // One more than max uint256 - should fail
+        x = 115792089237316195423570985008687907853269984665640564039457584007913129639936s;
+    }
+}
+// ----
+// Warning 9660: (132-211): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (132-211): Type shielded_int_const 1157...(70 digits omitted)...9936 is not implicitly convertible to expected type suint256. Literal is too large to fit in suint256.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_immutable_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_immutable_fail.sol
@@ -1,0 +1,6 @@
+contract C {
+    // Shielded types cannot be immutable
+    suint256 private immutable X = 42s;
+}
+// ----
+// DeclarationError 7491: (59-93): Shielded objects cannot be set to constant or immutable.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_implicit_widening.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_implicit_widening.sol
@@ -1,0 +1,23 @@
+contract C {
+    suint256 private wide;
+    sint256 private swide;
+
+    function test() internal {
+        // Small shielded literals should implicitly fit into wider types
+        wide = 1s;
+        wide = 255s;
+        wide = 65535s;
+        swide = 1s;
+        swide = -1s;
+        swide = 127s;
+        swide = -128s;
+    }
+}
+// ----
+// Warning 9660: (188-190): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (207-211): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (228-234): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (252-254): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (273-275): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (293-297): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (316-320): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_implicit_widening.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_implicit_widening.sol
@@ -14,10 +14,10 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (188-190): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (207-211): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (228-234): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (252-254): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (273-275): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (293-297): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (316-320): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (188-190): Shielded number literals will leak during contract deployment.
+// Warning 9667: (207-211): Shielded number literals will leak during contract deployment.
+// Warning 9667: (228-234): Shielded number literals will leak during contract deployment.
+// Warning 9667: (252-254): Shielded number literals will leak during contract deployment.
+// Warning 9667: (273-275): Shielded number literals will leak during contract deployment.
+// Warning 9667: (293-297): Shielded number literals will leak during contract deployment.
+// Warning 9667: (316-320): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_in_array_literal.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_in_array_literal.sol
@@ -5,11 +5,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (129-131): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (129-131): Shielded number literals will leak during contract deployment.
 // Warning 9660: (122-132): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (141-143): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (141-143): Shielded number literals will leak during contract deployment.
 // Warning 9660: (134-144): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (153-155): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (153-155): Shielded number literals will leak during contract deployment.
 // Warning 9660: (146-156): Literals converted to shielded integers will leak during contract deployment.
 // Warning 2072: (98-118): Unused local variable.
 // Warning 2018: (17-164): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/types/shielded_literal_in_array_literal.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_in_array_literal.sol
@@ -1,0 +1,15 @@
+contract C {
+    function test() internal {
+        // Array literal with shielded values
+        suint8[3] memory arr = [suint8(1s), suint8(2s), suint8(3s)];
+    }
+}
+// ----
+// Warning 9660: (129-131): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (122-132): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (141-143): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (134-144): Literals converted to shielded integers will leak during contract deployment.
+// Warning 9660: (153-155): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (146-156): Literals converted to shielded integers will leak during contract deployment.
+// Warning 2072: (98-118): Unused local variable.
+// Warning 2018: (17-164): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/types/shielded_literal_in_for_loop.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_in_for_loop.sol
@@ -10,10 +10,10 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (128-130): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (158-160): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (166-169): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (128-130): Shielded number literals will leak during contract deployment.
+// Warning 9667: (158-160): Shielded number literals will leak during contract deployment.
+// Warning 9667: (166-169): Shielded number literals will leak during contract deployment.
 // Warning 5765: (162-169): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
-// Warning 9660: (179-181): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (179-181): Shielded number literals will leak during contract deployment.
 // Warning 4282: (175-181): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.
 // Warning 4282: (201-206): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_in_for_loop.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_in_for_loop.sol
@@ -1,0 +1,19 @@
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        // Using shielded literals in for loop
+        x = 0s;
+        for (suint256 i = 0s; i < 10s; i = i + 1s) {
+            x = x + i;
+        }
+    }
+}
+// ----
+// Warning 9660: (128-130): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (158-160): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (166-169): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 5765: (162-169): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
+// Warning 9660: (179-181): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 4282: (175-181): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.
+// Warning 4282: (201-206): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_in_if_condition.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_in_if_condition.sol
@@ -1,0 +1,22 @@
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        x = 10s;
+        // Using shielded literals in if conditions (via comparison)
+        if (x == 10s) {
+            x = 20s;
+        }
+        if (x > 5s) {
+            x = 0s;
+        }
+    }
+}
+// ----
+// Warning 9660: (81-84): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (172-175): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 5765: (167-175): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
+// Warning 9660: (195-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (226-228): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 5765: (222-228): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
+// Warning 9660: (248-250): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_in_if_condition.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_in_if_condition.sol
@@ -13,10 +13,10 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (81-84): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (172-175): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (81-84): Shielded number literals will leak during contract deployment.
+// Warning 9667: (172-175): Shielded number literals will leak during contract deployment.
 // Warning 5765: (167-175): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
-// Warning 9660: (195-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (226-228): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (195-198): Shielded number literals will leak during contract deployment.
+// Warning 9667: (226-228): Shielded number literals will leak during contract deployment.
 // Warning 5765: (222-228): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
-// Warning 9660: (248-250): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (248-250): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_in_while_loop.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_in_while_loop.sol
@@ -13,11 +13,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (117-119): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (133-135): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (221-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (117-119): Shielded number literals will leak during contract deployment.
+// Warning 9667: (133-135): Shielded number literals will leak during contract deployment.
+// Warning 9667: (221-224): Shielded number literals will leak during contract deployment.
 // Warning 5765: (211-224): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
-// Warning 9660: (248-250): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (248-250): Shielded number literals will leak during contract deployment.
 // Warning 4282: (244-250): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.
-// Warning 9660: (284-286): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (284-286): Shielded number literals will leak during contract deployment.
 // Warning 4282: (274-286): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_in_while_loop.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_in_while_loop.sol
@@ -1,0 +1,23 @@
+contract C {
+    suint256 private x;
+    suint256 private counter;
+
+    function test() internal {
+        counter = 0s;
+        x = 0s;
+        // Using shielded literals in while loop condition
+        while (counter < 10s) {
+            x = x + 1s;
+            counter = counter + 1s;
+        }
+    }
+}
+// ----
+// Warning 9660: (117-119): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (133-135): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (221-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 5765: (211-224): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
+// Warning 9660: (248-250): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 4282: (244-250): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.
+// Warning 9660: (284-286): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 4282: (274-286): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_local_var.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_local_var.sol
@@ -10,11 +10,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (126-129): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (150-154): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (177-181): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (202-206): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (245-247): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (126-129): Shielded number literals will leak during contract deployment.
+// Warning 9667: (150-154): Shielded number literals will leak during contract deployment.
+// Warning 9667: (177-181): Shielded number literals will leak during contract deployment.
+// Warning 9667: (202-206): Shielded number literals will leak during contract deployment.
+// Warning 9667: (245-247): Shielded number literals will leak during contract deployment.
 // Warning 2072: (113-123): Unused local variable.
 // Warning 2072: (139-147): Unused local variable.
 // Warning 2072: (164-173): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_local_var.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_local_var.sol
@@ -1,0 +1,23 @@
+contract C {
+    function test() internal {
+        // Local variable declaration with shielded literals
+        suint256 a = 42s;
+        suint8 b = 255s;
+        sint256 c = -100s;
+        sint8 d = -128s;
+        // Zero
+        suint256 e = 0s;
+    }
+}
+// ----
+// Warning 9660: (126-129): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (150-154): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (177-181): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (202-206): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (245-247): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 2072: (113-123): Unused local variable.
+// Warning 2072: (139-147): Unused local variable.
+// Warning 2072: (164-173): Unused local variable.
+// Warning 2072: (191-198): Unused local variable.
+// Warning 2072: (232-242): Unused local variable.
+// Warning 2018: (17-254): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mapping_key_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mapping_key_fail.sol
@@ -1,0 +1,6 @@
+contract C {
+    // Shielded types cannot be used as mapping keys
+    mapping(suint256 => uint256) private m;
+}
+// ----
+// TypeError 7804: (78-86): Shielded types are not allowed as mapping keys.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mapping_value.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mapping_value.sol
@@ -1,0 +1,14 @@
+contract C {
+    mapping(uint256 => suint256) private m;
+
+    function test() internal {
+        // Assign shielded literal to mapping value
+        m[0] = 42s;
+        m[1] = 0s;
+        m[2] = 0xDEADs;
+    }
+}
+// ----
+// Warning 9660: (156-159): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (176-178): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (195-202): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mapping_value.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mapping_value.sol
@@ -9,6 +9,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (156-159): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (176-178): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (195-202): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (156-159): Shielded number literals will leak during contract deployment.
+// Warning 9667: (176-178): Shielded number literals will leak during contract deployment.
+// Warning 9667: (195-202): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_max_uint256.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_max_uint256.sol
@@ -13,6 +13,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (176-255): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (298-338): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (379-383): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (176-255): Shielded number literals will leak during contract deployment.
+// Warning 9667: (298-338): Shielded number literals will leak during contract deployment.
+// Warning 9667: (379-383): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_max_uint256.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_max_uint256.sol
@@ -1,0 +1,18 @@
+contract C {
+    suint256 private x;
+    suint128 private y;
+    suint8 private z;
+
+    function test() internal {
+        // Max uint256 value as shielded literal
+        x = 115792089237316195423570985008687907853269984665640564039457584007913129639935s;
+        // Max uint128 value
+        y = 340282366920938463463374607431768211455s;
+        // Max uint8 value
+        z = 255s;
+    }
+}
+// ----
+// Warning 9660: (176-255): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (298-338): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (379-383): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mixed_comparison_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mixed_comparison_fail.sol
@@ -1,0 +1,17 @@
+contract C {
+    function test() internal {
+        // Comparing shielded literal with non-shielded should fail
+        bool a = (1s == 1);
+        bool b = (2 > 1s);
+        bool c = (1s != 2);
+    }
+}
+// ----
+// Warning 9660: (130-132): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 2271: (130-137): Built-in binary operator == cannot be applied to types shielded_int_const 1 and int_const 1.
+// TypeError 9574: (120-138): Type sbool is not implicitly convertible to expected type bool.
+// Warning 9660: (162-164): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 2271: (158-164): Built-in binary operator > cannot be applied to types int_const 2 and shielded_int_const 1.
+// Warning 9660: (185-187): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 2271: (185-192): Built-in binary operator != cannot be applied to types shielded_int_const 1 and int_const 2.
+// TypeError 9574: (175-193): Type sbool is not implicitly convertible to expected type bool.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mixed_comparison_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mixed_comparison_fail.sol
@@ -7,11 +7,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (130-132): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (130-132): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (130-137): Built-in binary operator == cannot be applied to types shielded_int_const 1 and int_const 1.
 // TypeError 9574: (120-138): Type sbool is not implicitly convertible to expected type bool.
-// Warning 9660: (162-164): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (162-164): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (158-164): Built-in binary operator > cannot be applied to types int_const 2 and shielded_int_const 1.
-// Warning 9660: (185-187): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (185-187): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (185-192): Built-in binary operator != cannot be applied to types shielded_int_const 1 and int_const 2.
 // TypeError 9574: (175-193): Type sbool is not implicitly convertible to expected type bool.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mixed_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mixed_fail.sol
@@ -9,10 +9,10 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (144-146): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (144-146): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (144-150): Built-in binary operator + cannot be applied to types shielded_int_const 1 and int_const 1.
-// Warning 9660: (168-170): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (168-170): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (164-170): Built-in binary operator + cannot be applied to types int_const 2 and shielded_int_const 3.
 // TypeError 7407: (164-170): Type int_const 2 is not implicitly convertible to expected type suint256.
-// Warning 9660: (184-186): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (184-186): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (184-190): Built-in binary operator * cannot be applied to types shielded_int_const 1 and int_const 2.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mixed_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mixed_fail.sol
@@ -1,0 +1,18 @@
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        // Mixed shielded/non-shielded arithmetic is forbidden
+        x = 1s + 1;
+        x = 2 + 3s;
+        x = 1s * 2;
+    }
+}
+// ----
+// Warning 9660: (144-146): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 2271: (144-150): Built-in binary operator + cannot be applied to types shielded_int_const 1 and int_const 1.
+// Warning 9660: (168-170): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 2271: (164-170): Built-in binary operator + cannot be applied to types int_const 2 and shielded_int_const 3.
+// TypeError 7407: (164-170): Type int_const 2 is not implicitly convertible to expected type suint256.
+// Warning 9660: (184-186): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 2271: (184-190): Built-in binary operator * cannot be applied to types shielded_int_const 1 and int_const 2.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mixed_nonshielded_var_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mixed_nonshielded_var_fail.sol
@@ -10,7 +10,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (229-231): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (229-231): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (225-231): Built-in binary operator + cannot be applied to types uint256 and shielded_int_const 1.
-// Warning 9660: (249-251): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (249-251): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (245-251): Built-in binary operator * cannot be applied to types uint256 and shielded_int_const 2.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mixed_nonshielded_var_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mixed_nonshielded_var_fail.sol
@@ -1,0 +1,16 @@
+// Test: shielded literal mixed with non-shielded variable should fail
+contract C {
+    uint256 public x;
+
+    function test() internal {
+        x = 10;
+        // Non-shielded var + shielded literal should fail
+        x = x + 1s;
+        x = x * 2s;
+    }
+}
+// ----
+// Warning 9660: (229-231): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 2271: (225-231): Built-in binary operator + cannot be applied to types uint256 and shielded_int_const 1.
+// Warning 9660: (249-251): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 2271: (245-251): Built-in binary operator * cannot be applied to types uint256 and shielded_int_const 2.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mixed_shielded_var_arithmetic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mixed_shielded_var_arithmetic.sol
@@ -13,14 +13,14 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (148-151): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (212-214): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (148-151): Shielded number literals will leak during contract deployment.
+// Warning 9667: (212-214): Shielded number literals will leak during contract deployment.
 // Warning 4282: (208-214): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.
-// Warning 9660: (232-234): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (232-234): Shielded number literals will leak during contract deployment.
 // Warning 4282: (228-234): Shielded integer subtraction can leak information. A revert due to overflow reveals range information about the operands.
-// Warning 9660: (252-254): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (252-254): Shielded number literals will leak during contract deployment.
 // Warning 4282: (248-254): Shielded integer multiplication can leak information. A revert due to overflow reveals range information about the operands.
-// Warning 9660: (272-274): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (272-274): Shielded number literals will leak during contract deployment.
 // Warning 4281: (268-274): Shielded integer division can leak information. A revert due to division by zero reveals that the divisor is zero.
-// Warning 9660: (292-294): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (292-294): Shielded number literals will leak during contract deployment.
 // Warning 4281: (288-294): Shielded integer modulo can leak information. A revert due to division by zero reveals that the divisor is zero.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mixed_shielded_var_arithmetic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mixed_shielded_var_arithmetic.sol
@@ -1,0 +1,26 @@
+// Test: shielded literal mixed with shielded variable should work
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        x = 10s;
+        // Shielded var + shielded literal
+        x = x + 1s;
+        x = x - 5s;
+        x = x * 2s;
+        x = x / 2s;
+        x = x % 3s;
+    }
+}
+// ----
+// Warning 9660: (148-151): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (212-214): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 4282: (208-214): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.
+// Warning 9660: (232-234): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 4282: (228-234): Shielded integer subtraction can leak information. A revert due to overflow reveals range information about the operands.
+// Warning 9660: (252-254): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 4282: (248-254): Shielded integer multiplication can leak information. A revert due to overflow reveals range information about the operands.
+// Warning 9660: (272-274): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 4281: (268-274): Shielded integer division can leak information. A revert due to division by zero reveals that the divisor is zero.
+// Warning 9660: (292-294): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 4281: (288-294): Shielded integer modulo can leak information. A revert due to division by zero reveals that the divisor is zero.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_modulo_by_zero.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_modulo_by_zero.sol
@@ -1,0 +1,12 @@
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        // Modulo by zero with shielded literals
+        x = 1s % 0s;
+    }
+}
+// ----
+// Warning 9660: (130-132): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (135-137): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 2271: (130-137): Built-in binary operator % cannot be applied to types shielded_int_const 1 and shielded_int_const 0.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_modulo_by_zero.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_modulo_by_zero.sol
@@ -7,6 +7,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (130-132): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (135-137): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (130-132): Shielded number literals will leak during contract deployment.
+// Warning 9667: (135-137): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (130-137): Built-in binary operator % cannot be applied to types shielded_int_const 1 and shielded_int_const 0.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_multiple_types_same_expr.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_multiple_types_same_expr.sol
@@ -1,0 +1,20 @@
+contract C {
+    suint8 private a;
+    suint256 private b;
+
+    function test() internal {
+        // Same shielded literal fitting different types
+        a = 100s;
+        b = 100s;
+        // Arithmetic result fitting different types
+        a = 2s * 50s;
+        b = 2s * 50s;
+    }
+}
+// ----
+// Warning 9660: (160-164): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (178-182): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (249-251): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (254-257): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (271-273): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (276-279): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_multiple_types_same_expr.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_multiple_types_same_expr.sol
@@ -12,9 +12,9 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (160-164): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (178-182): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (249-251): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (254-257): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (271-273): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (276-279): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (160-164): Shielded number literals will leak during contract deployment.
+// Warning 9667: (178-182): Shielded number literals will leak during contract deployment.
+// Warning 9667: (249-251): Shielded number literals will leak during contract deployment.
+// Warning 9667: (254-257): Shielded number literals will leak during contract deployment.
+// Warning 9667: (271-273): Shielded number literals will leak during contract deployment.
+// Warning 9667: (276-279): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_negative_to_unsigned_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_negative_to_unsigned_fail.sol
@@ -1,0 +1,10 @@
+contract C {
+    suint8 private x;
+
+    function test() internal {
+        x = -1s;
+    }
+}
+// ----
+// Warning 9660: (80-82): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (79-82): Type shielded_int_const -1 is not implicitly convertible to expected type suint8. Cannot implicitly convert signed literal to unsigned type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_negative_to_unsigned_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_negative_to_unsigned_fail.sol
@@ -6,5 +6,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (80-82): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (80-82): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (79-82): Type shielded_int_const -1 is not implicitly convertible to expected type suint8. Cannot implicitly convert signed literal to unsigned type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_nested_arithmetic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_nested_arithmetic.sol
@@ -1,0 +1,30 @@
+contract C {
+    suint256 private x;
+    sint256 private y;
+
+    function test() internal {
+        // Nested arithmetic with shielded literals
+        x = (1s + 2s) * 3s;
+        x = 10s - (2s * 3s);
+        x = (100s / 10s) + (50s % 7s);
+        // Nested signed
+        y = (-10s + 5s) * 2s;
+        y = -(3s * 4s);
+    }
+}
+// ----
+// Warning 9660: (157-159): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (162-164): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (168-170): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (184-187): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (191-193): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (196-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (214-218): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (221-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (229-232): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (235-237): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (279-282): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (285-287): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (291-293): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (309-311): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (314-316): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_nested_arithmetic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_nested_arithmetic.sol
@@ -13,18 +13,18 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (157-159): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (162-164): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (168-170): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (184-187): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (191-193): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (196-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (214-218): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (221-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (229-232): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (235-237): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (279-282): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (285-287): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (291-293): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (309-311): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (314-316): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (157-159): Shielded number literals will leak during contract deployment.
+// Warning 9667: (162-164): Shielded number literals will leak during contract deployment.
+// Warning 9667: (168-170): Shielded number literals will leak during contract deployment.
+// Warning 9667: (184-187): Shielded number literals will leak during contract deployment.
+// Warning 9667: (191-193): Shielded number literals will leak during contract deployment.
+// Warning 9667: (196-198): Shielded number literals will leak during contract deployment.
+// Warning 9667: (214-218): Shielded number literals will leak during contract deployment.
+// Warning 9667: (221-224): Shielded number literals will leak during contract deployment.
+// Warning 9667: (229-232): Shielded number literals will leak during contract deployment.
+// Warning 9667: (235-237): Shielded number literals will leak during contract deployment.
+// Warning 9667: (279-282): Shielded number literals will leak during contract deployment.
+// Warning 9667: (285-287): Shielded number literals will leak during contract deployment.
+// Warning 9667: (291-293): Shielded number literals will leak during contract deployment.
+// Warning 9667: (309-311): Shielded number literals will leak during contract deployment.
+// Warning 9667: (314-316): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_no_regression_identifiers.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_no_regression_identifiers.sol
@@ -1,0 +1,29 @@
+// Ensure that identifiers ending in 's' are not mistakenly treated as shielded literals.
+contract C {
+    uint256 public items;
+    uint256 public blocks;
+    uint256 public results;
+
+    function setValues(uint256 _items, uint256 _blocks) public {
+        items = _items;
+        blocks = _blocks;
+        results = _items + _blocks;
+    }
+
+    function getResults() public view returns (uint256) {
+        return results;
+    }
+
+    // Single-letter 's' as identifier
+    function withLocalS() public pure returns (uint256) {
+        uint256 s = 42;
+        return s;
+    }
+
+    // Variable named 'seconds' (without the space)
+    function withSeconds() public pure returns (uint256) {
+        uint256 secs = 60;
+        return secs;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/types/shielded_literal_power_of_two.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_power_of_two.sol
@@ -17,14 +17,14 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (127-129): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (143-145): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (159-161): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (175-177): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (191-194): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (208-211): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (225-228): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (242-246): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (260-264): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (278-283): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (297-305): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (127-129): Shielded number literals will leak during contract deployment.
+// Warning 9667: (143-145): Shielded number literals will leak during contract deployment.
+// Warning 9667: (159-161): Shielded number literals will leak during contract deployment.
+// Warning 9667: (175-177): Shielded number literals will leak during contract deployment.
+// Warning 9667: (191-194): Shielded number literals will leak during contract deployment.
+// Warning 9667: (208-211): Shielded number literals will leak during contract deployment.
+// Warning 9667: (225-228): Shielded number literals will leak during contract deployment.
+// Warning 9667: (242-246): Shielded number literals will leak during contract deployment.
+// Warning 9667: (260-264): Shielded number literals will leak during contract deployment.
+// Warning 9667: (278-283): Shielded number literals will leak during contract deployment.
+// Warning 9667: (297-305): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_power_of_two.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_power_of_two.sol
@@ -1,0 +1,30 @@
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        // Powers of two as shielded literals
+        x = 1s;
+        x = 2s;
+        x = 4s;
+        x = 8s;
+        x = 16s;
+        x = 32s;
+        x = 64s;
+        x = 128s;
+        x = 256s;
+        x = 1024s;
+        x = 1048576s;
+    }
+}
+// ----
+// Warning 9660: (127-129): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (143-145): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (159-161): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (175-177): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (191-194): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (208-211): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (225-228): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (242-246): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (260-264): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (278-283): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (297-305): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_public_var_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_public_var_fail.sol
@@ -1,0 +1,7 @@
+contract C {
+    // Shielded types cannot be public (auto-getter)
+    suint256 public x = 42s;
+}
+// ----
+// Warning 9660: (90-93): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7091: (70-93): Shielded Types are not supported for public state variables.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_public_var_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_public_var_fail.sol
@@ -3,5 +3,5 @@ contract C {
     suint256 public x = 42s;
 }
 // ----
-// Warning 9660: (90-93): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (90-93): Shielded number literals will leak during contract deployment.
 // TypeError 7091: (70-93): Shielded Types are not supported for public state variables.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_require_condition.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_require_condition.sol
@@ -1,0 +1,19 @@
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        x = 10s;
+        // Shielded literal in comparison used in require
+        require(x > 5s);
+        require(x == 10s);
+        require(x != 0s);
+    }
+}
+// ----
+// Warning 9660: (81-84): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (164-166): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 5765: (160-166): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
+// Warning 9660: (190-193): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 5765: (185-193): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
+// Warning 9660: (217-219): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 5765: (212-219): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_require_condition.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_require_condition.sol
@@ -10,10 +10,10 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (81-84): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (164-166): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (81-84): Shielded number literals will leak during contract deployment.
+// Warning 9667: (164-166): Shielded number literals will leak during contract deployment.
 // Warning 5765: (160-166): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
-// Warning 9660: (190-193): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (190-193): Shielded number literals will leak during contract deployment.
 // Warning 5765: (185-193): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
-// Warning 9660: (217-219): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (217-219): Shielded number literals will leak during contract deployment.
 // Warning 5765: (212-219): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_return_cast.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_return_cast.sol
@@ -1,0 +1,16 @@
+contract C {
+    // Returning shielded literal from public function requires cast to unshielded
+    function f() public pure returns (uint256) {
+        return uint256(42s);
+    }
+
+    // Direct return of shielded literal from public function should fail
+    function g() public pure returns (uint256) {
+        return 42s;
+    }
+}
+// ----
+// Warning 9660: (168-171): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 9640: (160-172): Explicit type conversion not allowed from "shielded_int_const 42" to "uint256".
+// Warning 9660: (319-322): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 6359: (319-322): Return argument type shielded_int_const 42 is not implicitly convertible to expected type (type of first return variable) uint256. Shielded number literal cannot be implicitly converted to non-shielded type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_return_cast.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_return_cast.sol
@@ -10,7 +10,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (168-171): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (168-171): Shielded number literals will leak during contract deployment.
 // TypeError 9640: (160-172): Explicit type conversion not allowed from "shielded_int_const 42" to "uint256".
-// Warning 9660: (319-322): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (319-322): Shielded number literals will leak during contract deployment.
 // TypeError 6359: (319-322): Return argument type shielded_int_const 42 is not implicitly convertible to expected type (type of first return variable) uint256. Shielded number literal cannot be implicitly converted to non-shielded type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_scientific_fractional_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_scientific_fractional_fail.sol
@@ -1,0 +1,12 @@
+// Test: scientific notation that produces fractional result should fail
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        // 1e-1 = 0.1 -- fractional, should fail
+        x = 1e-1s;
+    }
+}
+// ----
+// Warning 9660: (203-208): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 2326: (203-208): Type shielded_rational_const 1 / 10 is not implicitly convertible to expected type suint256. Try converting to type ufixed8x1 or use an explicit conversion.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_scientific_fractional_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_scientific_fractional_fail.sol
@@ -8,5 +8,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (203-208): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (203-208): Shielded number literals will leak during contract deployment.
 // TypeError 2326: (203-208): Type shielded_rational_const 1 / 10 is not implicitly convertible to expected type suint256. Try converting to type ufixed8x1 or use an explicit conversion.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_scientific_various.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_scientific_various.sol
@@ -1,0 +1,20 @@
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        // Various scientific notation shielded literals
+        x = 1e0s;
+        x = 1e1s;
+        x = 1e18s;
+        x = 1e77s;
+        x = 5e10s;
+        x = 2e5s;
+    }
+}
+// ----
+// Warning 9660: (138-142): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (156-160): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (174-179): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (193-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (212-217): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (231-235): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_scientific_various.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_scientific_various.sol
@@ -12,9 +12,9 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (138-142): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (156-160): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (174-179): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (193-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (212-217): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (231-235): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (138-142): Shielded number literals will leak during contract deployment.
+// Warning 9667: (156-160): Shielded number literals will leak during contract deployment.
+// Warning 9667: (174-179): Shielded number literals will leak during contract deployment.
+// Warning 9667: (193-198): Shielded number literals will leak during contract deployment.
+// Warning 9667: (212-217): Shielded number literals will leak during contract deployment.
+// Warning 9667: (231-235): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_shift.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_shift.sol
@@ -1,0 +1,24 @@
+contract C {
+    suint256 private x;
+    suint8 private y;
+
+    function test() internal {
+        // Left shift
+        x = 1s << 8s;
+        // Right shift
+        x = 256s >> 4s;
+        // Shift small type
+        y = 1s << 4s;
+        // Large shift
+        x = 1s << 255s;
+    }
+}
+// ----
+// Warning 9660: (125-127): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (131-133): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (170-174): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (178-180): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (222-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (228-230): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (267-269): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (273-277): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_shift.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_shift.sol
@@ -14,11 +14,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (125-127): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (131-133): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (170-174): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (178-180): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (222-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (228-230): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (267-269): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (273-277): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (125-127): Shielded number literals will leak during contract deployment.
+// Warning 9667: (131-133): Shielded number literals will leak during contract deployment.
+// Warning 9667: (170-174): Shielded number literals will leak during contract deployment.
+// Warning 9667: (178-180): Shielded number literals will leak during contract deployment.
+// Warning 9667: (222-224): Shielded number literals will leak during contract deployment.
+// Warning 9667: (228-230): Shielded number literals will leak during contract deployment.
+// Warning 9667: (267-269): Shielded number literals will leak during contract deployment.
+// Warning 9667: (273-277): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_shift_with_variable.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_shift_with_variable.sol
@@ -1,0 +1,16 @@
+// Bug: shielded literal shifted by non-shielded variable should produce shielded result
+contract C {
+    suint256 private x;
+
+    function test(uint8 amount) internal {
+        // Shielded literal with non-shielded shift amount
+        x = 1s << amount;
+        // Shielded literal with non-shielded exponent
+        x = 2s ** amount;
+    }
+}
+// ----
+// Warning 9660: (241-243): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (241-253): Type uint256 is not implicitly convertible to expected type suint256.
+// Warning 9660: (322-324): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (322-334): Type uint256 is not implicitly convertible to expected type suint256.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_shift_with_variable.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_shift_with_variable.sol
@@ -10,7 +10,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (241-243): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (241-243): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (241-253): Type uint256 is not implicitly convertible to expected type suint256.
-// Warning 9660: (322-324): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (322-324): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (322-334): Type uint256 is not implicitly convertible to expected type suint256.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_signed_to_unsigned_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_signed_to_unsigned_fail.sol
@@ -12,11 +12,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (203-205): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (203-205): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (202-205): Type shielded_int_const -1 is not implicitly convertible to expected type suint8. Cannot implicitly convert signed literal to unsigned type.
-// Warning 9660: (220-222): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (220-222): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (219-222): Type shielded_int_const -1 is not implicitly convertible to expected type suint16. Cannot implicitly convert signed literal to unsigned type.
-// Warning 9660: (237-239): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (237-239): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (236-239): Type shielded_int_const -1 is not implicitly convertible to expected type suint256. Cannot implicitly convert signed literal to unsigned type.
-// Warning 9660: (254-258): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (254-258): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (253-258): Type shielded_int_const -100 is not implicitly convertible to expected type suint256. Cannot implicitly convert signed literal to unsigned type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_signed_to_unsigned_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_signed_to_unsigned_fail.sol
@@ -1,0 +1,22 @@
+contract C {
+    suint8 private a;
+    suint16 private b;
+    suint256 private c;
+
+    function test() internal {
+        // Negative shielded literal to unsigned should fail for all widths
+        a = -1s;
+        b = -1s;
+        c = -1s;
+        c = -100s;
+    }
+}
+// ----
+// Warning 9660: (203-205): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (202-205): Type shielded_int_const -1 is not implicitly convertible to expected type suint8. Cannot implicitly convert signed literal to unsigned type.
+// Warning 9660: (220-222): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (219-222): Type shielded_int_const -1 is not implicitly convertible to expected type suint16. Cannot implicitly convert signed literal to unsigned type.
+// Warning 9660: (237-239): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (236-239): Type shielded_int_const -1 is not implicitly convertible to expected type suint256. Cannot implicitly convert signed literal to unsigned type.
+// Warning 9660: (254-258): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (253-258): Type shielded_int_const -100 is not implicitly convertible to expected type suint256. Cannot implicitly convert signed literal to unsigned type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_sint_all_overflow_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_sint_all_overflow_fail.sol
@@ -21,23 +21,23 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (220-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (220-224): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (220-224): Type shielded_int_const 128 is not implicitly convertible to expected type sint8. Literal is too large to fit in sint8.
-// Warning 9660: (238-244): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (238-244): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (238-244): Type shielded_int_const 32768 is not implicitly convertible to expected type sint16. Literal is too large to fit in sint16.
-// Warning 9660: (258-269): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (258-269): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (258-269): Type shielded_int_const 2147483648 is not implicitly convertible to expected type sint32. Literal is too large to fit in sint32.
-// Warning 9660: (283-303): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (283-303): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (283-303): Type shielded_int_const 9223372036854775808 is not implicitly convertible to expected type sint64. Literal is too large to fit in sint64.
-// Warning 9660: (317-357): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (317-357): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (317-357): Type shielded_int_const 1701...(31 digits omitted)...5728 is not implicitly convertible to expected type sint128. Literal is too large to fit in sint128.
-// Warning 9660: (425-429): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (425-429): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (424-429): Type shielded_int_const -129 is not implicitly convertible to expected type sint8. Literal is too large to fit in sint8.
-// Warning 9660: (444-450): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (444-450): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (443-450): Type shielded_int_const -32769 is not implicitly convertible to expected type sint16. Literal is too large to fit in sint16.
-// Warning 9660: (465-476): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (465-476): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (464-476): Type shielded_int_const -2147483649 is not implicitly convertible to expected type sint32. Literal is too large to fit in sint32.
-// Warning 9660: (491-511): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (491-511): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (490-511): Type shielded_int_const -9223372036854775809 is not implicitly convertible to expected type sint64. Literal is too large to fit in sint64.
-// Warning 9660: (526-566): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (526-566): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (525-566): Type shielded_int_const -170...(32 digits omitted)...5729 is not implicitly convertible to expected type sint128. Literal is too large to fit in sint128.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_sint_all_overflow_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_sint_all_overflow_fail.sol
@@ -1,0 +1,43 @@
+contract C {
+    sint8 private a;
+    sint16 private b;
+    sint32 private c;
+    sint64 private d;
+    sint128 private e;
+
+    function test() internal {
+        // One more than max positive for each width
+        a = 128s;
+        b = 32768s;
+        c = 2147483648s;
+        d = 9223372036854775808s;
+        e = 170141183460469231731687303715884105728s;
+        // One less than min negative for each width
+        a = -129s;
+        b = -32769s;
+        c = -2147483649s;
+        d = -9223372036854775809s;
+        e = -170141183460469231731687303715884105729s;
+    }
+}
+// ----
+// Warning 9660: (220-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (220-224): Type shielded_int_const 128 is not implicitly convertible to expected type sint8. Literal is too large to fit in sint8.
+// Warning 9660: (238-244): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (238-244): Type shielded_int_const 32768 is not implicitly convertible to expected type sint16. Literal is too large to fit in sint16.
+// Warning 9660: (258-269): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (258-269): Type shielded_int_const 2147483648 is not implicitly convertible to expected type sint32. Literal is too large to fit in sint32.
+// Warning 9660: (283-303): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (283-303): Type shielded_int_const 9223372036854775808 is not implicitly convertible to expected type sint64. Literal is too large to fit in sint64.
+// Warning 9660: (317-357): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (317-357): Type shielded_int_const 1701...(31 digits omitted)...5728 is not implicitly convertible to expected type sint128. Literal is too large to fit in sint128.
+// Warning 9660: (425-429): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (424-429): Type shielded_int_const -129 is not implicitly convertible to expected type sint8. Literal is too large to fit in sint8.
+// Warning 9660: (444-450): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (443-450): Type shielded_int_const -32769 is not implicitly convertible to expected type sint16. Literal is too large to fit in sint16.
+// Warning 9660: (465-476): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (464-476): Type shielded_int_const -2147483649 is not implicitly convertible to expected type sint32. Literal is too large to fit in sint32.
+// Warning 9660: (491-511): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (490-511): Type shielded_int_const -9223372036854775809 is not implicitly convertible to expected type sint64. Literal is too large to fit in sint64.
+// Warning 9660: (526-566): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (525-566): Type shielded_int_const -170...(32 digits omitted)...5729 is not implicitly convertible to expected type sint128. Literal is too large to fit in sint128.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_sint_basic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_sint_basic.sol
@@ -19,12 +19,12 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (190-192): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (206-210): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (225-229): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (244-246): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (261-267): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (282-289): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (304-314): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (329-334): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (348-350): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (190-192): Shielded number literals will leak during contract deployment.
+// Warning 9667: (206-210): Shielded number literals will leak during contract deployment.
+// Warning 9667: (225-229): Shielded number literals will leak during contract deployment.
+// Warning 9667: (244-246): Shielded number literals will leak during contract deployment.
+// Warning 9667: (261-267): Shielded number literals will leak during contract deployment.
+// Warning 9667: (282-289): Shielded number literals will leak during contract deployment.
+// Warning 9667: (304-314): Shielded number literals will leak during contract deployment.
+// Warning 9667: (329-334): Shielded number literals will leak during contract deployment.
+// Warning 9667: (348-350): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_sint_basic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_sint_basic.sol
@@ -1,0 +1,30 @@
+contract C {
+    sint8 private a;
+    sint16 private b;
+    sint32 private c;
+    sint64 private d;
+    sint128 private e;
+    sint256 private f;
+
+    function test() internal {
+        a = 0s;
+        a = 127s;
+        a = -128s;
+        a = -1s;
+        b = -32768s;
+        c = -0xDEADs;
+        d = -1_000_000s;
+        e = -1e10s;
+        f = 0s;
+    }
+}
+// ----
+// Warning 9660: (190-192): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (206-210): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (225-229): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (244-246): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (261-267): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (282-289): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (304-314): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (329-334): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (348-350): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_sint_overflow_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_sint_overflow_fail.sol
@@ -1,0 +1,17 @@
+contract C {
+    sint8 private a;
+    sint16 private b;
+
+    function test() internal {
+        a = 128s;
+        a = -129s;
+        b = 32768s;
+    }
+}
+// ----
+// Warning 9660: (100-104): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (100-104): Type shielded_int_const 128 is not implicitly convertible to expected type sint8. Literal is too large to fit in sint8.
+// Warning 9660: (119-123): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (118-123): Type shielded_int_const -129 is not implicitly convertible to expected type sint8. Literal is too large to fit in sint8.
+// Warning 9660: (137-143): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (137-143): Type shielded_int_const 32768 is not implicitly convertible to expected type sint16. Literal is too large to fit in sint16.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_sint_overflow_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_sint_overflow_fail.sol
@@ -9,9 +9,9 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (100-104): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (100-104): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (100-104): Type shielded_int_const 128 is not implicitly convertible to expected type sint8. Literal is too large to fit in sint8.
-// Warning 9660: (119-123): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (119-123): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (118-123): Type shielded_int_const -129 is not implicitly convertible to expected type sint8. Literal is too large to fit in sint8.
-// Warning 9660: (137-143): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (137-143): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (137-143): Type shielded_int_const 32768 is not implicitly convertible to expected type sint16. Literal is too large to fit in sint16.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_sint_to_suint_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_sint_to_suint_fail.sol
@@ -1,0 +1,15 @@
+contract C {
+    suint256 private x;
+    sint256 private y;
+
+    function test() internal {
+        // Negative shielded literal should not fit in unsigned shielded type
+        x = -1s;
+        // But positive shielded literal should fit in signed type
+        y = 42s;
+    }
+}
+// ----
+// Warning 9660: (183-185): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (182-185): Type shielded_int_const -1 is not implicitly convertible to expected type suint256. Cannot implicitly convert signed literal to unsigned type.
+// Warning 9660: (266-269): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_sint_to_suint_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_sint_to_suint_fail.sol
@@ -10,6 +10,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (183-185): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (183-185): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (182-185): Type shielded_int_const -1 is not implicitly convertible to expected type suint256. Cannot implicitly convert signed literal to unsigned type.
-// Warning 9660: (266-269): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (266-269): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_storage_init.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_storage_init.sol
@@ -1,0 +1,12 @@
+contract C {
+    // Storage variable initialization with shielded literals
+    suint256 private x = 42s;
+    suint8 private y = 255s;
+    sint256 private z = -100s;
+    sint8 private w = -128s;
+}
+// ----
+// Warning 9660: (100-103): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (128-132): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (159-163): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (188-192): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_storage_init.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_storage_init.sol
@@ -6,7 +6,7 @@ contract C {
     sint8 private w = -128s;
 }
 // ----
-// Warning 9660: (100-103): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (128-132): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (159-163): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (188-192): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (100-103): Shielded number literals will leak during contract deployment.
+// Warning 9667: (128-132): Shielded number literals will leak during contract deployment.
+// Warning 9667: (159-163): Shielded number literals will leak during contract deployment.
+// Warning 9667: (188-192): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_struct_field.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_struct_field.sol
@@ -1,0 +1,22 @@
+contract C {
+    struct Data {
+        suint256 value;
+        sint256 signed_value;
+    }
+
+    Data private d;
+
+    function test() internal {
+        // Assign shielded literals to struct fields
+        d.value = 42s;
+        d.signed_value = -10s;
+        // Create struct with shielded literals
+        Data memory local = Data(100s, -50s);
+    }
+}
+// ----
+// Warning 9660: (215-218): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (246-249): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (332-336): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (339-342): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 2072: (307-324): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_struct_field.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_struct_field.sol
@@ -15,8 +15,8 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (215-218): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (246-249): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (332-336): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (339-342): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (215-218): Shielded number literals will leak during contract deployment.
+// Warning 9667: (246-249): Shielded number literals will leak during contract deployment.
+// Warning 9667: (332-336): Shielded number literals will leak during contract deployment.
+// Warning 9667: (339-342): Shielded number literals will leak during contract deployment.
 // Warning 2072: (307-324): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_subdenomination_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_subdenomination_fail.sol
@@ -1,0 +1,10 @@
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        // Shielded literal with ether subdenomination should fail
+        x = 1s ether;
+    }
+}
+// ----
+// ParserError 9832: (151-156): Shielded number literals cannot be used with unit denominations.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_suint_all_overflow_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_suint_all_overflow_fail.sol
@@ -15,13 +15,13 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (216-220): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (216-220): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (216-220): Type shielded_int_const 256 is not implicitly convertible to expected type suint8. Literal is too large to fit in suint8.
-// Warning 9660: (234-240): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (234-240): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (234-240): Type shielded_int_const 65536 is not implicitly convertible to expected type suint16. Literal is too large to fit in suint16.
-// Warning 9660: (254-265): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (254-265): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (254-265): Type shielded_int_const 4294967296 is not implicitly convertible to expected type suint32. Literal is too large to fit in suint32.
-// Warning 9660: (279-300): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (279-300): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (279-300): Type shielded_int_const 18446744073709551616 is not implicitly convertible to expected type suint64. Literal is too large to fit in suint64.
-// Warning 9660: (314-354): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (314-354): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (314-354): Type shielded_int_const 3402...(31 digits omitted)...1456 is not implicitly convertible to expected type suint128. Literal is too large to fit in suint128.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_suint_all_overflow_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_suint_all_overflow_fail.sol
@@ -1,0 +1,27 @@
+contract C {
+    suint8 private a;
+    suint16 private b;
+    suint32 private c;
+    suint64 private d;
+    suint128 private e;
+
+    function test() internal {
+        // One more than max for each width
+        a = 256s;
+        b = 65536s;
+        c = 4294967296s;
+        d = 18446744073709551616s;
+        e = 340282366920938463463374607431768211456s;
+    }
+}
+// ----
+// Warning 9660: (216-220): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (216-220): Type shielded_int_const 256 is not implicitly convertible to expected type suint8. Literal is too large to fit in suint8.
+// Warning 9660: (234-240): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (234-240): Type shielded_int_const 65536 is not implicitly convertible to expected type suint16. Literal is too large to fit in suint16.
+// Warning 9660: (254-265): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (254-265): Type shielded_int_const 4294967296 is not implicitly convertible to expected type suint32. Literal is too large to fit in suint32.
+// Warning 9660: (279-300): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (279-300): Type shielded_int_const 18446744073709551616 is not implicitly convertible to expected type suint64. Literal is too large to fit in suint64.
+// Warning 9660: (314-354): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (314-354): Type shielded_int_const 3402...(31 digits omitted)...1456 is not implicitly convertible to expected type suint128. Literal is too large to fit in suint128.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_suint_basic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_suint_basic.sol
@@ -17,10 +17,10 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (196-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (212-216): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (230-236): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (250-257): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (271-281): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (295-300): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (314-316): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (196-198): Shielded number literals will leak during contract deployment.
+// Warning 9667: (212-216): Shielded number literals will leak during contract deployment.
+// Warning 9667: (230-236): Shielded number literals will leak during contract deployment.
+// Warning 9667: (250-257): Shielded number literals will leak during contract deployment.
+// Warning 9667: (271-281): Shielded number literals will leak during contract deployment.
+// Warning 9667: (295-300): Shielded number literals will leak during contract deployment.
+// Warning 9667: (314-316): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_suint_basic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_suint_basic.sol
@@ -1,0 +1,26 @@
+contract C {
+    suint8 private a;
+    suint16 private b;
+    suint32 private c;
+    suint64 private d;
+    suint128 private e;
+    suint256 private f;
+
+    function test() internal {
+        a = 0s;
+        a = 255s;
+        b = 65535s;
+        c = 0xDEADs;
+        d = 1_000_000s;
+        e = 1e10s;
+        f = 0s;
+    }
+}
+// ----
+// Warning 9660: (196-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (212-216): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (230-236): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (250-257): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (271-281): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (295-300): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (314-316): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_suint_overflow_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_suint_overflow_fail.sol
@@ -8,7 +8,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (102-106): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (102-106): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (102-106): Type shielded_int_const 256 is not implicitly convertible to expected type suint8. Literal is too large to fit in suint8.
-// Warning 9660: (120-126): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (120-126): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (120-126): Type shielded_int_const 65536 is not implicitly convertible to expected type suint16. Literal is too large to fit in suint16.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_suint_overflow_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_suint_overflow_fail.sol
@@ -1,0 +1,14 @@
+contract C {
+    suint8 private a;
+    suint16 private b;
+
+    function test() internal {
+        a = 256s;
+        b = 65536s;
+    }
+}
+// ----
+// Warning 9660: (102-106): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (102-106): Type shielded_int_const 256 is not implicitly convertible to expected type suint8. Literal is too large to fit in suint8.
+// Warning 9660: (120-126): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 7407: (120-126): Type shielded_int_const 65536 is not implicitly convertible to expected type suint16. Literal is too large to fit in suint16.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_ternary.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_ternary.sol
@@ -1,0 +1,16 @@
+contract C {
+    suint256 private x;
+
+    function test(bool cond) internal {
+        // Ternary with shielded literals
+        x = cond ? 1s : 2s;
+        // Ternary with arithmetic
+        x = cond ? (10s + 20s) : 0s;
+    }
+}
+// ----
+// Warning 9660: (139-141): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (144-146): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (203-206): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (209-212): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (216-218): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_ternary.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_ternary.sol
@@ -9,8 +9,8 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (139-141): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (144-146): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (203-206): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (209-212): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (216-218): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (139-141): Shielded number literals will leak during contract deployment.
+// Warning 9667: (144-146): Shielded number literals will leak during contract deployment.
+// Warning 9667: (203-206): Shielded number literals will leak during contract deployment.
+// Warning 9667: (209-212): Shielded number literals will leak during contract deployment.
+// Warning 9667: (216-218): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_to_address_cast.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_to_address_cast.sol
@@ -8,8 +8,8 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (227-230): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (320-323): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (227-230): Shielded number literals will leak during contract deployment.
+// Warning 9667: (320-323): Shielded number literals will leak during contract deployment.
 // Warning 2072: (207-216): Unused local variable.
 // Warning 2072: (298-308): Unused local variable.
 // Warning 2018: (116-331): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/types/shielded_literal_to_address_cast.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_to_address_cast.sol
@@ -1,0 +1,15 @@
+// Bug: address(42s) should be blocked since shielded literals can't convert to non-shielded types
+contract C {
+    function test() internal {
+        // Explicit cast of shielded literal to address
+        address a = address(42s);
+        // Explicit cast of shielded literal to saddress
+        saddress b = saddress(42s);
+    }
+}
+// ----
+// Warning 9660: (227-230): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (320-323): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 2072: (207-216): Unused local variable.
+// Warning 2072: (298-308): Unused local variable.
+// Warning 2018: (116-331): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/types/shielded_literal_to_unshielded_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_to_unshielded_fail.sol
@@ -1,0 +1,17 @@
+contract C {
+    function test() internal {
+        // Shielded literal to uint
+        uint8 a = 1s;
+        // Shielded literal to int
+        int8 b = -1s;
+        // Shielded literal to uint256
+        uint256 c = 42s;
+    }
+}
+// ----
+// Warning 9660: (98-100): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 9574: (88-100): Type shielded_int_const 1 is not implicitly convertible to expected type uint8. Shielded number literal cannot be implicitly converted to non-shielded type.
+// Warning 9660: (155-157): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 9574: (145-157): Type shielded_int_const -1 is not implicitly convertible to expected type int8. Shielded number literal cannot be implicitly converted to non-shielded type.
+// Warning 9660: (218-221): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// TypeError 9574: (206-221): Type shielded_int_const 42 is not implicitly convertible to expected type uint256. Shielded number literal cannot be implicitly converted to non-shielded type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_to_unshielded_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_to_unshielded_fail.sol
@@ -9,9 +9,9 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (98-100): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (98-100): Shielded number literals will leak during contract deployment.
 // TypeError 9574: (88-100): Type shielded_int_const 1 is not implicitly convertible to expected type uint8. Shielded number literal cannot be implicitly converted to non-shielded type.
-// Warning 9660: (155-157): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (155-157): Shielded number literals will leak during contract deployment.
 // TypeError 9574: (145-157): Type shielded_int_const -1 is not implicitly convertible to expected type int8. Shielded number literal cannot be implicitly converted to non-shielded type.
-// Warning 9660: (218-221): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (218-221): Shielded number literals will leak during contract deployment.
 // TypeError 9574: (206-221): Type shielded_int_const 42 is not implicitly convertible to expected type uint256. Shielded number literal cannot be implicitly converted to non-shielded type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_type_min_max.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_type_min_max.sol
@@ -1,0 +1,15 @@
+contract C {
+    suint8 private a;
+    suint256 private b;
+    sint8 private c;
+    sint256 private d;
+
+    function test() internal {
+        // type().max and type().min with shielded types
+        a = type(suint8).max;
+        b = type(suint256).max;
+        c = type(sint8).min;
+        d = type(sint256).min;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/types/shielded_literal_unary_ops.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_unary_ops.sol
@@ -11,6 +11,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (104-107): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (151-154): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (201-204): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (104-107): Shielded number literals will leak during contract deployment.
+// Warning 9667: (151-154): Shielded number literals will leak during contract deployment.
+// Warning 9667: (201-204): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_unary_ops.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_unary_ops.sol
@@ -1,0 +1,16 @@
+contract C {
+    sint256 private x;
+
+    function test() internal {
+        // Unary minus
+        x = -42s;
+        // Double negation
+        x = -(-42s);
+        // Triple negation
+        x = -(-(-42s));
+    }
+}
+// ----
+// Warning 9660: (104-107): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (151-154): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (201-204): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_underscore_various.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_underscore_various.sol
@@ -1,0 +1,18 @@
+contract C {
+    suint256 private x;
+
+    function test() internal {
+        // Various underscore placements in shielded literals
+        x = 1_000s;
+        x = 1_000_000s;
+        x = 1_000_000_000s;
+        x = 0xFF_FFs;
+        x = 0x00_00_00_01s;
+    }
+}
+// ----
+// Warning 9660: (143-149): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (163-173): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (187-201): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (215-223): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (237-251): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_underscore_various.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_underscore_various.sol
@@ -11,8 +11,8 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (143-149): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (163-173): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (187-201): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (215-223): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (237-251): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (143-149): Shielded number literals will leak during contract deployment.
+// Warning 9667: (163-173): Shielded number literals will leak during contract deployment.
+// Warning 9667: (187-201): Shielded number literals will leak during contract deployment.
+// Warning 9667: (215-223): Shielded number literals will leak during contract deployment.
+// Warning 9667: (237-251): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_zero_contexts.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_zero_contexts.sol
@@ -1,0 +1,32 @@
+contract C {
+    suint256 private a;
+    suint8 private b;
+    sint256 private c;
+    sint8 private d;
+
+    function test() internal {
+        // Zero shielded literal in various contexts
+        a = 0s;
+        b = 0s;
+        c = 0s;
+        d = 0s;
+        // Zero in arithmetic
+        a = 0s + 1s;
+        a = 1s - 1s;
+        a = 0s * 100s;
+        // Hex zero
+        a = 0x0s;
+    }
+}
+// ----
+// Warning 9660: (200-202): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (216-218): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (232-234): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (248-250): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (294-296): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (299-301): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (315-317): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (320-322): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (336-338): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (341-345): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9660: (379-383): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_zero_contexts.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_zero_contexts.sol
@@ -19,14 +19,14 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (200-202): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (216-218): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (232-234): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (248-250): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (294-296): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (299-301): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (315-317): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (320-322): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (336-338): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (341-345): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (379-383): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (200-202): Shielded number literals will leak during contract deployment.
+// Warning 9667: (216-218): Shielded number literals will leak during contract deployment.
+// Warning 9667: (232-234): Shielded number literals will leak during contract deployment.
+// Warning 9667: (248-250): Shielded number literals will leak during contract deployment.
+// Warning 9667: (294-296): Shielded number literals will leak during contract deployment.
+// Warning 9667: (299-301): Shielded number literals will leak during contract deployment.
+// Warning 9667: (315-317): Shielded number literals will leak during contract deployment.
+// Warning 9667: (320-322): Shielded number literals will leak during contract deployment.
+// Warning 9667: (336-338): Shielded number literals will leak during contract deployment.
+// Warning 9667: (341-345): Shielded number literals will leak during contract deployment.
+// Warning 9667: (379-383): Shielded number literals will leak during contract deployment.


### PR DESCRIPTION
## Summary

- Add `s` suffix for numeric literals to create shielded integer constants (e.g. `suint8 x = 42s;` instead of `suint8 x = suint8(42);`)
- The literal's concrete shielded type (suint8 vs suint256, signed vs unsigned) is inferred from context
- Works with hex (`0xDEADs`), underscores (`1_000s`), scientific notation (`1e5s`), and unary minus (`-1s`)
- Mixed shielded/non-shielded arithmetic (`1s + 1`) is rejected — both operands must use `s`
- Shielded literals cannot implicitly convert to non-shielded types (`uint8 x = 1s;` errors)
- Warning 9660 emitted for all shielded literals (values visible in deployment bytecode)
- No impact on bools or variable names ending in `s`

## Changes

**Scanner/Token** (`liblangutil/`): New `ShieldedNumber` token; scanner consumes trailing `s` on numeric literals when not followed by an identifier character.

**Parser** (`libsolidity/parsing/`): Handle `ShieldedNumber` in literal/expression parsing; reject `s` + subdenomination combos.

**Type system** (`libsolidity/ast/`): `RationalNumberType` gains `m_shielded` flag propagated through unary/binary ops, equality, `mobileType()`, and `toString()`. New `shieldedIntegerType()` method.

**Analysis** (`libsolidity/analysis/`): `SyntaxChecker` validates formatting; `TypeChecker` emits warning 9660.

**AST JSON** (`libsolidity/ast/`): Export/import `"shieldedNumber"` literal kind.

## Test plan

- [x] 8129 unit tests (`soltest.sh`) — all pass
- [x] 3788 syntax tests (`isoltest`) — all pass, no regressions
- [x] 11 new syntax tests covering suint/sint basics, overflow, type mismatch, mixed arithmetic, fractional, identifier regression
- [x] 2 new semantic tests (`shielded_literal_suint.sol`, `shielded_literal_sint.sol`) — pass via seismic-revm
- [x] CI: full semantic test sweep with optimizer configurations