### PR TITLE
Rename rng built-in functions to sync_rng

### DIFF
--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -63,12 +63,12 @@ int magicVariableToID(std::string const& _name)
 		{"type", -27},
 		{"this", -28},
 		{"blobhash", -29},
-		{"rng8", -30},
-		{"rng16", -31},
-		{"rng32", -32},
-		{"rng64", -33},
-		{"rng128", -34},
-		{"rng256", -35},
+		{"sync_rng8", -30},
+		{"sync_rng16", -31},
+		{"sync_rng32", -32},
+		{"sync_rng64", -33},
+		{"sync_rng128", -34},
+		{"sync_rng256", -35},
 		{"ecdh", -36},
 		{"aes_gcm_encrypt", -37},
 		{"aes_gcm_decrypt", -38},
@@ -130,12 +130,12 @@ inline std::vector<std::shared_ptr<MagicVariableDeclaration const>> constructMag
 		);
 
 	// Seismic RNG precompile built-in functions
-	magicVariableDeclarations.push_back(magicVarDecl("rng8",   TypeProvider::function(strings{}, strings{"suint8"},   FunctionType::Kind::SeismicRNG, StateMutability::View)));
-	magicVariableDeclarations.push_back(magicVarDecl("rng16",  TypeProvider::function(strings{}, strings{"suint16"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
-	magicVariableDeclarations.push_back(magicVarDecl("rng32",  TypeProvider::function(strings{}, strings{"suint32"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
-	magicVariableDeclarations.push_back(magicVarDecl("rng64",  TypeProvider::function(strings{}, strings{"suint64"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
-	magicVariableDeclarations.push_back(magicVarDecl("rng128", TypeProvider::function(strings{}, strings{"suint128"}, FunctionType::Kind::SeismicRNG, StateMutability::View)));
-	magicVariableDeclarations.push_back(magicVarDecl("rng256", TypeProvider::function(strings{}, strings{"suint256"}, FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("sync_rng8",   TypeProvider::function(strings{}, strings{"suint8"},   FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("sync_rng16",  TypeProvider::function(strings{}, strings{"suint16"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("sync_rng32",  TypeProvider::function(strings{}, strings{"suint32"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("sync_rng64",  TypeProvider::function(strings{}, strings{"suint64"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("sync_rng128", TypeProvider::function(strings{}, strings{"suint128"}, FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("sync_rng256", TypeProvider::function(strings{}, strings{"suint256"}, FunctionType::Kind::SeismicRNG, StateMutability::View)));
 
 	// Seismic ECDH precompile built-in function
 	magicVariableDeclarations.push_back(magicVarDecl("ecdh", TypeProvider::function(strings{"sbytes32", "bytes memory"}, strings{"bytes32"}, FunctionType::Kind::SeismicECDH, StateMutability::View)));

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_builtins.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_builtins.sol
@@ -2,46 +2,46 @@
 pragma solidity ^0.8.0;
 
 contract RngBuiltins {
-    // Each test verifies the rng call succeeds and the result looks random.
+    // Each test verifies the sync_rng call succeeds and the result looks random.
     // For N-bit types (N >= 30): check val in [2^(N-30), max - 2^(N-30)].
     // P(false positive) ≈ 2 * 2^(-30) ≈ 2e-9 per test.
     // For smaller types: combine multiple samples.
 
     function testRng256() public view returns (bool) {
-        uint256 val = uint256(rng256());
+        uint256 val = uint256(sync_rng256());
         return val >= 2**226 && val <= type(uint256).max - 2**226;
     }
 
     function testRng128() public view returns (bool) {
-        uint128 val = uint128(rng128());
+        uint128 val = uint128(sync_rng128());
         return val >= 2**98 && val <= type(uint128).max - 2**98;
     }
 
     function testRng64() public view returns (bool) {
-        uint64 val = uint64(rng64());
+        uint64 val = uint64(sync_rng64());
         return val >= 2**34 && val <= type(uint64).max - 2**34;
     }
 
     function testRng32() public view returns (bool) {
-        uint32 val = uint32(rng32());
+        uint32 val = uint32(sync_rng32());
         return val >= 4 && val <= type(uint32).max - 4;
     }
 
     function testRng16() public view returns (bool) {
         // 16 bits: two samples, check not all-zero and not all-ones.
         // P(false positive) ≈ 2 * (1/2^16)^2 ≈ 5e-10.
-        uint16 a = uint16(rng16());
-        uint16 b = uint16(rng16());
+        uint16 a = uint16(sync_rng16());
+        uint16 b = uint16(sync_rng16());
         return (a | b) > 0 && (a & b) < type(uint16).max;
     }
 
     function testRng8() public view returns (bool) {
         // 8 bits: four samples, check not all-zero and not all-ones.
         // P(false positive) ≈ 2 * (1/2^8)^4 ≈ 5e-10.
-        uint8 a = uint8(rng8());
-        uint8 b = uint8(rng8());
-        uint8 c = uint8(rng8());
-        uint8 d = uint8(rng8());
+        uint8 a = uint8(sync_rng8());
+        uint8 b = uint8(sync_rng8());
+        uint8 c = uint8(sync_rng8());
+        uint8 d = uint8(sync_rng8());
         return (a | b | c | d) > 0 && (a & b & c & d) < type(uint8).max;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_type_check.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_type_check.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.0;
 
 contract C {
     function f() public view {
-        suint8 a = rng8();
-        suint16 b = rng16();
-        suint32 c = rng32();
-        suint64 d = rng64();
-        suint128 e = rng128();
-        suint256 g = rng256();
+        suint8 a = sync_rng8();
+        suint16 b = sync_rng16();
+        suint32 c = sync_rng32();
+        suint64 d = sync_rng64();
+        suint128 e = sync_rng128();
+        suint256 g = sync_rng256();
         a; b; c; d; e; g;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_view_not_pure.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_view_not_pure.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.0;
 
 contract C {
     function f() internal pure returns (suint256) {
-        return rng256();
+        return sync_rng256();
     }
 }
 // ----
-// TypeError 2527: (137-145): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (137-150): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".


### PR DESCRIPTION
## Summary
- Rename all rngN built-in functions to sync_rngN
- Update magic variable ID mappings and declarations in GlobalContext.cpp
- Update all existing semantic and syntax tests to use the new names

## Test plan
- [ ] Verify syntax tests pass
- [ ] Verify semantic tests pass
- [ ] Grep for any remaining rngN references