### PR TITLE
test: add missing tests for 6 untested Seismic error codes

### DIFF
--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_call_shielded_saddress.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_call_shielded_saddress.sol
@@ -1,0 +1,13 @@
+// abi.encodeCall with shielded saddress argument
+contract Target {
+    function setAddr(saddress x) external {}
+}
+
+contract Caller {
+    Target t;
+    function test() external view {
+        abi.encodeCall(t.setAddr, (saddress(address(this))));
+    }
+}
+// ----
+// TypeError 10203: (218-243): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_call_shielded_sbool.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_call_shielded_sbool.sol
@@ -1,0 +1,14 @@
+// abi.encodeCall with shielded sbool argument
+contract Target {
+    function setFlag(sbool x) external {}
+}
+
+contract Caller {
+    Target t;
+    function test() external view {
+        abi.encodeCall(t.setFlag, (sbool(true)));
+    }
+}
+// ----
+// Warning 10406: (213-224): Bool Literals converted to shielded bools will leak during contract deployment.
+// TypeError 10203: (212-225): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_call_shielded_suint.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_call_shielded_suint.sol
@@ -1,0 +1,14 @@
+// abi.encodeCall with shielded suint256 argument
+contract Target {
+    function setVal(suint256 x) external {}
+}
+
+contract Caller {
+    Target t;
+    function test() external view {
+        abi.encodeCall(t.setVal, (suint256(42)));
+    }
+}
+// ----
+// Warning 10403: (217-229): Literals converted to shielded integers will leak during contract deployment.
+// TypeError 10203: (216-230): Shielded types cannot be ABI encoded.

--- a/test/libsolidity/syntaxTests/array/shielded_push_to_unshielded_array_saddress.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_push_to_unshielded_array_saddress.sol
@@ -1,0 +1,11 @@
+// Cannot push a shielded saddress to a non-shielded address[] array
+contract C {
+    address[] arr;
+
+    function test() external {
+        saddress x = saddress(address(this));
+        arr.push(x);
+    }
+}
+// ----
+// TypeError 10206: (187-195): Cannot push a shielded type to a non-shielded array

--- a/test/libsolidity/syntaxTests/array/shielded_push_to_unshielded_array_sbool.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_push_to_unshielded_array_sbool.sol
@@ -1,0 +1,12 @@
+// Cannot push a shielded sbool to a non-shielded bool[] array
+contract C {
+    bool[] arr;
+
+    function test() external {
+        sbool x = sbool(true);
+        arr.push(x);
+    }
+}
+// ----
+// Warning 10406: (142-153): Bool Literals converted to shielded bools will leak during contract deployment.
+// TypeError 10206: (163-171): Cannot push a shielded type to a non-shielded array

