### PR TITLE
feat: rename sync_rng* built-ins to unsafe_rng_{u,b}*

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ This is **experimental** software, thread with caution.
     *   [6.1 Shielded Arrays](#61-shielded-arrays)
     *   [6.2 Limitations](#62-limitations)
     *   [6.3 Mappings](#63-mappings)
-7.  [Best Practices](#7-best-practices)
-8.  [Compiler Error Codes](#8-compiler-error-codes)
-9.  [Conclusion](#9-conclusion)
-10. [Upstream](#10-upstream)
-11. [Feedback](#11-feedback)
+7.  [RNG Precompiles](#7-rng-precompiles)
+8.  [Best Practices](#8-best-practices)
+9.  [Compiler Error Codes](#9-compiler-error-codes)
+10. [Conclusion](#10-conclusion)
+11. [Upstream](#11-upstream)
+12. [Feedback](#12-feedback)
 
 - - -
 
@@ -242,7 +243,20 @@ We introduce two new EVM instructions to handle confidential storage:
 *	 Mappings using shielded types for keys and/or values are supported. In such cases, the storage operations will employ the confidential instructions (CLOAD/CSTORE) accordingly.
 
 
-## 7\. Best Practices
+## 7\. RNG Precompiles
+
+The compiler exposes built-in functions for on-chain random number generation via Seismic's RNG precompile. These are available as global functions (no import needed):
+
+*   **`unsafe_rng_u8()` … `unsafe_rng_u256()`** — return a random `suint` of the corresponding bit width (8, 16, 32, 64, 96, 128, 256).
+*   **`unsafe_rng_b1()` … `unsafe_rng_b32()`** — return a random `sbytes` of the corresponding byte width (1–32).
+
+All RNG functions have `view` mutability and require the Mercury EVM version.
+
+> **Why `unsafe_`?** The randomness is generated synchronously by the sequencer and is **not** cryptographically committed before use — a malicious sequencer could influence the outcome. The `unsafe_` prefix signals that these functions are suitable for low-stakes randomness but should not be relied upon where sequencer trust is unacceptable.
+
+For full details, see the [RNG precompile documentation](https://docs.seismic.systems/reference/precompiles/rng).
+
+## 8\. Best Practices
 
 *   **Avoid Public Exposure**: Never expose shielded variables through public getters or events.
 *   **Careful with Gas Usage**: Be mindful of operations where gas cost can vary based on shielded values (e.g., loops, exponentiation).
@@ -251,7 +265,7 @@ We introduce two new EVM instructions to handle confidential storage:
 *   **Review Compiler Warnings**: Pay attention to compiler warnings related to shielded types to prevent accidental leaks.
 
 
-## 8\. Compiler Error Codes
+## 9\. Compiler Error Codes
 
 Seismic extends the upstream Solidity compiler with new errors and warnings specific to shielded types. To keep them clearly separated from upstream codes:
 
@@ -273,7 +287,7 @@ Within the `10XYZ` scheme, the third digit (`X`) indicates the category:
 | `104__` | 10400–10499 | **Deployment leak warnings** | Literals (int, bool, address, bytes, enum) converted to shielded types are visible in deployment bytecode |
 
 
-## 9\. Conclusion
+## 10\. Conclusion
 
 This extension enhances the EVM by introducing confidential storage capabilities, allowing developers to handle sensitive data securely. By understanding the new shielded types, instructions, and associated caveats, you can leverage these features to build more secure smart contracts.
 
@@ -281,13 +295,13 @@ We encourage you to refer to the standard Ethereum documentation for foundationa
 
 We also welcome external contributions to this repository.
 
-## 10\. Upstream
+## 11\. Upstream
 
 The upstream repository lives [here](https://github.com/ethereum/solidity/tree/develop). This fork is up-to-date with it through commit `ab55807`. You can see this by viewing the [develop](https://github.com/SeismicSystems/seismic-solidity/tree/develop) branch on this repository.
 
 You can view all of our changes vs. upstream on this [pull request](https://github.com/SeismicSystems/seismic-solidity/pull/27). The sole purpose of this PR is display our diff; it will never be merged in to the main branch of this repo.
 
-## 11\. Feedback
+## 12\. Feedback
 
 We welcome your feedback on this documentation. If you have suggestions or encounter any issues, please contact our support team or contribute to our documentation repository.
 

--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -70,47 +70,47 @@ int magicVariableToID(std::string const& _name)
 		{"aes_gcm_decrypt", -102},
 		{"hkdf", -103},
 		{"secp256k1_sign", -104},
-		// Seismic RNG bytes built-ins: sync_rng_bN at -(200+N).
-		{"sync_rng_b1", -201},
-		{"sync_rng_b2", -202},
-		{"sync_rng_b3", -203},
-		{"sync_rng_b4", -204},
-		{"sync_rng_b5", -205},
-		{"sync_rng_b6", -206},
-		{"sync_rng_b7", -207},
-		{"sync_rng_b8", -208},
-		{"sync_rng_b9", -209},
-		{"sync_rng_b10", -210},
-		{"sync_rng_b11", -211},
-		{"sync_rng_b12", -212},
-		{"sync_rng_b13", -213},
-		{"sync_rng_b14", -214},
-		{"sync_rng_b15", -215},
-		{"sync_rng_b16", -216},
-		{"sync_rng_b17", -217},
-		{"sync_rng_b18", -218},
-		{"sync_rng_b19", -219},
-		{"sync_rng_b20", -220},
-		{"sync_rng_b21", -221},
-		{"sync_rng_b22", -222},
-		{"sync_rng_b23", -223},
-		{"sync_rng_b24", -224},
-		{"sync_rng_b25", -225},
-		{"sync_rng_b26", -226},
-		{"sync_rng_b27", -227},
-		{"sync_rng_b28", -228},
-		{"sync_rng_b29", -229},
-		{"sync_rng_b30", -230},
-		{"sync_rng_b31", -231},
-		{"sync_rng_b32", -232},
+		// Seismic RNG bytes built-ins: unsafe_rng_bN at -(200+N).
+		{"unsafe_rng_b1", -201},
+		{"unsafe_rng_b2", -202},
+		{"unsafe_rng_b3", -203},
+		{"unsafe_rng_b4", -204},
+		{"unsafe_rng_b5", -205},
+		{"unsafe_rng_b6", -206},
+		{"unsafe_rng_b7", -207},
+		{"unsafe_rng_b8", -208},
+		{"unsafe_rng_b9", -209},
+		{"unsafe_rng_b10", -210},
+		{"unsafe_rng_b11", -211},
+		{"unsafe_rng_b12", -212},
+		{"unsafe_rng_b13", -213},
+		{"unsafe_rng_b14", -214},
+		{"unsafe_rng_b15", -215},
+		{"unsafe_rng_b16", -216},
+		{"unsafe_rng_b17", -217},
+		{"unsafe_rng_b18", -218},
+		{"unsafe_rng_b19", -219},
+		{"unsafe_rng_b20", -220},
+		{"unsafe_rng_b21", -221},
+		{"unsafe_rng_b22", -222},
+		{"unsafe_rng_b23", -223},
+		{"unsafe_rng_b24", -224},
+		{"unsafe_rng_b25", -225},
+		{"unsafe_rng_b26", -226},
+		{"unsafe_rng_b27", -227},
+		{"unsafe_rng_b28", -228},
+		{"unsafe_rng_b29", -229},
+		{"unsafe_rng_b30", -230},
+		{"unsafe_rng_b31", -231},
+		{"unsafe_rng_b32", -232},
 		// Seismic RNG integer built-ins start at -233.
-		{"sync_rng8", -233},
-		{"sync_rng16", -234},
-		{"sync_rng32", -235},
-		{"sync_rng64", -236},
-		{"sync_rng96", -237},
-		{"sync_rng128", -238},
-		{"sync_rng256", -239}
+		{"unsafe_rng_u8", -233},
+		{"unsafe_rng_u16", -234},
+		{"unsafe_rng_u32", -235},
+		{"unsafe_rng_u64", -236},
+		{"unsafe_rng_u96", -237},
+		{"unsafe_rng_u128", -238},
+		{"unsafe_rng_u256", -239}
 	};
 
 	if (auto id = magicVariables.find(_name); id != magicVariables.end())
@@ -167,18 +167,18 @@ inline std::vector<std::shared_ptr<MagicVariableDeclaration const>> constructMag
 		);
 
 	// Seismic RNG precompile built-in functions
-	magicVariableDeclarations.push_back(magicVarDecl("sync_rng8",   TypeProvider::function(strings{}, strings{"suint8"},   FunctionType::Kind::SeismicRNG, StateMutability::View)));
-	magicVariableDeclarations.push_back(magicVarDecl("sync_rng16",  TypeProvider::function(strings{}, strings{"suint16"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
-	magicVariableDeclarations.push_back(magicVarDecl("sync_rng32",  TypeProvider::function(strings{}, strings{"suint32"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
-	magicVariableDeclarations.push_back(magicVarDecl("sync_rng64",  TypeProvider::function(strings{}, strings{"suint64"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
-	magicVariableDeclarations.push_back(magicVarDecl("sync_rng96",  TypeProvider::function(strings{}, strings{"suint96"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
-	magicVariableDeclarations.push_back(magicVarDecl("sync_rng128", TypeProvider::function(strings{}, strings{"suint128"}, FunctionType::Kind::SeismicRNG, StateMutability::View)));
-	magicVariableDeclarations.push_back(magicVarDecl("sync_rng256", TypeProvider::function(strings{}, strings{"suint256"}, FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("unsafe_rng_u8",   TypeProvider::function(strings{}, strings{"suint8"},   FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("unsafe_rng_u16",  TypeProvider::function(strings{}, strings{"suint16"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("unsafe_rng_u32",  TypeProvider::function(strings{}, strings{"suint32"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("unsafe_rng_u64",  TypeProvider::function(strings{}, strings{"suint64"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("unsafe_rng_u96",  TypeProvider::function(strings{}, strings{"suint96"},  FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("unsafe_rng_u128", TypeProvider::function(strings{}, strings{"suint128"}, FunctionType::Kind::SeismicRNG, StateMutability::View)));
+	magicVariableDeclarations.push_back(magicVarDecl("unsafe_rng_u256", TypeProvider::function(strings{}, strings{"suint256"}, FunctionType::Kind::SeismicRNG, StateMutability::View)));
 
 	// Seismic RNG precompile built-in functions for shielded fixed bytes
 	for (unsigned i = 1; i <= 32; ++i)
 		magicVariableDeclarations.push_back(magicVarDecl(
-			"sync_rng_b" + std::to_string(i),
+			"unsafe_rng_b" + std::to_string(i),
 			TypeProvider::function(strings{}, strings{"sbytes" + std::to_string(i)}, FunctionType::Kind::SeismicRNG, StateMutability::View)
 		));
 

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_array_storage.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_array_storage.sol
@@ -7,7 +7,7 @@ contract RngArrayStorage {
     // Push random values into a dynamic array.
     function pushRandomValues() public {
         for (uint i = 0; i < 5; i++) {
-            arr.push(sync_rng256());
+            arr.push(unsafe_rng_u256());
         }
     }
 

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_bit_width_integrity.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_bit_width_integrity.sol
@@ -2,55 +2,55 @@
 pragma solidity ^0.8.0;
 
 contract RngBitWidthIntegrity {
-    // Verify that sync_rng8 values fit within 8 bits.
+    // Verify that unsafe_rng_u8 values fit within 8 bits.
     function testRng8FitsIn8Bits() public view returns (bool) {
         for (uint i = 0; i < 10; i++) {
-            uint256 val = uint256(uint8(sync_rng8()));
+            uint256 val = uint256(uint8(unsafe_rng_u8()));
             if (val > type(uint8).max) return false;
         }
         return true;
     }
 
-    // Verify that sync_rng16 values fit within 16 bits.
+    // Verify that unsafe_rng_u16 values fit within 16 bits.
     function testRng16FitsIn16Bits() public view returns (bool) {
         for (uint i = 0; i < 10; i++) {
-            uint256 val = uint256(uint16(sync_rng16()));
+            uint256 val = uint256(uint16(unsafe_rng_u16()));
             if (val > type(uint16).max) return false;
         }
         return true;
     }
 
-    // Verify that sync_rng32 values fit within 32 bits.
+    // Verify that unsafe_rng_u32 values fit within 32 bits.
     function testRng32FitsIn32Bits() public view returns (bool) {
         for (uint i = 0; i < 10; i++) {
-            uint256 val = uint256(uint32(sync_rng32()));
+            uint256 val = uint256(uint32(unsafe_rng_u32()));
             if (val > type(uint32).max) return false;
         }
         return true;
     }
 
-    // Verify that sync_rng64 values fit within 64 bits.
+    // Verify that unsafe_rng_u64 values fit within 64 bits.
     function testRng64FitsIn64Bits() public view returns (bool) {
         for (uint i = 0; i < 10; i++) {
-            uint256 val = uint256(uint64(sync_rng64()));
+            uint256 val = uint256(uint64(unsafe_rng_u64()));
             if (val > type(uint64).max) return false;
         }
         return true;
     }
 
-    // Verify that sync_rng96 values fit within 96 bits.
+    // Verify that unsafe_rng_u96 values fit within 96 bits.
     function testRng96FitsIn96Bits() public view returns (bool) {
         for (uint i = 0; i < 10; i++) {
-            uint256 val = uint256(uint128(sync_rng96()));
+            uint256 val = uint256(uint128(unsafe_rng_u96()));
             if (val > 2**96 - 1) return false;
         }
         return true;
     }
 
-    // Verify that sync_rng128 values fit within 128 bits.
+    // Verify that unsafe_rng_u128 values fit within 128 bits.
     function testRng128FitsIn128Bits() public view returns (bool) {
         for (uint i = 0; i < 10; i++) {
-            uint256 val = uint256(uint128(sync_rng128()));
+            uint256 val = uint256(uint128(unsafe_rng_u128()));
             if (val > type(uint128).max) return false;
         }
         return true;

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_builtins.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_builtins.sol
@@ -2,51 +2,51 @@
 pragma solidity ^0.8.0;
 
 contract RngBuiltins {
-    // Each test verifies the sync_rng call succeeds and the result looks random.
+    // Each test verifies the unsafe_rng_u call succeeds and the result looks random.
     // For N-bit types (N >= 30): check val in [2^(N-30), max - 2^(N-30)].
     // P(false positive) ≈ 2 * 2^(-30) ≈ 2e-9 per test.
     // For smaller types: combine multiple samples.
 
     function testRng256() public view returns (bool) {
-        uint256 val = uint256(sync_rng256());
+        uint256 val = uint256(unsafe_rng_u256());
         return val >= 2**226 && val <= type(uint256).max - 2**226;
     }
 
     function testRng128() public view returns (bool) {
-        uint128 val = uint128(sync_rng128());
+        uint128 val = uint128(unsafe_rng_u128());
         return val >= 2**98 && val <= type(uint128).max - 2**98;
     }
 
     function testRng96() public view returns (bool) {
-        uint128 val = uint128(sync_rng96());
+        uint128 val = uint128(unsafe_rng_u96());
         return val >= 2**66 && val <= 2**96 - 1 - 2**66;
     }
 
     function testRng64() public view returns (bool) {
-        uint64 val = uint64(sync_rng64());
+        uint64 val = uint64(unsafe_rng_u64());
         return val >= 2**34 && val <= type(uint64).max - 2**34;
     }
 
     function testRng32() public view returns (bool) {
-        uint32 val = uint32(sync_rng32());
+        uint32 val = uint32(unsafe_rng_u32());
         return val >= 4 && val <= type(uint32).max - 4;
     }
 
     function testRng16() public view returns (bool) {
         // 16 bits: two samples, check not all-zero and not all-ones.
         // P(false positive) ≈ 2 * (1/2^16)^2 ≈ 5e-10.
-        uint16 a = uint16(sync_rng16());
-        uint16 b = uint16(sync_rng16());
+        uint16 a = uint16(unsafe_rng_u16());
+        uint16 b = uint16(unsafe_rng_u16());
         return (a | b) > 0 && (a & b) < type(uint16).max;
     }
 
     function testRng8() public view returns (bool) {
         // 8 bits: four samples, check not all-zero and not all-ones.
         // P(false positive) ≈ 2 * (1/2^8)^4 ≈ 5e-10.
-        uint8 a = uint8(sync_rng8());
-        uint8 b = uint8(sync_rng8());
-        uint8 c = uint8(sync_rng8());
-        uint8 d = uint8(sync_rng8());
+        uint8 a = uint8(unsafe_rng_u8());
+        uint8 b = uint8(unsafe_rng_u8());
+        uint8 c = uint8(unsafe_rng_u8());
+        uint8 d = uint8(unsafe_rng_u8());
         return (a | b | c | d) > 0 && (a & b & c & d) < type(uint8).max;
     }
 }

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_bytes_builtins.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_bytes_builtins.sol
@@ -2,176 +2,176 @@
 pragma solidity ^0.8.0;
 
 contract RngBytesBuiltins {
-    // Each test casts sync_rng_bN() → bytesN → uintN*8, then checks randomness.
+    // Each test casts unsafe_rng_bN() → bytesN → uintN*8, then checks randomness.
     // For N*8 >= 30 bits: check val in [2^(N*8-30), max - 2^(N*8-30)].
     // P(false positive) ≈ 2 * 2^(-30) ≈ 2e-9 per test.
     // For smaller types: combine multiple samples.
 
     function testRngB1() public view returns (bool) {
         // 8 bits: four samples, check not all-zero and not all-ones.
-        uint8 a = uint8(bytes1(sync_rng_b1()));
-        uint8 b = uint8(bytes1(sync_rng_b1()));
-        uint8 c = uint8(bytes1(sync_rng_b1()));
-        uint8 d = uint8(bytes1(sync_rng_b1()));
+        uint8 a = uint8(bytes1(unsafe_rng_b1()));
+        uint8 b = uint8(bytes1(unsafe_rng_b1()));
+        uint8 c = uint8(bytes1(unsafe_rng_b1()));
+        uint8 d = uint8(bytes1(unsafe_rng_b1()));
         return (a | b | c | d) > 0 && (a & b & c & d) < type(uint8).max;
     }
 
     function testRngB2() public view returns (bool) {
         // 16 bits: two samples, check not all-zero and not all-ones.
-        uint16 a = uint16(bytes2(sync_rng_b2()));
-        uint16 b = uint16(bytes2(sync_rng_b2()));
+        uint16 a = uint16(bytes2(unsafe_rng_b2()));
+        uint16 b = uint16(bytes2(unsafe_rng_b2()));
         return (a | b) > 0 && (a & b) < type(uint16).max;
     }
 
     function testRngB3() public view returns (bool) {
         // 24 bits: two samples, check not all-zero and not all-ones.
-        uint24 a = uint24(bytes3(sync_rng_b3()));
-        uint24 b = uint24(bytes3(sync_rng_b3()));
+        uint24 a = uint24(bytes3(unsafe_rng_b3()));
+        uint24 b = uint24(bytes3(unsafe_rng_b3()));
         return (a | b) > 0 && (a & b) < type(uint24).max;
     }
 
     function testRngB4() public view returns (bool) {
-        uint32 val = uint32(bytes4(sync_rng_b4()));
+        uint32 val = uint32(bytes4(unsafe_rng_b4()));
         return val >= 4 && val <= type(uint32).max - 4;
     }
 
     function testRngB5() public view returns (bool) {
-        uint40 val = uint40(bytes5(sync_rng_b5()));
+        uint40 val = uint40(bytes5(unsafe_rng_b5()));
         return val >= 2**10 && val <= type(uint40).max - 2**10;
     }
 
     function testRngB6() public view returns (bool) {
-        uint48 val = uint48(bytes6(sync_rng_b6()));
+        uint48 val = uint48(bytes6(unsafe_rng_b6()));
         return val >= 2**18 && val <= type(uint48).max - 2**18;
     }
 
     function testRngB7() public view returns (bool) {
-        uint56 val = uint56(bytes7(sync_rng_b7()));
+        uint56 val = uint56(bytes7(unsafe_rng_b7()));
         return val >= 2**26 && val <= type(uint56).max - 2**26;
     }
 
     function testRngB8() public view returns (bool) {
-        uint64 val = uint64(bytes8(sync_rng_b8()));
+        uint64 val = uint64(bytes8(unsafe_rng_b8()));
         return val >= 2**34 && val <= type(uint64).max - 2**34;
     }
 
     function testRngB9() public view returns (bool) {
-        uint72 val = uint72(bytes9(sync_rng_b9()));
+        uint72 val = uint72(bytes9(unsafe_rng_b9()));
         return val >= 2**42 && val <= type(uint72).max - 2**42;
     }
 
     function testRngB10() public view returns (bool) {
-        uint80 val = uint80(bytes10(sync_rng_b10()));
+        uint80 val = uint80(bytes10(unsafe_rng_b10()));
         return val >= 2**50 && val <= type(uint80).max - 2**50;
     }
 
     function testRngB11() public view returns (bool) {
-        uint88 val = uint88(bytes11(sync_rng_b11()));
+        uint88 val = uint88(bytes11(unsafe_rng_b11()));
         return val >= 2**58 && val <= type(uint88).max - 2**58;
     }
 
     function testRngB12() public view returns (bool) {
-        uint96 val = uint96(bytes12(sync_rng_b12()));
+        uint96 val = uint96(bytes12(unsafe_rng_b12()));
         return val >= 2**66 && val <= type(uint96).max - 2**66;
     }
 
     function testRngB13() public view returns (bool) {
-        uint104 val = uint104(bytes13(sync_rng_b13()));
+        uint104 val = uint104(bytes13(unsafe_rng_b13()));
         return val >= 2**74 && val <= type(uint104).max - 2**74;
     }
 
     function testRngB14() public view returns (bool) {
-        uint112 val = uint112(bytes14(sync_rng_b14()));
+        uint112 val = uint112(bytes14(unsafe_rng_b14()));
         return val >= 2**82 && val <= type(uint112).max - 2**82;
     }
 
     function testRngB15() public view returns (bool) {
-        uint120 val = uint120(bytes15(sync_rng_b15()));
+        uint120 val = uint120(bytes15(unsafe_rng_b15()));
         return val >= 2**90 && val <= type(uint120).max - 2**90;
     }
 
     function testRngB16() public view returns (bool) {
-        uint128 val = uint128(bytes16(sync_rng_b16()));
+        uint128 val = uint128(bytes16(unsafe_rng_b16()));
         return val >= 2**98 && val <= type(uint128).max - 2**98;
     }
 
     function testRngB17() public view returns (bool) {
-        uint136 val = uint136(bytes17(sync_rng_b17()));
+        uint136 val = uint136(bytes17(unsafe_rng_b17()));
         return val >= 2**106 && val <= type(uint136).max - 2**106;
     }
 
     function testRngB18() public view returns (bool) {
-        uint144 val = uint144(bytes18(sync_rng_b18()));
+        uint144 val = uint144(bytes18(unsafe_rng_b18()));
         return val >= 2**114 && val <= type(uint144).max - 2**114;
     }
 
     function testRngB19() public view returns (bool) {
-        uint152 val = uint152(bytes19(sync_rng_b19()));
+        uint152 val = uint152(bytes19(unsafe_rng_b19()));
         return val >= 2**122 && val <= type(uint152).max - 2**122;
     }
 
     function testRngB20() public view returns (bool) {
-        uint160 val = uint160(bytes20(sync_rng_b20()));
+        uint160 val = uint160(bytes20(unsafe_rng_b20()));
         return val >= 2**130 && val <= type(uint160).max - 2**130;
     }
 
     function testRngB21() public view returns (bool) {
-        uint168 val = uint168(bytes21(sync_rng_b21()));
+        uint168 val = uint168(bytes21(unsafe_rng_b21()));
         return val >= 2**138 && val <= type(uint168).max - 2**138;
     }
 
     function testRngB22() public view returns (bool) {
-        uint176 val = uint176(bytes22(sync_rng_b22()));
+        uint176 val = uint176(bytes22(unsafe_rng_b22()));
         return val >= 2**146 && val <= type(uint176).max - 2**146;
     }
 
     function testRngB23() public view returns (bool) {
-        uint184 val = uint184(bytes23(sync_rng_b23()));
+        uint184 val = uint184(bytes23(unsafe_rng_b23()));
         return val >= 2**154 && val <= type(uint184).max - 2**154;
     }
 
     function testRngB24() public view returns (bool) {
-        uint192 val = uint192(bytes24(sync_rng_b24()));
+        uint192 val = uint192(bytes24(unsafe_rng_b24()));
         return val >= 2**162 && val <= type(uint192).max - 2**162;
     }
 
     function testRngB25() public view returns (bool) {
-        uint200 val = uint200(bytes25(sync_rng_b25()));
+        uint200 val = uint200(bytes25(unsafe_rng_b25()));
         return val >= 2**170 && val <= type(uint200).max - 2**170;
     }
 
     function testRngB26() public view returns (bool) {
-        uint208 val = uint208(bytes26(sync_rng_b26()));
+        uint208 val = uint208(bytes26(unsafe_rng_b26()));
         return val >= 2**178 && val <= type(uint208).max - 2**178;
     }
 
     function testRngB27() public view returns (bool) {
-        uint216 val = uint216(bytes27(sync_rng_b27()));
+        uint216 val = uint216(bytes27(unsafe_rng_b27()));
         return val >= 2**186 && val <= type(uint216).max - 2**186;
     }
 
     function testRngB28() public view returns (bool) {
-        uint224 val = uint224(bytes28(sync_rng_b28()));
+        uint224 val = uint224(bytes28(unsafe_rng_b28()));
         return val >= 2**194 && val <= type(uint224).max - 2**194;
     }
 
     function testRngB29() public view returns (bool) {
-        uint232 val = uint232(bytes29(sync_rng_b29()));
+        uint232 val = uint232(bytes29(unsafe_rng_b29()));
         return val >= 2**202 && val <= type(uint232).max - 2**202;
     }
 
     function testRngB30() public view returns (bool) {
-        uint240 val = uint240(bytes30(sync_rng_b30()));
+        uint240 val = uint240(bytes30(unsafe_rng_b30()));
         return val >= 2**210 && val <= type(uint240).max - 2**210;
     }
 
     function testRngB31() public view returns (bool) {
-        uint248 val = uint248(bytes31(sync_rng_b31()));
+        uint248 val = uint248(bytes31(unsafe_rng_b31()));
         return val >= 2**218 && val <= type(uint248).max - 2**218;
     }
 
     function testRngB32() public view returns (bool) {
-        uint256 val = uint256(bytes32(sync_rng_b32()));
+        uint256 val = uint256(bytes32(unsafe_rng_b32()));
         return val >= 2**226 && val <= type(uint256).max - 2**226;
     }
 }

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_bytes_width_integrity.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_bytes_width_integrity.sol
@@ -2,28 +2,28 @@
 pragma solidity ^0.8.0;
 
 contract RngBytesWidthIntegrity {
-    // For sync_rng_b1: result cast to bytes32 should have zero padding in lower 31 bytes.
+    // For unsafe_rng_b1: result cast to bytes32 should have zero padding in lower 31 bytes.
     function testB1Alignment() public view returns (bool) {
-        bytes32 raw = bytes32(bytes1(sync_rng_b1()));
+        bytes32 raw = bytes32(bytes1(unsafe_rng_b1()));
         // Lower 31 bytes should be zero (left-aligned in bytes1, padded when cast to bytes32).
         return raw & bytes32(uint256((1 << (31 * 8)) - 1)) == bytes32(0);
     }
 
-    // For sync_rng_b4: result cast to bytes32 should have zero padding in lower 28 bytes.
+    // For unsafe_rng_b4: result cast to bytes32 should have zero padding in lower 28 bytes.
     function testB4Alignment() public view returns (bool) {
-        bytes32 raw = bytes32(bytes4(sync_rng_b4()));
+        bytes32 raw = bytes32(bytes4(unsafe_rng_b4()));
         return raw & bytes32(uint256((1 << (28 * 8)) - 1)) == bytes32(0);
     }
 
-    // For sync_rng_b16: lower 16 bytes should be zero when cast to bytes32.
+    // For unsafe_rng_b16: lower 16 bytes should be zero when cast to bytes32.
     function testB16Alignment() public view returns (bool) {
-        bytes32 raw = bytes32(bytes16(sync_rng_b16()));
+        bytes32 raw = bytes32(bytes16(unsafe_rng_b16()));
         return raw & bytes32(uint256((1 << (16 * 8)) - 1)) == bytes32(0);
     }
 
-    // For sync_rng_b32: all 32 bytes are used, no padding constraint.
+    // For unsafe_rng_b32: all 32 bytes are used, no padding constraint.
     function testB32FullWidth() public view returns (bool) {
-        uint256 val = uint256(bytes32(sync_rng_b32()));
+        uint256 val = uint256(bytes32(unsafe_rng_b32()));
         return val >= 2**226 && val <= type(uint256).max - 2**226;
     }
 }

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_consecutive_differ.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_consecutive_differ.sol
@@ -2,33 +2,33 @@
 pragma solidity ^0.8.0;
 
 contract RngConsecutiveDiffer {
-    // Verify that consecutive sync_rng256 calls can produce different values.
+    // Verify that consecutive unsafe_rng_u256 calls can produce different values.
     // We call multiple times and check they are not all identical.
     // P(false positive) = (1/2^256)^3 ≈ 0, effectively impossible.
     function testConsecutiveCallsDiffer() public view returns (bool) {
-        uint256 a = uint256(sync_rng256());
-        uint256 b = uint256(sync_rng256());
-        uint256 c = uint256(sync_rng256());
-        uint256 d = uint256(sync_rng256());
+        uint256 a = uint256(unsafe_rng_u256());
+        uint256 b = uint256(unsafe_rng_u256());
+        uint256 c = uint256(unsafe_rng_u256());
+        uint256 d = uint256(unsafe_rng_u256());
         // At least one pair must differ
         return (a != b) || (b != c) || (c != d);
     }
 
     // Same test for a smaller type.
     function testConsecutive64Differ() public view returns (bool) {
-        uint64 a = uint64(sync_rng64());
-        uint64 b = uint64(sync_rng64());
-        uint64 c = uint64(sync_rng64());
-        uint64 d = uint64(sync_rng64());
+        uint64 a = uint64(unsafe_rng_u64());
+        uint64 b = uint64(unsafe_rng_u64());
+        uint64 c = uint64(unsafe_rng_u64());
+        uint64 d = uint64(unsafe_rng_u64());
         return (a != b) || (b != c) || (c != d);
     }
 
     // Same test for bytes variant.
     function testConsecutiveB32Differ() public view returns (bool) {
-        bytes32 a = bytes32(sync_rng_b32());
-        bytes32 b = bytes32(sync_rng_b32());
-        bytes32 c = bytes32(sync_rng_b32());
-        bytes32 d = bytes32(sync_rng_b32());
+        bytes32 a = bytes32(unsafe_rng_b32());
+        bytes32 b = bytes32(unsafe_rng_b32());
+        bytes32 c = bytes32(unsafe_rng_b32());
+        bytes32 d = bytes32(unsafe_rng_b32());
         return (a != b) || (b != c) || (c != d);
     }
 }

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_cross_contract.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_cross_contract.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.8.0;
 
 contract RngProvider {
     function getRandom256() external view returns (uint256) {
-        return uint256(sync_rng256());
+        return uint256(unsafe_rng_u256());
     }
 
     function getRandomB32() external view returns (bytes32) {
-        return bytes32(sync_rng_b32());
+        return bytes32(unsafe_rng_b32());
     }
 }
 

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_explicit_cast_to_plain.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_explicit_cast_to_plain.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 contract RngExplicitCast {
     // Explicit cast from shielded to plain should work and preserve value.
     function testCastSuint256ToUint256() public view returns (bool) {
-        suint256 r = sync_rng256();
+        suint256 r = unsafe_rng_u256();
         uint256 plain = uint256(r);
         // The value should be nonzero with overwhelming probability.
         return plain != 0;
@@ -12,24 +12,24 @@ contract RngExplicitCast {
 
     function testCastSuint8ToUint8() public view returns (bool) {
         // Multiple samples to avoid false positive.
-        uint8 a = uint8(sync_rng8());
-        uint8 b = uint8(sync_rng8());
-        uint8 c = uint8(sync_rng8());
-        uint8 d = uint8(sync_rng8());
+        uint8 a = uint8(unsafe_rng_u8());
+        uint8 b = uint8(unsafe_rng_u8());
+        uint8 c = uint8(unsafe_rng_u8());
+        uint8 d = uint8(unsafe_rng_u8());
         return (a | b | c | d) != 0;
     }
 
     function testCastSbytes32ToBytes32() public view returns (bool) {
-        sbytes32 r = sync_rng_b32();
+        sbytes32 r = unsafe_rng_b32();
         bytes32 plain = bytes32(r);
         return plain != bytes32(0);
     }
 
     function testCastSbytes1ToBytes1() public view returns (bool) {
-        bytes1 a = bytes1(sync_rng_b1());
-        bytes1 b = bytes1(sync_rng_b1());
-        bytes1 c = bytes1(sync_rng_b1());
-        bytes1 d = bytes1(sync_rng_b1());
+        bytes1 a = bytes1(unsafe_rng_b1());
+        bytes1 b = bytes1(unsafe_rng_b1());
+        bytes1 c = bytes1(unsafe_rng_b1());
+        bytes1 d = bytes1(unsafe_rng_b1());
         return (a | b | c | d) != bytes1(0);
     }
 }

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_in_constructor.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_in_constructor.sol
@@ -5,7 +5,7 @@ contract RngInConstructor {
     suint256 private val;
 
     constructor() {
-        val = sync_rng256();
+        val = unsafe_rng_u256();
     }
 
     // Value set in constructor should be nonzero.

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_in_loop.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_in_loop.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.0;
 contract RngInLoop {
     // Generate 10 random values in a loop and verify they're not all the same.
     function testLoopDiversity() public view returns (bool) {
-        uint256 first = uint256(sync_rng256());
+        uint256 first = uint256(unsafe_rng_u256());
         bool anyDifferent = false;
         for (uint i = 0; i < 9; i++) {
-            uint256 val = uint256(sync_rng256());
+            uint256 val = uint256(unsafe_rng_u256());
             if (val != first) {
                 anyDifferent = true;
             }
@@ -19,7 +19,7 @@ contract RngInLoop {
     function testLoopXorAccumulate() public view returns (bool) {
         bytes32 acc = bytes32(0);
         for (uint i = 0; i < 20; i++) {
-            acc = acc ^ bytes32(sync_rng_b32());
+            acc = acc ^ bytes32(unsafe_rng_b32());
         }
         return acc != bytes32(0);
     }

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_inheritance.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_inheritance.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 contract Base {
     function getBaseRng() internal view returns (suint256) {
-        return sync_rng256();
+        return unsafe_rng_u256();
     }
 }
 

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_internal_function_call.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_internal_function_call.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.8.0;
 
 contract RngInternalFunctionCall {
     function getSecret256() internal view returns (suint256) {
-        return sync_rng256();
+        return unsafe_rng_u256();
     }
 
     function getSecretB32() internal view returns (sbytes32) {
-        return sync_rng_b32();
+        return unsafe_rng_b32();
     }
 
     function testInternalCallInt() public view returns (bool) {

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_mapping_storage.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_mapping_storage.sol
@@ -7,7 +7,7 @@ contract RngMappingStorage {
     // Store random values in a mapping and verify they persist.
     function storeRandomValues() public {
         for (uint256 i = 0; i < 5; i++) {
-            m[i] = sync_rng256();
+            m[i] = unsafe_rng_u256();
         }
     }
 

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_modifier_context.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_modifier_context.sol
@@ -6,9 +6,9 @@ contract RngModifierContext {
     suint256 private postVal;
 
     modifier withRng() {
-        preVal = sync_rng256();
+        preVal = unsafe_rng_u256();
         _;
-        postVal = sync_rng256();
+        postVal = unsafe_rng_u256();
     }
 
     function execute() public withRng {

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_multiple_types_single_tx.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_multiple_types_single_tx.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.0;
 contract RngMultipleTypesSingleTx {
     // Call every integer width in one transaction and verify all look random.
     function testAllIntegerWidths() public view returns (bool) {
-        uint256 r8   = uint256(uint8(sync_rng8()));
-        uint256 r16  = uint256(uint16(sync_rng16()));
-        uint256 r32  = uint256(uint32(sync_rng32()));
-        uint256 r64  = uint256(uint64(sync_rng64()));
-        uint256 r96  = uint256(uint128(sync_rng96()));
-        uint256 r128 = uint256(uint128(sync_rng128()));
-        uint256 r256 = uint256(sync_rng256());
+        uint256 r8   = uint256(uint8(unsafe_rng_u8()));
+        uint256 r16  = uint256(uint16(unsafe_rng_u16()));
+        uint256 r32  = uint256(uint32(unsafe_rng_u32()));
+        uint256 r64  = uint256(uint64(unsafe_rng_u64()));
+        uint256 r96  = uint256(uint128(unsafe_rng_u96()));
+        uint256 r128 = uint256(uint128(unsafe_rng_u128()));
+        uint256 r256 = uint256(unsafe_rng_u256());
 
         // Each value should be nonzero with overwhelming probability.
         // P(any one is zero) = 1/2^N, and we OR them all.
@@ -21,10 +21,10 @@ contract RngMultipleTypesSingleTx {
 
     // Call several byte widths in one transaction.
     function testMixedByteWidths() public view returns (bool) {
-        bytes32 b1  = bytes32(bytes1(sync_rng_b1())) >> 0;
-        bytes32 b8  = bytes32(bytes8(sync_rng_b8())) >> 0;
-        bytes32 b16 = bytes32(bytes16(sync_rng_b16())) >> 0;
-        bytes32 b32 = bytes32(sync_rng_b32());
+        bytes32 b1  = bytes32(bytes1(unsafe_rng_b1())) >> 0;
+        bytes32 b8  = bytes32(bytes8(unsafe_rng_b8())) >> 0;
+        bytes32 b16 = bytes32(bytes16(unsafe_rng_b16())) >> 0;
+        bytes32 b32 = bytes32(unsafe_rng_b32());
 
         return (b1 | b8 | b16 | b32) != bytes32(0);
     }

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_store_and_retrieve.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_store_and_retrieve.sol
@@ -5,9 +5,9 @@ contract RngStoreAndRetrieve {
     suint256 private storedVal;
     sbytes32 private storedBytes;
 
-    // Store sync_rng result in confidential storage and verify it persists.
+    // Store unsafe_rng_u result in confidential storage and verify it persists.
     function storeRng256() public {
-        storedVal = sync_rng256();
+        storedVal = unsafe_rng_u256();
     }
 
     function retrieveStored256() public view returns (bool) {
@@ -16,7 +16,7 @@ contract RngStoreAndRetrieve {
     }
 
     function storeRngB32() public {
-        storedBytes = sync_rng_b32();
+        storedBytes = unsafe_rng_b32();
     }
 
     function retrieveStoredB32() public view returns (bool) {

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_struct_storage.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_struct_storage.sol
@@ -11,9 +11,9 @@ contract RngStructStorage {
     SecretData private data;
 
     function storeRng() public {
-        data.value = sync_rng256();
-        data.token = sync_rng_b32();
-        data.small = sync_rng64();
+        data.value = unsafe_rng_u256();
+        data.token = unsafe_rng_b32();
+        data.small = unsafe_rng_u64();
     }
 
     function testAllFieldsNonzero() public view returns (bool) {

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_ternary.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_ternary.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.0;
 
 contract RngTernary {
-    // sync_rng should work in both branches of a ternary.
+    // unsafe_rng_u should work in both branches of a ternary.
     function testTernaryTrue() public view returns (bool) {
-        uint256 val = uint256(true ? sync_rng256() : sync_rng256());
+        uint256 val = uint256(true ? unsafe_rng_u256() : unsafe_rng_u256());
         return val >= 2**226 && val <= type(uint256).max - 2**226;
     }
 
     function testTernaryFalse() public view returns (bool) {
-        uint256 val = uint256(false ? sync_rng256() : sync_rng256());
+        uint256 val = uint256(false ? unsafe_rng_u256() : unsafe_rng_u256());
         return val >= 2**226 && val <= type(uint256).max - 2**226;
     }
 }

--- a/test/libsolidity/semanticTests/seismic_builtins/rng_with_other_builtins.sol
+++ b/test/libsolidity/semanticTests/seismic_builtins/rng_with_other_builtins.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.0;
 
 contract RngWithOtherBuiltins {
-    // sync_rng should work alongside other built-in operations.
+    // unsafe_rng_u should work alongside other built-in operations.
     function testWithKeccak() public view returns (bool) {
-        bytes32 rngVal = bytes32(sync_rng_b32());
+        bytes32 rngVal = bytes32(unsafe_rng_b32());
         bytes32 hashed = keccak256(abi.encodePacked(rngVal));
         // Hash of a random value should be nonzero.
         return hashed != bytes32(0);
@@ -12,7 +12,7 @@ contract RngWithOtherBuiltins {
 
     function testWithGasleft() public view returns (bool) {
         uint256 gasBefore = gasleft();
-        uint256 rngVal = uint256(sync_rng256());
+        uint256 rngVal = uint256(unsafe_rng_u256());
         uint256 gasAfter = gasleft();
         // The RNG call should consume some gas.
         return gasBefore > gasAfter && rngVal != 0;

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_as_function_argument.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_as_function_argument.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng result can be passed as an argument to another function.
+// unsafe_rng_u result can be passed as an argument to another function.
 contract C {
     function consume(suint256 val) internal pure {
         val;
     }
 
     function f() public view {
-        consume(sync_rng256());
+        consume(unsafe_rng_u256());
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_bytes_type_check_17_to_24.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_bytes_type_check_17_to_24.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.0;
 
 contract C {
     function f() public view {
-        sbytes17 r17 = sync_rng_b17();
-        sbytes18 r18 = sync_rng_b18();
-        sbytes19 r19 = sync_rng_b19();
-        sbytes20 r20 = sync_rng_b20();
-        sbytes21 r21 = sync_rng_b21();
-        sbytes22 r22 = sync_rng_b22();
-        sbytes23 r23 = sync_rng_b23();
-        sbytes24 r24 = sync_rng_b24();
+        sbytes17 r17 = unsafe_rng_b17();
+        sbytes18 r18 = unsafe_rng_b18();
+        sbytes19 r19 = unsafe_rng_b19();
+        sbytes20 r20 = unsafe_rng_b20();
+        sbytes21 r21 = unsafe_rng_b21();
+        sbytes22 r22 = unsafe_rng_b22();
+        sbytes23 r23 = unsafe_rng_b23();
+        sbytes24 r24 = unsafe_rng_b24();
         r17; r18; r19; r20; r21; r22; r23; r24;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_bytes_type_check_1_to_8.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_bytes_type_check_1_to_8.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.0;
 
 contract C {
     function f() public view {
-        sbytes1 r1 = sync_rng_b1();
-        sbytes2 r2 = sync_rng_b2();
-        sbytes3 r3 = sync_rng_b3();
-        sbytes4 r4 = sync_rng_b4();
-        sbytes5 r5 = sync_rng_b5();
-        sbytes6 r6 = sync_rng_b6();
-        sbytes7 r7 = sync_rng_b7();
-        sbytes8 r8 = sync_rng_b8();
+        sbytes1 r1 = unsafe_rng_b1();
+        sbytes2 r2 = unsafe_rng_b2();
+        sbytes3 r3 = unsafe_rng_b3();
+        sbytes4 r4 = unsafe_rng_b4();
+        sbytes5 r5 = unsafe_rng_b5();
+        sbytes6 r6 = unsafe_rng_b6();
+        sbytes7 r7 = unsafe_rng_b7();
+        sbytes8 r8 = unsafe_rng_b8();
         r1; r2; r3; r4; r5; r6; r7; r8;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_bytes_type_check_25_to_32.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_bytes_type_check_25_to_32.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.0;
 
 contract C {
     function f() public view {
-        sbytes25 r25 = sync_rng_b25();
-        sbytes26 r26 = sync_rng_b26();
-        sbytes27 r27 = sync_rng_b27();
-        sbytes28 r28 = sync_rng_b28();
-        sbytes29 r29 = sync_rng_b29();
-        sbytes30 r30 = sync_rng_b30();
-        sbytes31 r31 = sync_rng_b31();
-        sbytes32 r32 = sync_rng_b32();
+        sbytes25 r25 = unsafe_rng_b25();
+        sbytes26 r26 = unsafe_rng_b26();
+        sbytes27 r27 = unsafe_rng_b27();
+        sbytes28 r28 = unsafe_rng_b28();
+        sbytes29 r29 = unsafe_rng_b29();
+        sbytes30 r30 = unsafe_rng_b30();
+        sbytes31 r31 = unsafe_rng_b31();
+        sbytes32 r32 = unsafe_rng_b32();
         r25; r26; r27; r28; r29; r30; r31; r32;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_bytes_type_check_9_to_16.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_bytes_type_check_9_to_16.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.0;
 
 contract C {
     function f() public view {
-        sbytes9 r9 = sync_rng_b9();
-        sbytes10 r10 = sync_rng_b10();
-        sbytes11 r11 = sync_rng_b11();
-        sbytes12 r12 = sync_rng_b12();
-        sbytes13 r13 = sync_rng_b13();
-        sbytes14 r14 = sync_rng_b14();
-        sbytes15 r15 = sync_rng_b15();
-        sbytes16 r16 = sync_rng_b16();
+        sbytes9 r9 = unsafe_rng_b9();
+        sbytes10 r10 = unsafe_rng_b10();
+        sbytes11 r11 = unsafe_rng_b11();
+        sbytes12 r12 = unsafe_rng_b12();
+        sbytes13 r13 = unsafe_rng_b13();
+        sbytes14 r14 = unsafe_rng_b14();
+        sbytes15 r15 = unsafe_rng_b15();
+        sbytes16 r16 = unsafe_rng_b16();
         r9; r10; r11; r12; r13; r14; r15; r16;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_bytes_view_not_pure.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_bytes_view_not_pure.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 contract C {
     function f() internal pure returns (sbytes32) {
-        return sync_rng_b32();
+        return unsafe_rng_b32();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_bytes_view_not_pure.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_bytes_view_not_pure.sol
@@ -7,4 +7,4 @@ contract C {
     }
 }
 // ----
-// TypeError 2527: (137-151): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (137-153): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_callable_from_nonview.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_callable_from_nonview.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng functions should be callable from non-pure/non-view (state-mutating) functions.
+// unsafe_rng_u functions should be callable from non-pure/non-view (state-mutating) functions.
 contract C {
     suint256 private stored;
 
     function f() public {
-        stored = sync_rng256();
+        stored = unsafe_rng_u256();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_cross_contract_call.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_cross_contract_call.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng can be used internally within contracts that interact.
+// unsafe_rng_u can be used internally within contracts that interact.
 contract RngProvider {
     function getRandom() internal view returns (suint256) {
-        return sync_rng256();
+        return unsafe_rng_u256();
     }
 }
 

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_in_array_push.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_in_array_push.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng result can be pushed to a shielded dynamic array.
+// unsafe_rng_u result can be pushed to a shielded dynamic array.
 contract C {
     suint256[] private arr;
 
     function f() public {
-        arr.push(sync_rng256());
+        arr.push(unsafe_rng_u256());
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_in_array_push.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_in_array_push.sol
@@ -10,4 +10,4 @@ contract C {
     }
 }
 // ----
-// Warning 10305: (136-158): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// Warning 10305: (140-162): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_in_constructor.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_in_constructor.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng should be callable from a constructor.
+// unsafe_rng_u should be callable from a constructor.
 contract C {
     suint256 private val;
     constructor() {
-        val = sync_rng256();
+        val = unsafe_rng_u256();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_in_if_condition.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_in_if_condition.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng result can be used in expressions and comparisons.
+// unsafe_rng_u result can be used in expressions and comparisons.
 contract C {
     suint256 private stored;
 
     function f() public {
-        suint256 r = sync_rng256();
+        suint256 r = unsafe_rng_u256();
         stored = r;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_in_loop.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_in_loop.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng calls within loops should compile.
+// unsafe_rng_u calls within loops should compile.
 contract C {
     suint256[] private arr;
 
     function f() public {
         for (uint i = 0; i < 10; i++) {
-            arr.push(sync_rng256());
+            arr.push(unsafe_rng_u256());
         }
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_in_loop.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_in_loop.sol
@@ -12,4 +12,4 @@ contract C {
     }
 }
 // ----
-// Warning 10305: (121-143): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// Warning 10305: (125-147): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_in_mapping_value.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_in_mapping_value.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng result can be stored in a mapping with shielded value type.
+// unsafe_rng_u result can be stored in a mapping with shielded value type.
 contract C {
     mapping(uint256 => suint256) private m;
 
     function f(uint256 key) public {
-        m[key] = sync_rng256();
+        m[key] = unsafe_rng_u256();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_in_modifier.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_in_modifier.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng should be callable from a modifier.
+// unsafe_rng_u should be callable from a modifier.
 contract C {
     modifier withRng() {
-        suint256 r = sync_rng256();
+        suint256 r = unsafe_rng_u256();
         r;
         _;
     }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_in_struct_field.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_in_struct_field.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng result can be assigned to a struct field with shielded type.
+// unsafe_rng_u result can be assigned to a struct field with shielded type.
 contract C {
     struct SecretData {
         suint256 value;
@@ -11,8 +11,8 @@ contract C {
     SecretData private data;
 
     function f() public {
-        data.value = sync_rng256();
-        data.token = sync_rng_b32();
+        data.value = unsafe_rng_u256();
+        data.token = unsafe_rng_b32();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_in_ternary.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_in_ternary.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng calls in ternary expressions should compile.
+// unsafe_rng_u calls in ternary expressions should compile.
 contract C {
     function f(bool cond) internal view returns (suint256) {
-        return cond ? sync_rng256() : sync_rng256();
+        return cond ? unsafe_rng_u256() : unsafe_rng_u256();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_inheritance.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_inheritance.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng should work across inheritance.
+// unsafe_rng_u should work across inheritance.
 contract Base {
     function getRng() internal view returns (suint256) {
-        return sync_rng256();
+        return unsafe_rng_u256();
     }
 }
 

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_interface_return.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_interface_return.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 // Shielded return types cannot be used in external/public functions.
 contract C {
     function getRandom() external view returns (suint256) {
-        return sync_rng256();
+        return unsafe_rng_u256();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_mixed_int_and_bytes.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_mixed_int_and_bytes.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// Mixing sync_rng integer and bytes calls in the same function should compile.
+// Mixing unsafe_rng_u integer and bytes calls in the same function should compile.
 contract C {
     function f() public view {
-        suint256 a = sync_rng256();
-        sbytes32 b = sync_rng_b32();
-        suint8 c = sync_rng8();
-        sbytes1 d = sync_rng_b1();
+        suint256 a = unsafe_rng_u256();
+        sbytes32 b = unsafe_rng_b32();
+        suint8 c = unsafe_rng_u8();
+        sbytes1 d = unsafe_rng_b1();
         a; b; c; d;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_multiple_calls_same_function.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_multiple_calls_same_function.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// Multiple sync_rng calls in the same function should compile.
+// Multiple unsafe_rng_u calls in the same function should compile.
 contract C {
     function f() internal view returns (suint256, suint256, suint128, suint64) {
-        return (sync_rng256(), sync_rng256(), sync_rng128(), sync_rng64());
+        return (unsafe_rng_u256(), unsafe_rng_u256(), unsafe_rng_u128(), unsafe_rng_u64());
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_bytes_to_int.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_bytes_to_int.sol
@@ -9,4 +9,4 @@ contract C {
     }
 }
 // ----
-// TypeError 9574: (177-204): Type sbytes32 is not implicitly convertible to expected type suint256.
+// TypeError 9574: (179-208): Type sbytes32 is not implicitly convertible to expected type suint256.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_bytes_to_int.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_bytes_to_int.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng_b result cannot be assigned to a shielded integer type.
+// unsafe_rng_b result cannot be assigned to a shielded integer type.
 contract C {
     function f() public view {
-        suint256 a = sync_rng_b32();
+        suint256 a = unsafe_rng_b32();
         a;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_int_to_bytes.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_int_to_bytes.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng integer result cannot be assigned to a shielded bytes type.
+// unsafe_rng_u integer result cannot be assigned to a shielded bytes type.
 contract C {
     function f() public view {
-        sbytes32 a = sync_rng256();
+        sbytes32 a = unsafe_rng_u256();
         a;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_int_to_bytes.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_int_to_bytes.sol
@@ -9,4 +9,4 @@ contract C {
     }
 }
 // ----
-// TypeError 9574: (181-207): Type suint256 is not implicitly convertible to expected type sbytes32.
+// TypeError 9574: (185-215): Type suint256 is not implicitly convertible to expected type sbytes32.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_address.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_address.sol
@@ -10,5 +10,5 @@ contract C {
     }
 }
 // ----
-// TypeError 9574: (175-200): Type suint256 is not implicitly convertible to expected type address.
-// TypeError 9574: (210-236): Type suint256 is not implicitly convertible to expected type saddress.
+// TypeError 9574: (179-208): Type suint256 is not implicitly convertible to expected type address.
+// TypeError 9574: (218-248): Type suint256 is not implicitly convertible to expected type saddress.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_address.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_address.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng integer cannot be assigned to an address or saddress.
+// unsafe_rng_u integer cannot be assigned to an address or saddress.
 contract C {
     function f() public view {
-        address a = sync_rng256();
-        saddress b = sync_rng256();
+        address a = unsafe_rng_u256();
+        saddress b = unsafe_rng_u256();
         a; b;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_bool.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_bool.sol
@@ -10,5 +10,5 @@ contract C {
     }
 }
 // ----
-// TypeError 9574: (165-185): Type suint8 is not implicitly convertible to expected type bool.
-// TypeError 9574: (195-216): Type suint8 is not implicitly convertible to expected type sbool.
+// TypeError 9574: (169-193): Type suint8 is not implicitly convertible to expected type bool.
+// TypeError 9574: (203-228): Type suint8 is not implicitly convertible to expected type sbool.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_bool.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_bool.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng result cannot be assigned to bool or sbool.
+// unsafe_rng_u result cannot be assigned to bool or sbool.
 contract C {
     function f() public view {
-        bool a = sync_rng8();
-        sbool b = sync_rng8();
+        bool a = unsafe_rng_u8();
+        sbool b = unsafe_rng_u8();
         a; b;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_plain_bytes.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_plain_bytes.sol
@@ -9,4 +9,4 @@ contract C {
     }
 }
 // ----
-// TypeError 9574: (199-225): Type sbytes32 is not implicitly convertible to expected type bytes32.
+// TypeError 9574: (201-229): Type sbytes32 is not implicitly convertible to expected type bytes32.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_plain_bytes.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_plain_bytes.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng_b returns shielded bytes, which cannot be implicitly assigned to plain bytes.
+// unsafe_rng_b returns shielded bytes, which cannot be implicitly assigned to plain bytes.
 contract C {
     function f() public view {
-        bytes32 a = sync_rng_b32();
+        bytes32 a = unsafe_rng_b32();
         a;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_plain_uint.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_plain_uint.sol
@@ -9,4 +9,4 @@ contract C {
     }
 }
 // ----
-// TypeError 9574: (197-222): Type suint256 is not implicitly convertible to expected type uint256.
+// TypeError 9574: (201-230): Type suint256 is not implicitly convertible to expected type uint256.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_plain_uint.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_no_assign_to_plain_uint.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng returns shielded types, which cannot be implicitly assigned to plain types.
+// unsafe_rng_u returns shielded types, which cannot be implicitly assigned to plain types.
 contract C {
     function f() public view {
-        uint256 a = sync_rng256();
+        uint256 a = unsafe_rng_u256();
         a;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_no_external_return.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_no_external_return.sol
@@ -11,5 +11,5 @@ contract C {
     }
 }
 // ----
-// TypeError 10102: (170-178): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.
-// TypeError 10102: (256-264): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.
+// TypeError 10102: (174-182): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.
+// TypeError 10102: (264-272): Shielded objects cannot be returned from public or external functions. Use internal or private functions or cast to an unshielded type.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_no_external_return.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_no_external_return.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng results cannot be returned from public functions.
+// unsafe_rng_u results cannot be returned from public functions.
 contract C {
     function a() public view returns (suint256) {
-        return sync_rng256();
+        return unsafe_rng_u256();
     }
     function b() public view returns (sbytes32) {
-        return sync_rng_b32();
+        return unsafe_rng_b32();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_pure_reject_all_bytes_variants.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_pure_reject_all_bytes_variants.sol
@@ -10,8 +10,8 @@ contract C {
     function e() internal pure returns (sbytes32) { return unsafe_rng_b32(); }
 }
 // ----
-// TypeError 2527: (196-209): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (271-284): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (347-361): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (424-438): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (501-515): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (200-215): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (277-292): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (355-371): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (434-450): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (513-529): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_pure_reject_all_bytes_variants.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_pure_reject_all_bytes_variants.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// Every bytes sync_rng variant must be rejected in a pure context.
+// Every bytes unsafe_rng_u variant must be rejected in a pure context.
 contract C {
-    function a() internal pure returns (sbytes1) { return sync_rng_b1(); }
-    function b() internal pure returns (sbytes8) { return sync_rng_b8(); }
-    function c() internal pure returns (sbytes16) { return sync_rng_b16(); }
-    function d() internal pure returns (sbytes24) { return sync_rng_b24(); }
-    function e() internal pure returns (sbytes32) { return sync_rng_b32(); }
+    function a() internal pure returns (sbytes1) { return unsafe_rng_b1(); }
+    function b() internal pure returns (sbytes8) { return unsafe_rng_b8(); }
+    function c() internal pure returns (sbytes16) { return unsafe_rng_b16(); }
+    function d() internal pure returns (sbytes24) { return unsafe_rng_b24(); }
+    function e() internal pure returns (sbytes32) { return unsafe_rng_b32(); }
 }
 // ----
 // TypeError 2527: (196-209): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_pure_reject_all_int_variants.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_pure_reject_all_int_variants.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// Every integer sync_rng variant must be rejected in a pure context.
+// Every integer unsafe_rng_u variant must be rejected in a pure context.
 contract C {
-    function a() internal pure returns (suint8) { return sync_rng8(); }
-    function b() internal pure returns (suint16) { return sync_rng16(); }
-    function c() internal pure returns (suint32) { return sync_rng32(); }
-    function d() internal pure returns (suint64) { return sync_rng64(); }
-    function e() internal pure returns (suint96) { return sync_rng96(); }
-    function f() internal pure returns (suint128) { return sync_rng128(); }
-    function g() internal pure returns (suint256) { return sync_rng256(); }
+    function a() internal pure returns (suint8) { return unsafe_rng_u8(); }
+    function b() internal pure returns (suint16) { return unsafe_rng_u16(); }
+    function c() internal pure returns (suint32) { return unsafe_rng_u32(); }
+    function d() internal pure returns (suint64) { return unsafe_rng_u64(); }
+    function e() internal pure returns (suint96) { return unsafe_rng_u96(); }
+    function f() internal pure returns (suint128) { return unsafe_rng_u128(); }
+    function g() internal pure returns (suint256) { return unsafe_rng_u256(); }
 }
 // ----
 // TypeError 2527: (197-208): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_pure_reject_all_int_variants.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_pure_reject_all_int_variants.sol
@@ -12,10 +12,10 @@ contract C {
     function g() internal pure returns (suint256) { return unsafe_rng_u256(); }
 }
 // ----
-// TypeError 2527: (197-208): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (270-282): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (344-356): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (418-430): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (492-504): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (567-580): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (643-656): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (201-216): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (278-294): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (356-372): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (434-450): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (512-528): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (591-608): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (671-688): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_arguments.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_arguments.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng functions take no arguments.
+// unsafe_rng_u functions take no arguments.
 contract C {
     function f() public view {
-        sync_rng256(42);
+        unsafe_rng_u256(42);
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_arguments.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_arguments.sol
@@ -8,4 +8,4 @@ contract C {
     }
 }
 // ----
-// TypeError 6160: (150-165): Wrong argument count for function call: 1 arguments given but expected 0.
+// TypeError 6160: (154-173): Wrong argument count for function call: 1 arguments given but expected 0.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_arguments_bytes.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_arguments_bytes.sol
@@ -8,4 +8,4 @@ contract C {
     }
 }
 // ----
-// TypeError 6160: (152-168): Wrong argument count for function call: 1 arguments given but expected 0.
+// TypeError 6160: (154-172): Wrong argument count for function call: 1 arguments given but expected 0.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_arguments_bytes.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_arguments_bytes.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng_b functions take no arguments.
+// unsafe_rng_b functions take no arguments.
 contract C {
     function f() public view {
-        sync_rng_b32(42);
+        unsafe_rng_b32(42);
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_gas_member.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_gas_member.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng functions should not expose .gas() member.
+// unsafe_rng_u functions should not expose .gas() member.
 contract C {
     function f() public view {
-        sync_rng256.gas();
+        unsafe_rng_u256.gas();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_gas_member.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_gas_member.sol
@@ -8,4 +8,4 @@ contract C {
     }
 }
 // ----
-// TypeError 9582: (164-179): Member "gas" not found or not visible after argument-dependent lookup in function () view returns (suint256).
+// TypeError 9582: (168-187): Member "gas" not found or not visible after argument-dependent lookup in function () view returns (suint256).

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_gas_member_bytes.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_gas_member_bytes.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng_b functions should not expose .gas() member.
+// unsafe_rng_b functions should not expose .gas() member.
 contract C {
     function f() public view {
-        sync_rng_b32.gas();
+        unsafe_rng_b32.gas();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_gas_member_bytes.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_gas_member_bytes.sol
@@ -8,4 +8,4 @@ contract C {
     }
 }
 // ----
-// TypeError 9582: (166-182): Member "gas" not found or not visible after argument-dependent lookup in function () view returns (sbytes32).
+// TypeError 9582: (168-186): Member "gas" not found or not visible after argument-dependent lookup in function () view returns (sbytes32).

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_multiple_arguments.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_multiple_arguments.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng functions reject multiple arguments.
+// unsafe_rng_u functions reject multiple arguments.
 contract C {
     function f() public view {
-        sync_rng256(1, 2, 3);
+        unsafe_rng_u256(1, 2, 3);
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_multiple_arguments.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_multiple_arguments.sol
@@ -8,4 +8,4 @@ contract C {
     }
 }
 // ----
-// TypeError 6160: (158-178): Wrong argument count for function call: 3 arguments given but expected 0.
+// TypeError 6160: (162-186): Wrong argument count for function call: 3 arguments given but expected 0.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_value_member.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_value_member.sol
@@ -8,4 +8,4 @@ contract C {
     }
 }
 // ----
-// TypeError 8820: (166-183): Member "value" is only available for payable functions.
+// TypeError 8820: (170-191): Member "value" is only available for payable functions.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_value_member.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_value_member.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng functions should not expose .value() member.
+// unsafe_rng_u functions should not expose .value() member.
 contract C {
     function f() public view {
-        sync_rng256.value();
+        unsafe_rng_u256.value();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_value_member_bytes.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_value_member_bytes.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng_b functions should not expose .value() member.
+// unsafe_rng_b functions should not expose .value() member.
 contract C {
     function f() public view {
-        sync_rng_b32.value();
+        unsafe_rng_b32.value();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_value_member_bytes.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_reject_value_member_bytes.sol
@@ -8,4 +8,4 @@ contract C {
     }
 }
 // ----
-// TypeError 8820: (168-186): Member "value" is only available for payable functions.
+// TypeError 8820: (170-190): Member "value" is only available for payable functions.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_return_type_exact_match.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_return_type_exact_match.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// Each sync_rng variant returns exactly the right shielded type.
+// Each unsafe_rng_u variant returns exactly the right shielded type.
 contract C {
-    function a() internal view returns (suint8) { return sync_rng8(); }
-    function b() internal view returns (suint16) { return sync_rng16(); }
-    function c() internal view returns (suint32) { return sync_rng32(); }
-    function d() internal view returns (suint64) { return sync_rng64(); }
-    function e() internal view returns (suint96) { return sync_rng96(); }
-    function f() internal view returns (suint128) { return sync_rng128(); }
-    function g() internal view returns (suint256) { return sync_rng256(); }
-    function h() internal view returns (sbytes1) { return sync_rng_b1(); }
-    function i() internal view returns (sbytes16) { return sync_rng_b16(); }
-    function j() internal view returns (sbytes32) { return sync_rng_b32(); }
+    function a() internal view returns (suint8) { return unsafe_rng_u8(); }
+    function b() internal view returns (suint16) { return unsafe_rng_u16(); }
+    function c() internal view returns (suint32) { return unsafe_rng_u32(); }
+    function d() internal view returns (suint64) { return unsafe_rng_u64(); }
+    function e() internal view returns (suint96) { return unsafe_rng_u96(); }
+    function f() internal view returns (suint128) { return unsafe_rng_u128(); }
+    function g() internal view returns (suint256) { return unsafe_rng_u256(); }
+    function h() internal view returns (sbytes1) { return unsafe_rng_b1(); }
+    function i() internal view returns (sbytes16) { return unsafe_rng_b16(); }
+    function j() internal view returns (sbytes32) { return unsafe_rng_b32(); }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_shadow_local_variable.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_shadow_local_variable.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// A local variable named sync_rng256 should shadow the built-in.
+// A local variable named unsafe_rng_u256 should shadow the built-in.
 contract C {
     function f() public pure returns (uint256) {
-        uint256 sync_rng256 = 42;
-        return sync_rng256;
+        uint256 unsafe_rng_u256 = 42;
+        return unsafe_rng_u256;
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_shadow_local_variable.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_shadow_local_variable.sol
@@ -9,4 +9,4 @@ contract C {
     }
 }
 // ----
-// Warning 2319: (193-212): This declaration shadows a builtin symbol.
+// Warning 2319: (197-220): This declaration shadows a builtin symbol.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_type_check.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_type_check.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.0;
 
 contract C {
     function f() public view {
-        suint8 r8 = sync_rng8();
-        suint16 r16 = sync_rng16();
-        suint32 r32 = sync_rng32();
-        suint64 r64 = sync_rng64();
-        suint96 r96 = sync_rng96();
-        suint128 r128 = sync_rng128();
-        suint256 r256 = sync_rng256();
+        suint8 r8 = unsafe_rng_u8();
+        suint16 r16 = unsafe_rng_u16();
+        suint32 r32 = unsafe_rng_u32();
+        suint64 r64 = unsafe_rng_u64();
+        suint96 r96 = unsafe_rng_u96();
+        suint128 r128 = unsafe_rng_u128();
+        suint256 r256 = unsafe_rng_u256();
         r8; r16; r32; r64; r96; r128; r256;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_type_mismatch_bytes.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_type_mismatch_bytes.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// Assigning sync_rng_b32 to a smaller sbytes type must fail.
+// Assigning unsafe_rng_b32 to a smaller sbytes type must fail.
 contract C {
     function f() public view {
-        sbytes1 a = sync_rng_b32();
+        sbytes1 a = unsafe_rng_b32();
         a;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_type_mismatch_bytes.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_type_mismatch_bytes.sol
@@ -9,4 +9,4 @@ contract C {
     }
 }
 // ----
-// TypeError 9574: (171-197): Type sbytes32 is not implicitly convertible to expected type sbytes1.
+// TypeError 9574: (173-201): Type sbytes32 is not implicitly convertible to expected type sbytes1.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_type_mismatch_bytes_reverse.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_type_mismatch_bytes_reverse.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// Assigning sync_rng_b1 to a larger sbytes type must fail.
+// Assigning unsafe_rng_b1 to a larger sbytes type must fail.
 contract C {
     function f() public view {
-        sbytes32 a = sync_rng_b1();
+        sbytes32 a = unsafe_rng_b1();
         a;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_type_mismatch_int.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_type_mismatch_int.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// Assigning sync_rng result to the wrong shielded integer width must fail.
+// Assigning unsafe_rng_u result to the wrong shielded integer width must fail.
 contract C {
     function f() public view {
-        suint8 a = sync_rng256();
+        suint8 a = unsafe_rng_u256();
         a;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_type_mismatch_int.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_type_mismatch_int.sol
@@ -9,4 +9,4 @@ contract C {
     }
 }
 // ----
-// TypeError 9574: (185-209): Type suint256 is not implicitly convertible to expected type suint8.
+// TypeError 9574: (189-217): Type suint256 is not implicitly convertible to expected type suint8.

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_type_mismatch_int_reverse.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_type_mismatch_int_reverse.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// Assigning a smaller sync_rng result to a larger shielded type must fail.
+// Assigning a smaller unsafe_rng_u result to a larger shielded type must fail.
 contract C {
     function f() public view {
-        suint256 a = sync_rng8();
+        suint256 a = unsafe_rng_u8();
         a;
     }
 }

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_view_from_external.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_view_from_external.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng functions should be callable from external functions (storing result).
+// unsafe_rng_u functions should be callable from external functions (storing result).
 contract C {
     suint256 private stored;
 
     function f() external {
-        stored = sync_rng256();
+        stored = unsafe_rng_u256();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_view_from_internal.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_view_from_internal.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng functions should be callable from internal view functions.
+// unsafe_rng_u functions should be callable from internal view functions.
 contract C {
     function f() internal view returns (suint256) {
-        return sync_rng256();
+        return unsafe_rng_u256();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_view_from_private.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_view_from_private.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// sync_rng functions should be callable from private view functions.
+// unsafe_rng_u functions should be callable from private view functions.
 contract C {
     function f() private view returns (suint256) {
-        return sync_rng256();
+        return unsafe_rng_u256();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_view_not_pure.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_view_not_pure.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 contract C {
     function f() internal pure returns (suint256) {
-        return sync_rng256();
+        return unsafe_rng_u256();
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/seismic_builtins/rng_view_not_pure.sol
+++ b/test/libsolidity/syntaxTests/seismic_builtins/rng_view_not_pure.sol
@@ -7,4 +7,4 @@ contract C {
     }
 }
 // ----
-// TypeError 2527: (137-150): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (137-154): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".


### PR DESCRIPTION
## Summary
- Renames all RNG built-in functions to start with `unsafe_` to signal that randomness is sequencer-provided and not cryptographically committed
- Integer variants: `sync_rng{N}` → `unsafe_rng_u{N}` (e.g. `unsafe_rng_u256()`)
- Bytes variants: `sync_rng_b{N}` → `unsafe_rng_b{N}` (unchanged prefix, e.g. `unsafe_rng_b32()`)
- Adds new "RNG Precompiles" section to README linking to https://docs.seismic.systems/reference/precompiles/rng

## Test plan
- [ ] `scripts/soltest.sh` passes (unit tests)
- [ ] Semantic tests pass via seismic-revm (all 4 configurations)
- [ ] `isoltest --no-semantic-tests` passes for `syntaxTests/seismic_builtins/rng_*`