### PR TITLE
fix: unique error ID for shielded number literal suffix warning

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -4277,10 +4277,9 @@ void TypeChecker::endVisit(Literal const& _literal)
 
 	if (_literal.token() == Token::ShieldedNumber)
 		m_errorReporter.warning(
-			9660_error,
+			9667_error,
 			_literal.location(),
-			"Shielded number literals are converted to shielded integers whose values "
-			"will be visible in contract creation code during deployment."
+			"Shielded number literals will leak during contract deployment."
 		);
 
 	if (_literal.subDenomination() == Literal::SubDenomination::Year)

--- a/test/libsolidity/syntaxTests/types/shielded_literal_abi_encode_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_abi_encode_fail.sol
@@ -5,5 +5,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (136-139): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (136-139): Shielded number literals will leak during contract deployment.
 // TypeError 3648: (136-139): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_address_length_hex.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_address_length_hex.sol
@@ -8,5 +8,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (227-270): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (227-270): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (227-270): Type address is not implicitly convertible to expected type suint256.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_all_sint_widths.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_all_sint_widths.sol
@@ -24,15 +24,15 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (234-238): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (252-258): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (272-283): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (297-317): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (331-371): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (385-463): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (522-526): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (541-547): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (562-573): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (588-608): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (623-663): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (678-756): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (234-238): Shielded number literals will leak during contract deployment.
+// Warning 9667: (252-258): Shielded number literals will leak during contract deployment.
+// Warning 9667: (272-283): Shielded number literals will leak during contract deployment.
+// Warning 9667: (297-317): Shielded number literals will leak during contract deployment.
+// Warning 9667: (331-371): Shielded number literals will leak during contract deployment.
+// Warning 9667: (385-463): Shielded number literals will leak during contract deployment.
+// Warning 9667: (522-526): Shielded number literals will leak during contract deployment.
+// Warning 9667: (541-547): Shielded number literals will leak during contract deployment.
+// Warning 9667: (562-573): Shielded number literals will leak during contract deployment.
+// Warning 9667: (588-608): Shielded number literals will leak during contract deployment.
+// Warning 9667: (623-663): Shielded number literals will leak during contract deployment.
+// Warning 9667: (678-756): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_all_suint_widths.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_all_suint_widths.sol
@@ -17,9 +17,9 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (237-241): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (255-261): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (275-286): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (300-321): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (335-375): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (389-468): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (237-241): Shielded number literals will leak during contract deployment.
+// Warning 9667: (255-261): Shielded number literals will leak during contract deployment.
+// Warning 9667: (275-286): Shielded number literals will leak during contract deployment.
+// Warning 9667: (300-321): Shielded number literals will leak during contract deployment.
+// Warning 9667: (335-375): Shielded number literals will leak during contract deployment.
+// Warning 9667: (389-468): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_arithmetic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_arithmetic.sol
@@ -18,15 +18,15 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (124-126): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (129-131): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (168-171): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (174-177): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (217-219): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (222-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (258-261): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (264-266): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (298-301): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (304-306): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (346-348): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (352-354): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (124-126): Shielded number literals will leak during contract deployment.
+// Warning 9667: (129-131): Shielded number literals will leak during contract deployment.
+// Warning 9667: (168-171): Shielded number literals will leak during contract deployment.
+// Warning 9667: (174-177): Shielded number literals will leak during contract deployment.
+// Warning 9667: (217-219): Shielded number literals will leak during contract deployment.
+// Warning 9667: (222-224): Shielded number literals will leak during contract deployment.
+// Warning 9667: (258-261): Shielded number literals will leak during contract deployment.
+// Warning 9667: (264-266): Shielded number literals will leak during contract deployment.
+// Warning 9667: (298-301): Shielded number literals will leak during contract deployment.
+// Warning 9667: (304-306): Shielded number literals will leak during contract deployment.
+// Warning 9667: (346-348): Shielded number literals will leak during contract deployment.
+// Warning 9667: (352-354): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_array_element.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_array_element.sol
@@ -14,8 +14,8 @@ contract C {
 }
 // ----
 // Warning 9665: (17-39): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
-// Warning 9660: (173-176): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (196-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (265-267): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (292-294): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (319-323): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (173-176): Shielded number literals will leak during contract deployment.
+// Warning 9667: (196-198): Shielded number literals will leak during contract deployment.
+// Warning 9667: (265-267): Shielded number literals will leak during contract deployment.
+// Warning 9667: (292-294): Shielded number literals will leak during contract deployment.
+// Warning 9667: (319-323): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_assign_to_var_expression.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_assign_to_var_expression.sol
@@ -12,11 +12,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (152-155): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (173-175): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (152-155): Shielded number literals will leak during contract deployment.
+// Warning 9667: (173-175): Shielded number literals will leak during contract deployment.
 // Warning 4282: (169-175): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.
-// Warning 9660: (193-195): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (193-195): Shielded number literals will leak during contract deployment.
 // Warning 4282: (189-195): Shielded integer multiplication can leak information. A revert due to overflow reveals range information about the operands.
-// Warning 9660: (210-212): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (230-232): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (210-212): Shielded number literals will leak during contract deployment.
+// Warning 9667: (230-232): Shielded number literals will leak during contract deployment.
 // Warning 4282: (226-232): Shielded integer subtraction can leak information. A revert due to overflow reveals range information about the operands.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_basic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_basic.sol
@@ -23,11 +23,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (166-169): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (183-187): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (202-204): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (251-256): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (310-316): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (379-383): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (429-431): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (434-436): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (166-169): Shielded number literals will leak during contract deployment.
+// Warning 9667: (183-187): Shielded number literals will leak during contract deployment.
+// Warning 9667: (202-204): Shielded number literals will leak during contract deployment.
+// Warning 9667: (251-256): Shielded number literals will leak during contract deployment.
+// Warning 9667: (310-316): Shielded number literals will leak during contract deployment.
+// Warning 9667: (379-383): Shielded number literals will leak during contract deployment.
+// Warning 9667: (429-431): Shielded number literals will leak during contract deployment.
+// Warning 9667: (434-436): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_bitwise.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_bitwise.sol
@@ -16,14 +16,14 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (126-131): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (134-139): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (175-180): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (183-188): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (225-230): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (233-238): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (280-285): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (288-293): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (297-302): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (350-355): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (358-363): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (126-131): Shielded number literals will leak during contract deployment.
+// Warning 9667: (134-139): Shielded number literals will leak during contract deployment.
+// Warning 9667: (175-180): Shielded number literals will leak during contract deployment.
+// Warning 9667: (183-188): Shielded number literals will leak during contract deployment.
+// Warning 9667: (225-230): Shielded number literals will leak during contract deployment.
+// Warning 9667: (233-238): Shielded number literals will leak during contract deployment.
+// Warning 9667: (280-285): Shielded number literals will leak during contract deployment.
+// Warning 9667: (288-293): Shielded number literals will leak during contract deployment.
+// Warning 9667: (297-302): Shielded number literals will leak during contract deployment.
+// Warning 9667: (350-355): Shielded number literals will leak during contract deployment.
+// Warning 9667: (358-363): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_bitwise_not.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_bitwise_not.sol
@@ -9,6 +9,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (144-146): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (144-146): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (143-146): Type shielded_int_const -1 is not implicitly convertible to expected type suint8. Cannot implicitly convert signed literal to unsigned type.
-// Warning 9660: (161-163): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (161-163): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_comparison.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_comparison.sol
@@ -18,17 +18,17 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (139-141): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (145-147): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (193-195): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (199-201): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (246-248): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (251-253): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (301-303): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (306-308): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (362-364): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (368-370): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (427-429): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (433-435): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (139-141): Shielded number literals will leak during contract deployment.
+// Warning 9667: (145-147): Shielded number literals will leak during contract deployment.
+// Warning 9667: (193-195): Shielded number literals will leak during contract deployment.
+// Warning 9667: (199-201): Shielded number literals will leak during contract deployment.
+// Warning 9667: (246-248): Shielded number literals will leak during contract deployment.
+// Warning 9667: (251-253): Shielded number literals will leak during contract deployment.
+// Warning 9667: (301-303): Shielded number literals will leak during contract deployment.
+// Warning 9667: (306-308): Shielded number literals will leak during contract deployment.
+// Warning 9667: (362-364): Shielded number literals will leak during contract deployment.
+// Warning 9667: (368-370): Shielded number literals will leak during contract deployment.
+// Warning 9667: (427-429): Shielded number literals will leak during contract deployment.
+// Warning 9667: (433-435): Shielded number literals will leak during contract deployment.
 // Warning 2072: (52-70): Unused local variable.
 // Warning 2018: (17-443): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/types/shielded_literal_comparison_result_type.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_comparison_result_type.sol
@@ -12,12 +12,12 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (215-217): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (220-222): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (238-240): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (244-246): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (262-264): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (268-270): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (350-352): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (355-357): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (215-217): Shielded number literals will leak during contract deployment.
+// Warning 9667: (220-222): Shielded number literals will leak during contract deployment.
+// Warning 9667: (238-240): Shielded number literals will leak during contract deployment.
+// Warning 9667: (244-246): Shielded number literals will leak during contract deployment.
+// Warning 9667: (262-264): Shielded number literals will leak during contract deployment.
+// Warning 9667: (268-270): Shielded number literals will leak during contract deployment.
+// Warning 9667: (350-352): Shielded number literals will leak during contract deployment.
+// Warning 9667: (355-357): Shielded number literals will leak during contract deployment.
 // TypeError 9574: (340-358): Type sbool is not implicitly convertible to expected type bool.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_constructor_init.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_constructor_init.sol
@@ -8,5 +8,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (93-96): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (111-115): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (93-96): Shielded number literals will leak during contract deployment.
+// Warning 9667: (111-115): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_cross_assign_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_cross_assign_fail.sol
@@ -10,7 +10,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (163-165): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (163-165): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (163-165): Type shielded_int_const 0 is not implicitly convertible to expected type saddress.
-// Warning 9660: (237-239): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (237-239): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (237-239): Type shielded_int_const 1 is not implicitly convertible to expected type sbool.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_division_by_zero.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_division_by_zero.sol
@@ -7,6 +7,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (132-134): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (137-139): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (132-134): Shielded number literals will leak during contract deployment.
+// Warning 9667: (137-139): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (132-139): Built-in binary operator / cannot be applied to types shielded_int_const 1 and shielded_int_const 0.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_double_negation.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_double_negation.sol
@@ -10,5 +10,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (134-137): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (199-202): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (134-137): Shielded number literals will leak during contract deployment.
+// Warning 9667: (199-202): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_event_emit_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_event_emit_fail.sol
@@ -7,5 +7,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (186-189): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (186-189): Shielded number literals will leak during contract deployment.
 // TypeError 9553: (186-189): Invalid type for argument in function call. Invalid implicit conversion from shielded_int_const 42 to uint256 requested. Shielded number literal cannot be implicitly converted to non-shielded type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_exp_limit_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_exp_limit_fail.sol
@@ -7,6 +7,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (136-138): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (142-146): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (136-138): Shielded number literals will leak during contract deployment.
+// Warning 9667: (142-146): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (136-146): Type shielded_int_const 1157...(70 digits omitted)...9936 is not implicitly convertible to expected type suint256. Literal is too large to fit in suint256.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_exp_limit_fine.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_exp_limit_fine.sol
@@ -10,11 +10,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (121-123): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (127-131): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (145-148): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (152-155): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (169-171): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (175-177): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (191-193): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (197-199): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (121-123): Shielded number literals will leak during contract deployment.
+// Warning 9667: (127-131): Shielded number literals will leak during contract deployment.
+// Warning 9667: (145-148): Shielded number literals will leak during contract deployment.
+// Warning 9667: (152-155): Shielded number literals will leak during contract deployment.
+// Warning 9667: (169-171): Shielded number literals will leak during contract deployment.
+// Warning 9667: (175-177): Shielded number literals will leak during contract deployment.
+// Warning 9667: (191-193): Shielded number literals will leak during contract deployment.
+// Warning 9667: (197-199): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_exp_with_shielded_var.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_exp_with_shielded_var.sol
@@ -12,7 +12,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (193-195): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (261-263): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (321-323): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (193-195): Shielded number literals will leak during contract deployment.
+// Warning 9667: (261-263): Shielded number literals will leak during contract deployment.
+// Warning 9667: (321-323): Shielded number literals will leak during contract deployment.
 // Warning 3817: (321-331): Shielded integer exponentiation will leak the exponent value through gas cost.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_explicit_cast.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_explicit_cast.sol
@@ -12,9 +12,9 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (160-163): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (160-163): Shielded number literals will leak during contract deployment.
 // Warning 9660: (153-164): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (224-227): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (224-227): Shielded number literals will leak during contract deployment.
 // Warning 9660: (215-228): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (339-342): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (339-342): Shielded number literals will leak during contract deployment.
 // TypeError 9640: (331-343): Explicit type conversion not allowed from "shielded_int_const 42" to "uint256".

--- a/test/libsolidity/syntaxTests/types/shielded_literal_explicit_cast_to_unshielded.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_explicit_cast_to_unshielded.sol
@@ -8,11 +8,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (136-139): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (136-139): Shielded number literals will leak during contract deployment.
 // TypeError 9640: (128-140): Explicit type conversion not allowed from "shielded_int_const 42" to "uint256".
-// Warning 9660: (166-170): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (166-170): Shielded number literals will leak during contract deployment.
 // TypeError 9640: (160-171): Explicit type conversion not allowed from "shielded_int_const 255" to "uint8".
-// Warning 9660: (200-203): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (200-203): Shielded number literals will leak during contract deployment.
 // TypeError 9640: (192-204): Explicit type conversion not allowed from "shielded_int_const -42" to "int256".
-// Warning 9660: (229-233): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (229-233): Shielded number literals will leak during contract deployment.
 // TypeError 9640: (223-234): Explicit type conversion not allowed from "shielded_int_const -128" to "int8".

--- a/test/libsolidity/syntaxTests/types/shielded_literal_fractional_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_fractional_fail.sol
@@ -6,5 +6,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (81-85): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (81-85): Shielded number literals will leak during contract deployment.
 // TypeError 2326: (81-85): Type shielded_rational_const 3 / 2 is not implicitly convertible to expected type suint256. Try converting to type ufixed8x1 or use an explicit conversion.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_function_arg.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_function_arg.sol
@@ -9,8 +9,8 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (247-250): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (253-256): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (247-250): Shielded number literals will leak during contract deployment.
+// Warning 9667: (253-256): Shielded number literals will leak during contract deployment.
 // Warning 5667: (53-62): Unused function parameter. Remove or comment out the variable name to silence this warning.
 // Warning 2072: (219-229): Unused local variable.
 // Warning 2018: (128-264): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/types/shielded_literal_hex_boundary_8bit.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_hex_boundary_8bit.sol
@@ -10,7 +10,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (120-125): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (139-144): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (158-163): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (177-182): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (120-125): Shielded number literals will leak during contract deployment.
+// Warning 9667: (139-144): Shielded number literals will leak during contract deployment.
+// Warning 9667: (158-163): Shielded number literals will leak during contract deployment.
+// Warning 9667: (177-182): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_hex_various.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_hex_various.sol
@@ -19,11 +19,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (190-195): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (209-214): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (228-233): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (247-254): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (268-279): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (293-312): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (354-358): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (394-401): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (190-195): Shielded number literals will leak during contract deployment.
+// Warning 9667: (209-214): Shielded number literals will leak during contract deployment.
+// Warning 9667: (228-233): Shielded number literals will leak during contract deployment.
+// Warning 9667: (247-254): Shielded number literals will leak during contract deployment.
+// Warning 9667: (268-279): Shielded number literals will leak during contract deployment.
+// Warning 9667: (293-312): Shielded number literals will leak during contract deployment.
+// Warning 9667: (354-358): Shielded number literals will leak during contract deployment.
+// Warning 9667: (394-401): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_huge_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_huge_fail.sol
@@ -7,5 +7,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (132-211): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (132-211): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (132-211): Type shielded_int_const 1157...(70 digits omitted)...9936 is not implicitly convertible to expected type suint256. Literal is too large to fit in suint256.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_implicit_widening.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_implicit_widening.sol
@@ -14,10 +14,10 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (188-190): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (207-211): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (228-234): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (252-254): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (273-275): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (293-297): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (316-320): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (188-190): Shielded number literals will leak during contract deployment.
+// Warning 9667: (207-211): Shielded number literals will leak during contract deployment.
+// Warning 9667: (228-234): Shielded number literals will leak during contract deployment.
+// Warning 9667: (252-254): Shielded number literals will leak during contract deployment.
+// Warning 9667: (273-275): Shielded number literals will leak during contract deployment.
+// Warning 9667: (293-297): Shielded number literals will leak during contract deployment.
+// Warning 9667: (316-320): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_in_array_literal.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_in_array_literal.sol
@@ -5,11 +5,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (129-131): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (129-131): Shielded number literals will leak during contract deployment.
 // Warning 9660: (122-132): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (141-143): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (141-143): Shielded number literals will leak during contract deployment.
 // Warning 9660: (134-144): Literals converted to shielded integers will leak during contract deployment.
-// Warning 9660: (153-155): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (153-155): Shielded number literals will leak during contract deployment.
 // Warning 9660: (146-156): Literals converted to shielded integers will leak during contract deployment.
 // Warning 2072: (98-118): Unused local variable.
 // Warning 2018: (17-164): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/types/shielded_literal_in_for_loop.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_in_for_loop.sol
@@ -10,10 +10,10 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (128-130): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (158-160): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (166-169): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (128-130): Shielded number literals will leak during contract deployment.
+// Warning 9667: (158-160): Shielded number literals will leak during contract deployment.
+// Warning 9667: (166-169): Shielded number literals will leak during contract deployment.
 // Warning 5765: (162-169): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
-// Warning 9660: (179-181): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (179-181): Shielded number literals will leak during contract deployment.
 // Warning 4282: (175-181): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.
 // Warning 4282: (201-206): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_in_if_condition.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_in_if_condition.sol
@@ -13,10 +13,10 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (81-84): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (172-175): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (81-84): Shielded number literals will leak during contract deployment.
+// Warning 9667: (172-175): Shielded number literals will leak during contract deployment.
 // Warning 5765: (167-175): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
-// Warning 9660: (195-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (226-228): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (195-198): Shielded number literals will leak during contract deployment.
+// Warning 9667: (226-228): Shielded number literals will leak during contract deployment.
 // Warning 5765: (222-228): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
-// Warning 9660: (248-250): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (248-250): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_in_while_loop.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_in_while_loop.sol
@@ -13,11 +13,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (117-119): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (133-135): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (221-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (117-119): Shielded number literals will leak during contract deployment.
+// Warning 9667: (133-135): Shielded number literals will leak during contract deployment.
+// Warning 9667: (221-224): Shielded number literals will leak during contract deployment.
 // Warning 5765: (211-224): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
-// Warning 9660: (248-250): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (248-250): Shielded number literals will leak during contract deployment.
 // Warning 4282: (244-250): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.
-// Warning 9660: (284-286): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (284-286): Shielded number literals will leak during contract deployment.
 // Warning 4282: (274-286): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_local_var.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_local_var.sol
@@ -10,11 +10,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (126-129): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (150-154): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (177-181): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (202-206): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (245-247): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (126-129): Shielded number literals will leak during contract deployment.
+// Warning 9667: (150-154): Shielded number literals will leak during contract deployment.
+// Warning 9667: (177-181): Shielded number literals will leak during contract deployment.
+// Warning 9667: (202-206): Shielded number literals will leak during contract deployment.
+// Warning 9667: (245-247): Shielded number literals will leak during contract deployment.
 // Warning 2072: (113-123): Unused local variable.
 // Warning 2072: (139-147): Unused local variable.
 // Warning 2072: (164-173): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mapping_value.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mapping_value.sol
@@ -9,6 +9,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (156-159): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (176-178): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (195-202): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (156-159): Shielded number literals will leak during contract deployment.
+// Warning 9667: (176-178): Shielded number literals will leak during contract deployment.
+// Warning 9667: (195-202): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_max_uint256.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_max_uint256.sol
@@ -13,6 +13,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (176-255): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (298-338): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (379-383): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (176-255): Shielded number literals will leak during contract deployment.
+// Warning 9667: (298-338): Shielded number literals will leak during contract deployment.
+// Warning 9667: (379-383): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mixed_comparison_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mixed_comparison_fail.sol
@@ -7,11 +7,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (130-132): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (130-132): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (130-137): Built-in binary operator == cannot be applied to types shielded_int_const 1 and int_const 1.
 // TypeError 9574: (120-138): Type sbool is not implicitly convertible to expected type bool.
-// Warning 9660: (162-164): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (162-164): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (158-164): Built-in binary operator > cannot be applied to types int_const 2 and shielded_int_const 1.
-// Warning 9660: (185-187): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (185-187): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (185-192): Built-in binary operator != cannot be applied to types shielded_int_const 1 and int_const 2.
 // TypeError 9574: (175-193): Type sbool is not implicitly convertible to expected type bool.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mixed_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mixed_fail.sol
@@ -9,10 +9,10 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (144-146): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (144-146): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (144-150): Built-in binary operator + cannot be applied to types shielded_int_const 1 and int_const 1.
-// Warning 9660: (168-170): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (168-170): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (164-170): Built-in binary operator + cannot be applied to types int_const 2 and shielded_int_const 3.
 // TypeError 7407: (164-170): Type int_const 2 is not implicitly convertible to expected type suint256.
-// Warning 9660: (184-186): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (184-186): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (184-190): Built-in binary operator * cannot be applied to types shielded_int_const 1 and int_const 2.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mixed_nonshielded_var_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mixed_nonshielded_var_fail.sol
@@ -10,7 +10,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (229-231): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (229-231): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (225-231): Built-in binary operator + cannot be applied to types uint256 and shielded_int_const 1.
-// Warning 9660: (249-251): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (249-251): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (245-251): Built-in binary operator * cannot be applied to types uint256 and shielded_int_const 2.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_mixed_shielded_var_arithmetic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_mixed_shielded_var_arithmetic.sol
@@ -13,14 +13,14 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (148-151): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (212-214): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (148-151): Shielded number literals will leak during contract deployment.
+// Warning 9667: (212-214): Shielded number literals will leak during contract deployment.
 // Warning 4282: (208-214): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.
-// Warning 9660: (232-234): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (232-234): Shielded number literals will leak during contract deployment.
 // Warning 4282: (228-234): Shielded integer subtraction can leak information. A revert due to overflow reveals range information about the operands.
-// Warning 9660: (252-254): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (252-254): Shielded number literals will leak during contract deployment.
 // Warning 4282: (248-254): Shielded integer multiplication can leak information. A revert due to overflow reveals range information about the operands.
-// Warning 9660: (272-274): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (272-274): Shielded number literals will leak during contract deployment.
 // Warning 4281: (268-274): Shielded integer division can leak information. A revert due to division by zero reveals that the divisor is zero.
-// Warning 9660: (292-294): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (292-294): Shielded number literals will leak during contract deployment.
 // Warning 4281: (288-294): Shielded integer modulo can leak information. A revert due to division by zero reveals that the divisor is zero.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_modulo_by_zero.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_modulo_by_zero.sol
@@ -7,6 +7,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (130-132): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (135-137): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (130-132): Shielded number literals will leak during contract deployment.
+// Warning 9667: (135-137): Shielded number literals will leak during contract deployment.
 // TypeError 2271: (130-137): Built-in binary operator % cannot be applied to types shielded_int_const 1 and shielded_int_const 0.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_multiple_types_same_expr.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_multiple_types_same_expr.sol
@@ -12,9 +12,9 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (160-164): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (178-182): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (249-251): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (254-257): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (271-273): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (276-279): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (160-164): Shielded number literals will leak during contract deployment.
+// Warning 9667: (178-182): Shielded number literals will leak during contract deployment.
+// Warning 9667: (249-251): Shielded number literals will leak during contract deployment.
+// Warning 9667: (254-257): Shielded number literals will leak during contract deployment.
+// Warning 9667: (271-273): Shielded number literals will leak during contract deployment.
+// Warning 9667: (276-279): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_negative_to_unsigned_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_negative_to_unsigned_fail.sol
@@ -6,5 +6,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (80-82): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (80-82): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (79-82): Type shielded_int_const -1 is not implicitly convertible to expected type suint8. Cannot implicitly convert signed literal to unsigned type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_nested_arithmetic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_nested_arithmetic.sol
@@ -13,18 +13,18 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (157-159): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (162-164): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (168-170): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (184-187): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (191-193): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (196-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (214-218): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (221-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (229-232): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (235-237): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (279-282): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (285-287): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (291-293): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (309-311): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (314-316): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (157-159): Shielded number literals will leak during contract deployment.
+// Warning 9667: (162-164): Shielded number literals will leak during contract deployment.
+// Warning 9667: (168-170): Shielded number literals will leak during contract deployment.
+// Warning 9667: (184-187): Shielded number literals will leak during contract deployment.
+// Warning 9667: (191-193): Shielded number literals will leak during contract deployment.
+// Warning 9667: (196-198): Shielded number literals will leak during contract deployment.
+// Warning 9667: (214-218): Shielded number literals will leak during contract deployment.
+// Warning 9667: (221-224): Shielded number literals will leak during contract deployment.
+// Warning 9667: (229-232): Shielded number literals will leak during contract deployment.
+// Warning 9667: (235-237): Shielded number literals will leak during contract deployment.
+// Warning 9667: (279-282): Shielded number literals will leak during contract deployment.
+// Warning 9667: (285-287): Shielded number literals will leak during contract deployment.
+// Warning 9667: (291-293): Shielded number literals will leak during contract deployment.
+// Warning 9667: (309-311): Shielded number literals will leak during contract deployment.
+// Warning 9667: (314-316): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_power_of_two.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_power_of_two.sol
@@ -17,14 +17,14 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (127-129): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (143-145): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (159-161): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (175-177): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (191-194): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (208-211): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (225-228): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (242-246): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (260-264): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (278-283): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (297-305): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (127-129): Shielded number literals will leak during contract deployment.
+// Warning 9667: (143-145): Shielded number literals will leak during contract deployment.
+// Warning 9667: (159-161): Shielded number literals will leak during contract deployment.
+// Warning 9667: (175-177): Shielded number literals will leak during contract deployment.
+// Warning 9667: (191-194): Shielded number literals will leak during contract deployment.
+// Warning 9667: (208-211): Shielded number literals will leak during contract deployment.
+// Warning 9667: (225-228): Shielded number literals will leak during contract deployment.
+// Warning 9667: (242-246): Shielded number literals will leak during contract deployment.
+// Warning 9667: (260-264): Shielded number literals will leak during contract deployment.
+// Warning 9667: (278-283): Shielded number literals will leak during contract deployment.
+// Warning 9667: (297-305): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_public_var_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_public_var_fail.sol
@@ -3,5 +3,5 @@ contract C {
     suint256 public x = 42s;
 }
 // ----
-// Warning 9660: (90-93): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (90-93): Shielded number literals will leak during contract deployment.
 // TypeError 7091: (70-93): Shielded Types are not supported for public state variables.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_require_condition.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_require_condition.sol
@@ -10,10 +10,10 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (81-84): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (164-166): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (81-84): Shielded number literals will leak during contract deployment.
+// Warning 9667: (164-166): Shielded number literals will leak during contract deployment.
 // Warning 5765: (160-166): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
-// Warning 9660: (190-193): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (190-193): Shielded number literals will leak during contract deployment.
 // Warning 5765: (185-193): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
-// Warning 9660: (217-219): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (217-219): Shielded number literals will leak during contract deployment.
 // Warning 5765: (212-219): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_return_cast.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_return_cast.sol
@@ -10,7 +10,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (168-171): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (168-171): Shielded number literals will leak during contract deployment.
 // TypeError 9640: (160-172): Explicit type conversion not allowed from "shielded_int_const 42" to "uint256".
-// Warning 9660: (319-322): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (319-322): Shielded number literals will leak during contract deployment.
 // TypeError 6359: (319-322): Return argument type shielded_int_const 42 is not implicitly convertible to expected type (type of first return variable) uint256. Shielded number literal cannot be implicitly converted to non-shielded type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_scientific_fractional_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_scientific_fractional_fail.sol
@@ -8,5 +8,5 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (203-208): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (203-208): Shielded number literals will leak during contract deployment.
 // TypeError 2326: (203-208): Type shielded_rational_const 1 / 10 is not implicitly convertible to expected type suint256. Try converting to type ufixed8x1 or use an explicit conversion.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_scientific_various.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_scientific_various.sol
@@ -12,9 +12,9 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (138-142): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (156-160): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (174-179): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (193-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (212-217): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (231-235): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (138-142): Shielded number literals will leak during contract deployment.
+// Warning 9667: (156-160): Shielded number literals will leak during contract deployment.
+// Warning 9667: (174-179): Shielded number literals will leak during contract deployment.
+// Warning 9667: (193-198): Shielded number literals will leak during contract deployment.
+// Warning 9667: (212-217): Shielded number literals will leak during contract deployment.
+// Warning 9667: (231-235): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_shift.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_shift.sol
@@ -14,11 +14,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (125-127): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (131-133): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (170-174): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (178-180): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (222-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (228-230): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (267-269): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (273-277): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (125-127): Shielded number literals will leak during contract deployment.
+// Warning 9667: (131-133): Shielded number literals will leak during contract deployment.
+// Warning 9667: (170-174): Shielded number literals will leak during contract deployment.
+// Warning 9667: (178-180): Shielded number literals will leak during contract deployment.
+// Warning 9667: (222-224): Shielded number literals will leak during contract deployment.
+// Warning 9667: (228-230): Shielded number literals will leak during contract deployment.
+// Warning 9667: (267-269): Shielded number literals will leak during contract deployment.
+// Warning 9667: (273-277): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_shift_with_variable.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_shift_with_variable.sol
@@ -10,7 +10,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (241-243): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (241-243): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (241-253): Type uint256 is not implicitly convertible to expected type suint256.
-// Warning 9660: (322-324): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (322-324): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (322-334): Type uint256 is not implicitly convertible to expected type suint256.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_signed_to_unsigned_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_signed_to_unsigned_fail.sol
@@ -12,11 +12,11 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (203-205): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (203-205): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (202-205): Type shielded_int_const -1 is not implicitly convertible to expected type suint8. Cannot implicitly convert signed literal to unsigned type.
-// Warning 9660: (220-222): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (220-222): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (219-222): Type shielded_int_const -1 is not implicitly convertible to expected type suint16. Cannot implicitly convert signed literal to unsigned type.
-// Warning 9660: (237-239): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (237-239): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (236-239): Type shielded_int_const -1 is not implicitly convertible to expected type suint256. Cannot implicitly convert signed literal to unsigned type.
-// Warning 9660: (254-258): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (254-258): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (253-258): Type shielded_int_const -100 is not implicitly convertible to expected type suint256. Cannot implicitly convert signed literal to unsigned type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_sint_all_overflow_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_sint_all_overflow_fail.sol
@@ -21,23 +21,23 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (220-224): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (220-224): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (220-224): Type shielded_int_const 128 is not implicitly convertible to expected type sint8. Literal is too large to fit in sint8.
-// Warning 9660: (238-244): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (238-244): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (238-244): Type shielded_int_const 32768 is not implicitly convertible to expected type sint16. Literal is too large to fit in sint16.
-// Warning 9660: (258-269): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (258-269): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (258-269): Type shielded_int_const 2147483648 is not implicitly convertible to expected type sint32. Literal is too large to fit in sint32.
-// Warning 9660: (283-303): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (283-303): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (283-303): Type shielded_int_const 9223372036854775808 is not implicitly convertible to expected type sint64. Literal is too large to fit in sint64.
-// Warning 9660: (317-357): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (317-357): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (317-357): Type shielded_int_const 1701...(31 digits omitted)...5728 is not implicitly convertible to expected type sint128. Literal is too large to fit in sint128.
-// Warning 9660: (425-429): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (425-429): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (424-429): Type shielded_int_const -129 is not implicitly convertible to expected type sint8. Literal is too large to fit in sint8.
-// Warning 9660: (444-450): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (444-450): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (443-450): Type shielded_int_const -32769 is not implicitly convertible to expected type sint16. Literal is too large to fit in sint16.
-// Warning 9660: (465-476): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (465-476): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (464-476): Type shielded_int_const -2147483649 is not implicitly convertible to expected type sint32. Literal is too large to fit in sint32.
-// Warning 9660: (491-511): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (491-511): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (490-511): Type shielded_int_const -9223372036854775809 is not implicitly convertible to expected type sint64. Literal is too large to fit in sint64.
-// Warning 9660: (526-566): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (526-566): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (525-566): Type shielded_int_const -170...(32 digits omitted)...5729 is not implicitly convertible to expected type sint128. Literal is too large to fit in sint128.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_sint_basic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_sint_basic.sol
@@ -19,12 +19,12 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (190-192): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (206-210): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (225-229): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (244-246): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (261-267): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (282-289): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (304-314): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (329-334): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (348-350): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (190-192): Shielded number literals will leak during contract deployment.
+// Warning 9667: (206-210): Shielded number literals will leak during contract deployment.
+// Warning 9667: (225-229): Shielded number literals will leak during contract deployment.
+// Warning 9667: (244-246): Shielded number literals will leak during contract deployment.
+// Warning 9667: (261-267): Shielded number literals will leak during contract deployment.
+// Warning 9667: (282-289): Shielded number literals will leak during contract deployment.
+// Warning 9667: (304-314): Shielded number literals will leak during contract deployment.
+// Warning 9667: (329-334): Shielded number literals will leak during contract deployment.
+// Warning 9667: (348-350): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_sint_overflow_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_sint_overflow_fail.sol
@@ -9,9 +9,9 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (100-104): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (100-104): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (100-104): Type shielded_int_const 128 is not implicitly convertible to expected type sint8. Literal is too large to fit in sint8.
-// Warning 9660: (119-123): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (119-123): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (118-123): Type shielded_int_const -129 is not implicitly convertible to expected type sint8. Literal is too large to fit in sint8.
-// Warning 9660: (137-143): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (137-143): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (137-143): Type shielded_int_const 32768 is not implicitly convertible to expected type sint16. Literal is too large to fit in sint16.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_sint_to_suint_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_sint_to_suint_fail.sol
@@ -10,6 +10,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (183-185): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (183-185): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (182-185): Type shielded_int_const -1 is not implicitly convertible to expected type suint256. Cannot implicitly convert signed literal to unsigned type.
-// Warning 9660: (266-269): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (266-269): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_storage_init.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_storage_init.sol
@@ -6,7 +6,7 @@ contract C {
     sint8 private w = -128s;
 }
 // ----
-// Warning 9660: (100-103): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (128-132): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (159-163): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (188-192): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (100-103): Shielded number literals will leak during contract deployment.
+// Warning 9667: (128-132): Shielded number literals will leak during contract deployment.
+// Warning 9667: (159-163): Shielded number literals will leak during contract deployment.
+// Warning 9667: (188-192): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_struct_field.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_struct_field.sol
@@ -15,8 +15,8 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (215-218): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (246-249): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (332-336): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (339-342): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (215-218): Shielded number literals will leak during contract deployment.
+// Warning 9667: (246-249): Shielded number literals will leak during contract deployment.
+// Warning 9667: (332-336): Shielded number literals will leak during contract deployment.
+// Warning 9667: (339-342): Shielded number literals will leak during contract deployment.
 // Warning 2072: (307-324): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_suint_all_overflow_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_suint_all_overflow_fail.sol
@@ -15,13 +15,13 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (216-220): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (216-220): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (216-220): Type shielded_int_const 256 is not implicitly convertible to expected type suint8. Literal is too large to fit in suint8.
-// Warning 9660: (234-240): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (234-240): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (234-240): Type shielded_int_const 65536 is not implicitly convertible to expected type suint16. Literal is too large to fit in suint16.
-// Warning 9660: (254-265): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (254-265): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (254-265): Type shielded_int_const 4294967296 is not implicitly convertible to expected type suint32. Literal is too large to fit in suint32.
-// Warning 9660: (279-300): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (279-300): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (279-300): Type shielded_int_const 18446744073709551616 is not implicitly convertible to expected type suint64. Literal is too large to fit in suint64.
-// Warning 9660: (314-354): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (314-354): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (314-354): Type shielded_int_const 3402...(31 digits omitted)...1456 is not implicitly convertible to expected type suint128. Literal is too large to fit in suint128.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_suint_basic.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_suint_basic.sol
@@ -17,10 +17,10 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (196-198): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (212-216): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (230-236): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (250-257): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (271-281): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (295-300): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (314-316): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (196-198): Shielded number literals will leak during contract deployment.
+// Warning 9667: (212-216): Shielded number literals will leak during contract deployment.
+// Warning 9667: (230-236): Shielded number literals will leak during contract deployment.
+// Warning 9667: (250-257): Shielded number literals will leak during contract deployment.
+// Warning 9667: (271-281): Shielded number literals will leak during contract deployment.
+// Warning 9667: (295-300): Shielded number literals will leak during contract deployment.
+// Warning 9667: (314-316): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_suint_overflow_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_suint_overflow_fail.sol
@@ -8,7 +8,7 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (102-106): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (102-106): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (102-106): Type shielded_int_const 256 is not implicitly convertible to expected type suint8. Literal is too large to fit in suint8.
-// Warning 9660: (120-126): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (120-126): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (120-126): Type shielded_int_const 65536 is not implicitly convertible to expected type suint16. Literal is too large to fit in suint16.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_ternary.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_ternary.sol
@@ -9,8 +9,8 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (139-141): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (144-146): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (203-206): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (209-212): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (216-218): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (139-141): Shielded number literals will leak during contract deployment.
+// Warning 9667: (144-146): Shielded number literals will leak during contract deployment.
+// Warning 9667: (203-206): Shielded number literals will leak during contract deployment.
+// Warning 9667: (209-212): Shielded number literals will leak during contract deployment.
+// Warning 9667: (216-218): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_to_address_cast.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_to_address_cast.sol
@@ -8,8 +8,8 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (227-230): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (320-323): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (227-230): Shielded number literals will leak during contract deployment.
+// Warning 9667: (320-323): Shielded number literals will leak during contract deployment.
 // Warning 2072: (207-216): Unused local variable.
 // Warning 2072: (298-308): Unused local variable.
 // Warning 2018: (116-331): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/types/shielded_literal_to_unshielded_fail.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_to_unshielded_fail.sol
@@ -9,9 +9,9 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (98-100): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (98-100): Shielded number literals will leak during contract deployment.
 // TypeError 9574: (88-100): Type shielded_int_const 1 is not implicitly convertible to expected type uint8. Shielded number literal cannot be implicitly converted to non-shielded type.
-// Warning 9660: (155-157): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (155-157): Shielded number literals will leak during contract deployment.
 // TypeError 9574: (145-157): Type shielded_int_const -1 is not implicitly convertible to expected type int8. Shielded number literal cannot be implicitly converted to non-shielded type.
-// Warning 9660: (218-221): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (218-221): Shielded number literals will leak during contract deployment.
 // TypeError 9574: (206-221): Type shielded_int_const 42 is not implicitly convertible to expected type uint256. Shielded number literal cannot be implicitly converted to non-shielded type.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_unary_ops.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_unary_ops.sol
@@ -11,6 +11,6 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (104-107): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (151-154): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (201-204): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (104-107): Shielded number literals will leak during contract deployment.
+// Warning 9667: (151-154): Shielded number literals will leak during contract deployment.
+// Warning 9667: (201-204): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_underscore_various.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_underscore_various.sol
@@ -11,8 +11,8 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (143-149): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (163-173): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (187-201): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (215-223): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (237-251): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (143-149): Shielded number literals will leak during contract deployment.
+// Warning 9667: (163-173): Shielded number literals will leak during contract deployment.
+// Warning 9667: (187-201): Shielded number literals will leak during contract deployment.
+// Warning 9667: (215-223): Shielded number literals will leak during contract deployment.
+// Warning 9667: (237-251): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_zero_contexts.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_zero_contexts.sol
@@ -19,14 +19,14 @@ contract C {
     }
 }
 // ----
-// Warning 9660: (200-202): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (216-218): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (232-234): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (248-250): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (294-296): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (299-301): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (315-317): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (320-322): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (336-338): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (341-345): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
-// Warning 9660: (379-383): Shielded number literals are converted to shielded integers whose values will be visible in contract creation code during deployment.
+// Warning 9667: (200-202): Shielded number literals will leak during contract deployment.
+// Warning 9667: (216-218): Shielded number literals will leak during contract deployment.
+// Warning 9667: (232-234): Shielded number literals will leak during contract deployment.
+// Warning 9667: (248-250): Shielded number literals will leak during contract deployment.
+// Warning 9667: (294-296): Shielded number literals will leak during contract deployment.
+// Warning 9667: (299-301): Shielded number literals will leak during contract deployment.
+// Warning 9667: (315-317): Shielded number literals will leak during contract deployment.
+// Warning 9667: (320-322): Shielded number literals will leak during contract deployment.
+// Warning 9667: (336-338): Shielded number literals will leak during contract deployment.
+// Warning 9667: (341-345): Shielded number literals will leak during contract deployment.
+// Warning 9667: (379-383): Shielded number literals will leak during contract deployment.


### PR DESCRIPTION
## Summary
- The `0s` shielded literal suffix was reusing error ID 9660 (used by `suint256(0)` conversions) with a different message, violating the repo convention that each error ID must be unique
- Assigns new unique ID **9667** for `ShieldedNumber` token warnings
- Shortens warning message to: "Shielded number literals will leak during contract deployment."
- Updates all 67 test expectation files

## Related
- #236 — full audit of duplicate error IDs across the codebase

## Test plan
- [ ] `scripts/soltest.sh` passes
- [ ] `isoltest --no-semantic-tests -t "syntaxTests/types/shielded_literal_*"` passes
- [ ] `python3 scripts/error_codes.py --check` no longer reports 9660 as duplicate