--- a/test/libsolidity/syntaxTests/array/shielded_push_to_unshielded_array_suint.sol
+++ b/test/libsolidity/syntaxTests/array/shielded_push_to_unshielded_array_suint.sol
@@ -1,0 +1,12 @@
+// Cannot push a shielded suint256 to a non-shielded uint256[] array
+contract C {
+    uint256[] arr;
+
+    function test() external {
+        suint256 x = suint256(1);
+        arr.push(x);
+    }
+}
+// ----
+// Warning 10403: (154-165): Literals converted to shielded integers will leak during contract deployment.
+// TypeError 10206: (175-183): Cannot push a shielded type to a non-shielded array

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_enum.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_enum.sol
@@ -1,0 +1,16 @@
+// Enum value passed to constructor with suint256 param via new expression
+enum Color { Red, Green, Blue }
+
+contract Child {
+    suint256 private val;
+    constructor(suint256 _val) { val = _val; }
+}
+
+contract Parent {
+    function test() external {
+        new Child(suint256(Color.Red));
+    }
+}
+// ----
+// Warning 10103: (167-180): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// Warning 10413: (268-287): Enums converted to shielded integers will leak during contract deployment. Contract creation (CREATE/CREATE2) does not encrypt calldata. This is expected to be fixed in a future release.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_enum_multiple.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_enum_multiple.sol
@@ -1,0 +1,19 @@
+// Multiple enum values passed to constructor with suint params via new expression
+enum Status { Pending, Active, Closed }
+
+contract Child {
+    suint256 private a;
+    suint256 private b;
+    constructor(suint256 _a, suint256 _b) { a = _a; b = _b; }
+}
+
+contract Parent {
+    function test() external {
+        new Child(suint256(Status.Active), suint256(Status.Closed));
+    }
+}
+// ----
+// Warning 10103: (205-216): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// Warning 10103: (218-229): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// Warning 10413: (321-344): Enums converted to shielded integers will leak during contract deployment. Contract creation (CREATE/CREATE2) does not encrypt calldata. This is expected to be fixed in a future release.
+// Warning 10413: (346-369): Enums converted to shielded integers will leak during contract deployment. Contract creation (CREATE/CREATE2) does not encrypt calldata. This is expected to be fixed in a future release.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_saddress.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_saddress.sol
@@ -1,0 +1,14 @@
+// Address literal passed to constructor with saddress param via new expression
+contract Child {
+    saddress private addr;
+    constructor(saddress _addr) { addr = _addr; }
+}
+
+contract Parent {
+    function test() external {
+        new Child(saddress(0xdCad3a6d3569DF655070DEd06cb7A1b2Ccd1D3AF));
+    }
+}
+// ----
+// Warning 10103: (140-154): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// Warning 10407: (244-296): Address Literals converted to shielded addresses will leak during contract deployment. Contract creation (CREATE/CREATE2) does not encrypt calldata. This is expected to be fixed in a future release.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_saddress_multiple.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_saddress_multiple.sol
@@ -1,0 +1,20 @@
+// Multiple address literals passed to constructor with saddress params via new expression
+contract Child {
+    saddress private a;
+    saddress private b;
+    constructor(saddress _a, saddress _b) { a = _a; b = _b; }
+}
+
+contract Parent {
+    function test() external {
+        new Child(
+            saddress(0xdCad3a6d3569DF655070DEd06cb7A1b2Ccd1D3AF),
+            saddress(0x5B38Da6a701c568545dCfcB03FcB875f56beddC4)
+        );
+    }
+}
+// ----
+// Warning 10103: (172-183): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// Warning 10103: (185-196): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// Warning 10407: (301-353): Address Literals converted to shielded addresses will leak during contract deployment. Contract creation (CREATE/CREATE2) does not encrypt calldata. This is expected to be fixed in a future release.
+// Warning 10407: (367-419): Address Literals converted to shielded addresses will leak during contract deployment. Contract creation (CREATE/CREATE2) does not encrypt calldata. This is expected to be fixed in a future release.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_saddress_payable.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_saddress_payable.sol
@@ -1,4 +1,4 @@
-// Address literal cast through payable then to saddress — hits conversion error, not 10407
+// Address literal cast through payable then to saddress - hits conversion error, not 10407
 contract Child {
     saddress payable private addr;
     constructor(saddress payable _addr) { addr = _addr; }
@@ -10,5 +10,5 @@ contract Parent {
     }
 }
 // ----
