### PR TITLE
test: add semantic test for timestamp_ms division invariant

### DIFF
--- a/test/libsolidity/semanticTests/timestamps/timestamp_ms_division_invariant.sol
+++ b/test/libsolidity/semanticTests/timestamps/timestamp_ms_division_invariant.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0;
+
+// Verify that block.timestamp_ms / 1000 == block.timestamp
+// and block.timestamp_seconds == block.timestamp within a single call.
+contract C {
+    function checkMsDivisionEqualsTimestamp() public view returns (bool) {
+        return block.timestamp_ms / 1000 == block.timestamp;
+    }
+
+    function checkSecondsEqualsTimestamp() public view returns (bool) {
+        return block.timestamp_seconds == block.timestamp;
+    }
+
+    function checkAllConsistent() public view returns (bool) {
+        uint256 ts = block.timestamp;
+        uint256 tsMs = block.timestamp_ms;
+        uint256 tsSec = block.timestamp_seconds;
+        return (tsMs / 1000 == ts) && (tsSec == ts);
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// checkMsDivisionEqualsTimestamp() -> true
+// checkSecondsEqualsTimestamp() -> true
+// checkAllConsistent() -> true


### PR DESCRIPTION
## Summary
- Adds a semantic test verifying that `block.timestamp_ms / 1000 == block.timestamp` and `block.timestamp_seconds == block.timestamp` within a single call
- Existing tests only check the weaker `block.timestamp_ms >= block.timestamp * 1000` inequality; this test asserts exact equality after integer division
- Runs via both legacy and IR (`compileViaYul: also`) pipelines

## Test plan
- [x] CI semantic tests pass for both legacy and via-IR compilation