### PR TITLE
feat: add sync_rng96 built-in

### DIFF
--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -108,9 +108,9 @@ int magicVariableToID(std::string const& _name)
 		{"sync_rng16", -234},
 		{"sync_rng32", -235},
 		{"sync_rng64", -236},
-		{"sync_rng128", -237},
-		{"sync_rng256", -238},
-		{"sync_rng96", -239}
+		{"sync_rng96", -237},
+		{"sync_rng128", -238},
+		{"sync_rng256", -239}
 	};
 
 	if (auto id = magicVariables.find(_name); id != magicVariables.end())

--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -109,7 +109,8 @@ int magicVariableToID(std::string const& _name)
 		{"sync_rng32", -235},
 		{"sync_rng64", -236},
 		{"sync_rng128", -237},
-		{"sync_rng256", -238}
+		{"sync_rng256", -238},
+		{"sync_rng96", -239}
 	};
 
 	if (auto id = magicVariables.find(_name); id != magicVariables.end())
@@ -170,6 +171,7 @@ inline std::vector<std::shared_ptr<MagicVariableDeclaration const>> constructMag
 	magicVariableDeclarations.push_back(magicVarDecl("sync_rng16",  TypeProvider::function(strings{}, strings{"suint16"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
 	magicVariableDeclarations.push_back(magicVarDecl("sync_rng32",  TypeProvider::function(strings{}, strings{"suint32"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
 	magicVariableDeclarations.push_back(magicVarDecl("sync_rng64",  TypeProvider::function(strings{}, strings{"suint64"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("sync_rng96",  TypeProvider::function(strings{}, strings{"suint96"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
 	magicVariableDeclarations.push_back(magicVarDecl("sync_rng128", TypeProvider::function(strings{}, strings{"suint128"}, FunctionType::Kind::SeismicRNG, StateMutability::View)));
 	magicVariableDeclarations.push_back(magicVarDecl("sync_rng256", TypeProvider::function(strings{}, strings{"suint256"}, FunctionType::Kind::SeismicRNG, StateMutability::View)));
 

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_builtins.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_builtins.sol
@@ -17,6 +17,11 @@ contract RngBuiltins {
         return val >= 2**98 && val <= type(uint128).max - 2**98;
     }
 
+    function testRng96() public view returns (bool) {
+        uint128 val = uint128(sync_rng96());
+        return val >= 2**66 && val <= 2**96 - 1 - 2**66;
+    }
+
     function testRng64() public view returns (bool) {
         uint64 val = uint64(sync_rng64());
         return val >= 2**34 && val <= type(uint64).max - 2**34;
@@ -51,6 +56,7 @@ contract RngBuiltins {
 // ----
 // testRng256() -> true
 // testRng128() -> true
+// testRng96() -> true
 // testRng64() -> true
 // testRng32() -> true
 // testRng16() -> true

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_type_check.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_type_check.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.0;
 
 contract C {
     function f() public view {
-        suint8 a = sync_rng8();
-        suint16 b = sync_rng16();
-        suint32 c = sync_rng32();
-        suint64 d = sync_rng64();
-        suint96 e2 = sync_rng96();
-        suint128 e = sync_rng128();
-        suint256 g = sync_rng256();
-        a; b; c; d; e2; e; g;
+        suint8 r8 = sync_rng8();
+        suint16 r16 = sync_rng16();
+        suint32 r32 = sync_rng32();
+        suint64 r64 = sync_rng64();
+        suint96 r96 = sync_rng96();
+        suint128 r128 = sync_rng128();
+        suint256 r256 = sync_rng256();
+        r8; r16; r32; r64; r96; r128; r256;
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_type_check.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_type_check.sol
@@ -7,9 +7,10 @@ contract C {
         suint16 b = sync_rng16();
         suint32 c = sync_rng32();
         suint64 d = sync_rng64();
+        suint96 e2 = sync_rng96();
         suint128 e = sync_rng128();
         suint256 g = sync_rng256();
-        a; b; c; d; e; g;
+        a; b; c; d; e2; e; g;
     }
 }
 // ----


### PR DESCRIPTION
## Summary
- Add `sync_rng96()` built-in function returning `suint96`, following the same pattern as the existing `sync_rng8`/`16`/`32`/`64`/`128`/`256` family
- Register the magic variable ID (-239) and declaration in `GlobalContext.cpp`
- No codegen changes needed -- the RNG precompile dispatch already derives `byteWidth` from the return type dynamically

## Test plan
- [ ] Updated `rng_type_check.sol` syntax test to include `sync_rng96`
- [ ] Updated `rng_builtins.sol` semantic test with a `testRng96()` that verifies the returned value is in the expected random range
- [ ] Existing sync_rng tests continue to pass unchanged