### PR TITLE
ci: add error codes check workflow

### DIFF
--- a/.github/workflows/error-codes.yml
+++ b/.github/workflows/error-codes.yml
@@ -1,0 +1,26 @@
+# Check error codes for duplicates and coverage (mirrors upstream CircleCI chk_errorcodes job)
+name: Error Codes
+
+on:
+  push:
+    branches:
+      - seismic
+  pull_request:
+    branches:
+      - seismic
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  check-error-codes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Check for error codes
+        run: scripts/error_codes.py --check


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that mirrors upstream's CircleCI `chk_errorcodes` job, running `scripts/error_codes.py --check` on push/PR to the seismic branch.

This will currently fail due to 6 untested error codes — that's expected and will be resolved in a follow-up once tests are added for those codes (tracked in #236).

## Test plan

- [x] Workflow runs and correctly reports untested codes