### PR TITLE
ci: clone seismic-revm from seismic branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,12 +82,9 @@ jobs:
       - name: Run soltest
         run: ./scripts/soltest.sh
 
-      # TODO: Remove the hardcoded commit checkout once we merge the --skip-via-ir flag into the seismic branch of seismic-revm
       - name: Clone seismic-revm repo
         run: |
-          git clone https://github.com/SeismicSystems/seismic-revm.git /tmp/seismic-revm
-          cd /tmp/seismic-revm
-          git checkout e962e2174e097e69284cf9cbbbf7bc15e5d718cf
+          git clone --branch seismic https://github.com/SeismicSystems/seismic-revm.git /tmp/seismic-revm
           echo "SEISMIC_REVM_PATH=/tmp/seismic-revm" >> $GITHUB_ENV
           echo "seismic-revm cloned to: /tmp/seismic-revm"
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

- Fix CI failure: `git checkout e962e217...` fails because that commit only exists on the unmerged `ci-via-ir-support` branch in seismic-revm
- The `--unsafe-via-ir` flag has already been merged into seismic-revm's `seismic` branch (commit `03f561fd`)
- Clone `--branch seismic` directly instead of cloning default branch + checking out a hardcoded commit

## Test plan

- [ ] CI workflow successfully clones seismic-revm and runs semantic tests