### PR TITLE
ci: add lint workflow for coding style checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: Lint
+
+on:
+  push:
+    branches: [seismic]
+  pull_request:
+    branches: [seismic]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+          pip install codespell
+
+      - name: Check C++ coding style
+        run: scripts/check_style.sh
+
+      - name: Check shell scripts (shellcheck)
+        run: scripts/chk_shellscripts/chk_shellscripts.sh
+
+      - name: Check for broken symlinks
+        run: scripts/check_symlinks.sh
+
+      - name: Run codespell
+        run: codespell


### PR DESCRIPTION
## Summary
- Add `.github/workflows/lint.yml` that runs on PRs and pushes to `seismic`
- Runs four lightweight checks in a single job on `ubuntu-latest`: C++ coding style (`check_style.sh`), shellcheck (`chk_shellscripts.sh`), broken symlink detection (`check_symlinks.sh`), and `codespell` for spelling errors
- Uses the same concurrency pattern as the existing `test.yml` workflow

## Test plan
- [ ] Verify the workflow triggers on a PR to `seismic`
- [ ] Confirm all four check steps pass (or produce expected failures for known issues)