-// Warning 10103: (156-178): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
-// TypeError 9553: (268-329): Invalid type for argument in function call. Invalid implicit conversion from saddress to saddress payable requested.
+// Warning 10103: (160-182): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// TypeError 9553: (272-333): Invalid type for argument in function call. Invalid implicit conversion from saddress to saddress payable requested.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_saddress_payable.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_saddress_payable.sol
@@ -1,0 +1,14 @@
+// Address literal cast through payable then to saddress — hits conversion error, not 10407
+contract Child {
+    saddress payable private addr;
+    constructor(saddress payable _addr) { addr = _addr; }
+}
+
+contract Parent {
+    function test() external {
+        new Child(saddress(payable(0xdCad3a6d3569DF655070DEd06cb7A1b2Ccd1D3AF)));
+    }
+}
+// ----
+// Warning 10103: (156-178): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// TypeError 9553: (268-329): Invalid type for argument in function call. Invalid implicit conversion from saddress to saddress payable requested.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_sbytes.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_sbytes.sol
@@ -1,0 +1,14 @@
+// FixedBytes literal passed to constructor with sbytes32 param via new expression
+contract Child {
+    sbytes32 private data;
+    constructor(sbytes32 _data) { data = _data; }
+}
+
+contract Parent {
+    function test() external {
+        new Child(sbytes32(0x0102030405060708091011121314151617181920212223242526272829303132));
+    }
+}
+// ----
+// Warning 10103: (143-157): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// Warning 10410: (247-323): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment. Contract creation (CREATE/CREATE2) does not encrypt calldata. This is expected to be fixed in a future release.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_sbytes4.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_literal_new_sbytes4.sol
@@ -1,0 +1,14 @@
+// FixedBytes literal passed to constructor with sbytes4 param via new expression
+contract Child {
+    sbytes4 private data;
+    constructor(sbytes4 _data) { data = _data; }
+}
+
+contract Parent {
+    function test() external {
+        new Child(sbytes4(0x01020304));
+    }
+}
+// ----
+// Warning 10103: (141-154): Shielded types in constructor parameters are visible in deployment transaction data. Contract creation (CREATE/CREATE2) does not encrypt calldata. Consider setting shielded state via a post-deployment transaction instead. This is expected to be fixed in a future release.
+// Warning 10410: (244-263): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment. Contract creation (CREATE/CREATE2) does not encrypt calldata. This is expected to be fixed in a future release.

--- a/test/libyul/yulSyntaxTests/eof/cload_in_eof.yul
+++ b/test/libyul/yulSyntaxTests/eof/cload_in_eof.yul
@@ -1,0 +1,11 @@
+object "a" {
+    code {
+        pop(cload(0))
+    }
+}
+
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// TypeError 10110: (20-25): The "cload" instruction is only available in Seismic legacy bytecode VM (you are currently compiling to EOF).
+// TypeError 3950: (20-28): Expected expression to evaluate to one value, but got 0 values instead.

--- a/test/libyul/yulSyntaxTests/eof/cstore_in_eof.yul
+++ b/test/libyul/yulSyntaxTests/eof/cstore_in_eof.yul
@@ -1,0 +1,10 @@
+object "a" {
+    code {
+        cstore(0, 42)
+    }
+}
+
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// TypeError 10110: (20-26): The "cstore" instruction is only available in Seismic legacy bytecode VM (you are currently compiling to EOF).


### PR DESCRIPTION
## Summary

Stacked on #238. Adds test coverage for the 6 previously untested Seismic error codes, making `scripts/error_codes.py --check` pass cleanly.

### Tests added (15 files)

| Code | What it checks | Tests |
|------|---------------|-------|
| **10110** | CSTORE/CLOAD not available in EOF | `cstore_in_eof.yul`, `cload_in_eof.yul` |
| **10203** | Shielded types in `abi.encodeCall` | `abi_encode_call_shielded_{suint,sbool,saddress}.sol` |
| **10206** | Push shielded type to non-shielded array | `shielded_push_to_unshielded_array_{suint,sbool,saddress}.sol` |
| **10407** | Address literal → saddress in `new` expression | 3 tests (single, multiple, payable conversion error) |
| **10410** | FixedBytes literal → sbytes in `new` expression | `warn_shielded_literal_new_sbytes{,4}.sol` |
| **10413** | Enum → shielded int in `new` expression | `warn_shielded_literal_new_enum{,_multiple}.sol` |

## Test plan

- [x] `python3 scripts/error_codes.py --check` passes with "No incorrect IDs found"
- [x] `./scripts/soltest.sh` passes
- [x] Semantic tests via seismic-revm pass