### PR TITLE
fix: preserve shielded ops for bytes(sbytes) aliases (#248)

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -57,6 +57,107 @@ using namespace solidity::util;
 using namespace solidity::langutil;
 using namespace solidity::frontend;
 
+namespace
+{
+
+/// Preserves the shielded-storage marker across casts/aliases like bytes(sbytesStorageRef). The
+/// resulting type stays unshielded bytes/string, but it still points at shielded storage, so both
+/// reads and writes must keep using shielded storage ops.
+Type const* preserveShieldedStorageMarker(Type const& _from, Type const& _to)
+{
+	auto const* fromArrayType = dynamic_cast<ArrayType const*>(&_from);
+	auto const* toArrayType = dynamic_cast<ArrayType const*>(&_to);
+	if (
+		// Only array types can carry the shielded-storage marker.
+		!fromArrayType ||
+		// Only array types can receive the shielded-storage marker.
+		!toArrayType ||
+		// The marker only matters for aliases that still point at storage.
+		fromArrayType->location() != DataLocation::Storage ||
+		// The marker is only for byte-array/string aliases like bytes(sbytesRef).
+		!fromArrayType->isByteArrayOrString() ||
+		// The target must also be a byte-array/string alias.
+		!toArrayType->isByteArrayOrString() ||
+		// There is nothing to preserve unless the source already uses shielded storage.
+		!fromArrayType->usesShieldedStorage() ||
+		// Do not mark genuinely shielded targets; they already select shielded ops directly.
+		toArrayType->baseType()->isShielded()
+	)
+		return &_to;
+
+	return TypeProvider::withShieldedStorageMarker(*toArrayType);
+}
+
+/// Local storage-reference declarations need the adjusted type annotation as well. Otherwise
+/// `bytes storage ref = bytes(sbytesRef)` would validate the initializer against the right type,
+/// but later uses of `ref` would still see plain `bytes storage` and lose the shielded-storage
+/// marker that codegen needs.
+void preserveShieldedStorageMarkerInDeclaration(
+	VariableDeclaration const& _variable,
+	Type const& _valueType
+)
+{
+	solAssert(_variable.annotation().type, "");
+	_variable.annotation().type = preserveShieldedStorageMarker(
+		_valueType,
+		*_variable.annotation().type
+	);
+}
+
+bool canPreserveShieldedStorageMarkerInAssignment(VariableDeclaration const& _variable)
+{
+	return
+		(_variable.isLocalVariable() || _variable.isCallableOrCatchParameter()) &&
+		_variable.referenceLocation() == VariableDeclaration::Location::Storage;
+}
+
+FunctionDefinition const* internalFunctionDefinition(FunctionType const& _functionType)
+{
+	if (_functionType.kind() != FunctionType::Kind::Internal || !_functionType.hasDeclaration())
+		return nullptr;
+
+	return dynamic_cast<FunctionDefinition const*>(&_functionType.declaration());
+}
+
+void preserveShieldedStorageMarkersInInternalCall(
+	FunctionCall const& _functionCall,
+	FunctionType const& _functionType
+)
+{
+	auto const* function = internalFunctionDefinition(_functionType);
+	if (!function)
+		return;
+
+	bool const isPositionalCall = _functionCall.names().empty();
+	TypePointers const& parameterTypes = _functionType.parameterTypes();
+	std::vector<ASTPointer<Expression const>> const& arguments = _functionCall.arguments();
+
+	if (arguments.size() != parameterTypes.size())
+		return;
+
+	std::vector<Expression const*> paramArgMap(parameterTypes.size());
+	if (isPositionalCall)
+		for (size_t i = 0; i < paramArgMap.size(); ++i)
+			paramArgMap[i] = arguments[i].get();
+	else
+	{
+		auto const& parameterNames = _functionType.parameterNames();
+		for (size_t i = 0; i < _functionCall.names().size(); ++i)
+			for (size_t j = 0; j < parameterNames.size(); ++j)
+				if (parameterNames[j] == *_functionCall.names()[i])
+				{
+					paramArgMap[j] = arguments[i].get();
+					break;
+				}
+	}
+
+	for (size_t i = 0; i < paramArgMap.size() && i < function->parameters().size(); ++i)
+		if (paramArgMap[i])
+			preserveShieldedStorageMarkerInDeclaration(*function->parameters()[i], *type(*paramArgMap[i]));
+}
+
+}
+
 bool TypeChecker::typeSupportedByOldABIEncoder(Type const& _type, bool _isLibraryCall)
 {
 	if (_isLibraryCall && _type.dataStoredIn(DataLocation::Storage))
@@ -1395,6 +1496,15 @@ void TypeChecker::endVisit(Return const& _return)
 		return;
 	}
 	TypePointers returnTypes;
+	if (auto tupleType = dynamic_cast<TupleType const*>(type(*_return.expression())))
+	{
+		for (size_t i = 0; i < std::min(tupleType->components().size(), params->parameters().size()); ++i)
+			if (tupleType->components()[i])
+				preserveShieldedStorageMarkerInDeclaration(*params->parameters()[i], *tupleType->components()[i]);
+	}
+	else if (params->parameters().size() == 1)
+		preserveShieldedStorageMarkerInDeclaration(*params->parameters().front(), *type(*_return.expression()));
+
 	for (auto const& var: params->parameters())
 		returnTypes.push_back(type(*var));
 	if (auto tupleType = dynamic_cast<TupleType const*>(type(*_return.expression())))
@@ -1526,8 +1636,7 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 		solAssert(!var.value(), "Value has to be tied to statement.");
 		Type const* valueComponentType = valueTypes[i];
 		solAssert(!!valueComponentType, "");
-		solAssert(var.annotation().type, "");
-
+		preserveShieldedStorageMarkerInDeclaration(var, *valueComponentType);
 		var.accept(*this);
 		BoolResult result = valueComponentType->isImplicitlyConvertibleTo(*var.annotation().type);
 		if (!result)
@@ -1729,7 +1838,13 @@ bool TypeChecker::visit(Assignment const& _assignment)
 		expectType(_assignment.rightHandSide(), *tupleType);
 	}
 	else if (_assignment.assignmentOperator() == Token::Assign)
+	{
 		expectType(_assignment.rightHandSide(), *t);
+		if (auto const* identifier = dynamic_cast<Identifier const*>(&_assignment.leftHandSide()))
+			if (auto const* variable = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration))
+				if (canPreserveShieldedStorageMarkerInAssignment(*variable))
+					preserveShieldedStorageMarkerInDeclaration(*variable, *type(_assignment.rightHandSide()));
+	}
 	else
 	{
 		// compound assignment
@@ -2218,6 +2333,7 @@ Type const* TypeChecker::typeCheckTypeConversionAndRetrieveReturnType(
 			dataLoc = argRefType->location();
 		if (auto type = dynamic_cast<ReferenceType const*>(resultType))
 			resultType = TypeProvider::withLocation(type, dataLoc, type->isPointer());
+		resultType = preserveShieldedStorageMarker(*argType, *resultType);
 		BoolResult result = argType->isExplicitlyConvertibleTo(*resultType);
 		SecondarySourceLocation ssl;
 		if (result)
@@ -2381,6 +2497,7 @@ void TypeChecker::typeCheckFunctionCall(
 
 	// Perform standard function call type checking
 	typeCheckFunctionGeneralChecks(_functionCall, _functionType);
+	preserveShieldedStorageMarkersInInternalCall(_functionCall, *_functionType);
 }
 
 void TypeChecker::typeCheckFallbackFunction(FunctionDefinition const& _function)
@@ -3268,12 +3385,14 @@ bool TypeChecker::visit(FunctionCall const& _functionCall)
 			returnTypes = functionType->returnParameterTypes();
 			break;
 		}
-		default:
-		{
-			typeCheckFunctionCall(_functionCall, functionType);
-			returnTypes = m_evmVersion.supportsReturndata() ?
-				functionType->returnParameterTypes() :
-				functionType->returnParameterTypesWithoutDynamicTypes();
+			default:
+			{
+				typeCheckFunctionCall(_functionCall, functionType);
+				if (auto const* function = internalFunctionDefinition(*functionType))
+					functionType = function->functionType(true);
+				returnTypes = m_evmVersion.supportsReturndata() ?
+					functionType->returnParameterTypes() :
+					functionType->returnParameterTypesWithoutDynamicTypes();
 			break;
 		}
 		}

--- a/libsolidity/ast/TypeProvider.cpp
+++ b/libsolidity/ast/TypeProvider.cpp
@@ -478,6 +478,13 @@ ArrayType const* TypeProvider::bytesCalldata()
 	return m_bytesCalldata.get();
 }
 
+ArrayType const* TypeProvider::withShieldedStorageMarker(ArrayType const& _type)
+{
+	if (_type.hasShieldedStorageMarker())
+		return &_type;
+	return createAndGet<ArrayType>(_type, ArrayType::ShieldedStorageMarker{});
+}
+
 ArrayType const* TypeProvider::stringStorage()
 {
 	if (!m_stringStorage)

--- a/libsolidity/ast/TypeProvider.h
+++ b/libsolidity/ast/TypeProvider.h
@@ -75,6 +75,7 @@ public:
 	static ArrayType const* bytesStorage();
 	static ArrayType const* bytesMemory();
 	static ArrayType const* bytesCalldata();
+	static ArrayType const* withShieldedStorageMarker(ArrayType const& _type);
 	static ArrayType const* shieldedBytesStorage();
 	static ArrayType const* shieldedBytesMemory();
 	static ArrayType const* shieldedBytesCalldata();

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1896,6 +1896,18 @@ ArrayType::ArrayType(DataLocation _location, ShieldedByteArrayTag):
 {
 }
 
+ArrayType::ArrayType(ArrayType const& _other, ShieldedStorageMarker):
+	ReferenceType(_other.location()),
+	m_arrayKind(_other.m_arrayKind),
+	m_baseType(copyForLocationIfReference(_other.m_baseType)),
+	m_hasDynamicLength(_other.m_hasDynamicLength),
+	m_length(_other.m_length),
+	m_hasShieldedStorageMarker(true)
+{
+	if (location() == DataLocation::Storage)
+		m_isPointer = _other.isPointer();
+}
+
 void ArrayType::clearCache() const
 {
 	Type::clearCache();
@@ -1968,6 +1980,11 @@ BoolResult ArrayType::isExplicitlyConvertibleTo(Type const& _convertTo) const
 	return true;
 }
 
+bool ArrayType::containsShieldedType() const
+{
+	return m_hasShieldedStorageMarker || CompositeType::containsShieldedType();
+}
+
 std::string ArrayType::richIdentifier() const
 {
 	std::string id;
@@ -1986,6 +2003,8 @@ std::string ArrayType::richIdentifier() const
 		else
 			id += length().str();
 	}
+	if (m_hasShieldedStorageMarker)
+		id += "_shielded_storage_marker";
 	id += identifierLocationSuffix();
 
 	return id;
@@ -2004,6 +2023,7 @@ bool ArrayType::operator==(ArrayType const& _other) const
 		!equals(_other) ||
 		_other.isByteArray() != isByteArray() ||
 		_other.isString() != isString() ||
+		_other.m_hasShieldedStorageMarker != m_hasShieldedStorageMarker ||
 		_other.isDynamicallySized() != isDynamicallySized()
 	)
 		return false;
@@ -2226,7 +2246,11 @@ MemberList::MemberMap ArrayType::nativeMembers(ASTNode const*) const
 	MemberList::MemberMap members;
 	if (!isString())
 	{
-		if (isDynamicallySized() && containsShieldedType())
+		// The shielded-storage marker only preserves storage op selection for aliases like
+		// `bytes(sbytesStorageRef)`. It must not leak into the surface type of `bytes`, so
+		// members like `.length` keep their ordinary `uint256` type unless the array itself is
+		// genuinely shielded.
+		if (isDynamicallySized() && CompositeType::containsShieldedType())
 			members.emplace_back("length", TypeProvider::shieldedUint256());
 		else
 			members.emplace_back("length", TypeProvider::uint256());
@@ -2347,6 +2371,8 @@ std::unique_ptr<ReferenceType> ArrayType::copyForLocation(DataLocation _location
 	copy->m_baseType = copy->copyForLocationIfReference(m_baseType);
 	copy->m_hasDynamicLength = m_hasDynamicLength;
 	copy->m_length = m_length;
+	copy->m_hasShieldedStorageMarker =
+		_location == DataLocation::Storage ? m_hasShieldedStorageMarker : false;
 	return copy;
 }
 

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -973,6 +973,11 @@ public:
 	/// Constructor for a shielded byte array ("sbytes").
 	ArrayType(DataLocation _location, ShieldedByteArrayTag);
 
+	/// Tag type for constructing byte-array/string references with the shielded-storage marker.
+	struct ShieldedStorageMarker {};
+	/// Constructor for a byte-array/string reference that preserves the shielded-storage marker.
+	ArrayType(ArrayType const& _other, ShieldedStorageMarker);
+
 	/// Constructor for a dynamically sized array type ("<type>[]")
 	ArrayType(DataLocation _location, Type const* _baseType):
 		ReferenceType(_location),
@@ -992,6 +997,7 @@ public:
 
 	BoolResult isImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	BoolResult isExplicitlyConvertibleTo(Type const& _convertTo) const override;
+	bool containsShieldedType() const override;
 	std::string richIdentifier() const override;
 	bool operator==(ArrayType const& _other) const;
 	bool operator==(Type const& _other) const override;
@@ -1025,6 +1031,14 @@ public:
 	/// @returns true if this is a string
 	bool isString() const { return m_arrayKind == ArrayKind::String; }
 	Type const* baseType() const { solAssert(!!m_baseType, ""); return m_baseType; }
+	bool hasShieldedStorageMarker() const { return m_hasShieldedStorageMarker; }
+	bool usesShieldedStorage() const
+	{
+		return
+			isByteArrayOrString() ?
+			baseType()->isShielded() || m_hasShieldedStorageMarker :
+			containsShieldedType();
+	}
 	Type const* finalBaseType(bool breakIfDynamicArrayType) const;
 	u256 const& length() const { return m_length; }
 	u256 memoryDataSize() const override;
@@ -1054,6 +1068,11 @@ private:
 	Type const* m_baseType;
 	bool m_hasDynamicLength = true;
 	u256 m_length;
+	/// Marks byte-array/string references that still point at shielded storage even though their
+	/// surface type is unshielded. This exists for casts like bytes(sbytesStorageRef): after the
+	/// cast the type is plain bytes, but the underlying slots are still private. Any storage access
+	/// through such a reference must therefore keep using shielded storage ops (cload/cstore).
+	bool m_hasShieldedStorageMarker = false;
 	mutable std::optional<TypeResult> m_interfaceType;
 	mutable std::optional<TypeResult> m_interfaceType_library;
 };

--- a/libsolidity/codegen/ABIFunctions.cpp
+++ b/libsolidity/codegen/ABIFunctions.cpp
@@ -724,7 +724,7 @@ std::string ABIFunctions::abiEncodingFunctionCompactStorageArray(
 			templ("lengthPaddedShort", _options.padded ? "0x20" : "length");
 			templ("lengthPaddedLong", _options.padded ? "i" : "length");
 			templ("arrayDataSlot", m_utils.arrayDataAreaFunction(_from));
-			templ("loadOpcode", _from.baseType()->isShielded() ? "cload" : "sload");
+			templ("loadOpcode", _from.usesShieldedStorage() ? "cload" : "sload");
 			return templ.render();
 		}
 		else

--- a/libsolidity/codegen/ArrayUtils.cpp
+++ b/libsolidity/codegen/ArrayUtils.cpp
@@ -443,7 +443,7 @@ void ArrayUtils::copyArrayToMemory(ArrayType const& _sourceType, bool _padToWord
 		// Special case for tightly-stored byte arrays
 		if (_sourceType.isByteArrayOrString())
 		{
-			auto const loadOp = _sourceType.containsShieldedType() ? Instruction::CLOAD : Instruction::SLOAD;
+			auto const loadOp = _sourceType.usesShieldedStorage() ? Instruction::CLOAD : Instruction::SLOAD;
 			// stack here: memory_offset storage_offset length
 			m_context << Instruction::DUP1 << u256(31) << Instruction::LT;
 			evmasm::AssemblyItem longByteArray = m_context.appendConditionalJump();
@@ -488,7 +488,7 @@ void ArrayUtils::copyArrayToMemory(ArrayType const& _sourceType, bool _padToWord
 		if (_sourceType.isByteArrayOrString())
 		{
 			// Packed both in storage and memory.
-			m_context << Instruction::DUP2 << (_sourceType.containsShieldedType() ? Instruction::CLOAD : Instruction::SLOAD);
+			m_context << Instruction::DUP2 << (_sourceType.usesShieldedStorage() ? Instruction::CLOAD : Instruction::SLOAD);
 			m_context << Instruction::DUP2 << Instruction::MSTORE;
 			// increment storage_data_offset by 1
 			m_context << Instruction::SWAP1 << u256(1) << Instruction::ADD;
@@ -1066,7 +1066,7 @@ void ArrayUtils::retrieveLength(ArrayType const& _arrayType, unsigned _stackDept
 			m_context << Instruction::MLOAD;
 			break;
 		case DataLocation::Storage:
-			if (_arrayType.containsShieldedType())
+			if (_arrayType.usesShieldedStorage())
 				m_context << Instruction::CLOAD;
 			else
 				m_context << Instruction::SLOAD;
@@ -1136,7 +1136,7 @@ void ArrayUtils::accessIndex(ArrayType const& _arrayType, bool _doBoundsCheck, b
 		{
 			// Special case of short byte arrays.
 			m_context << Instruction::SWAP1;
-			m_context << Instruction::DUP2 << (_arrayType.containsShieldedType() ? Instruction::CLOAD : Instruction::SLOAD);
+			m_context << Instruction::DUP2 << (_arrayType.usesShieldedStorage() ? Instruction::CLOAD : Instruction::SLOAD);
 			m_context << u256(1) << Instruction::AND << Instruction::ISZERO;
 			// No action needed for short byte arrays.
 			m_context.appendConditionalJumpTo(endTag);

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -67,6 +67,15 @@ using solidity::util::errinfo_comment;
 namespace
 {
 
+Type const& effectiveType(Expression const& _expression)
+{
+	if (auto const* identifier = dynamic_cast<Identifier const*>(&_expression))
+		if (auto const* variable = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration))
+			return *variable->annotation().type;
+
+	return *_expression.annotation().type;
+}
+
 /**
  * Simple helper class to ensure that the stack height is the same at certain places in the code.
  */
@@ -1541,7 +1550,7 @@ void ContractCompiler::compileExpression(Expression const& _expression, Type con
 	ExpressionCompiler expressionCompiler(m_context, m_optimiserSettings.runOrderLiterals);
 	expressionCompiler.compile(_expression);
 	if (_targetType)
-		CompilerUtils(m_context).convertType(*_expression.annotation().type, *_targetType);
+		CompilerUtils(m_context).convertType(effectiveType(_expression), *_targetType);
 }
 
 void ContractCompiler::popScopedVariables(ASTNode const* _node)

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -52,6 +52,29 @@ using namespace solidity::util;
 namespace
 {
 
+Type const& effectiveType(Expression const& _expression)
+{
+	if (auto const* identifier = dynamic_cast<Identifier const*>(&_expression))
+		if (auto const* variable = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration))
+			return *variable->annotation().type;
+
+	return *_expression.annotation().type;
+}
+
+FunctionTypePointer effectiveFunctionType(Expression const& _expression)
+{
+	if (auto const* functionType = dynamic_cast<FunctionType const*>(_expression.annotation().type))
+		if (
+			functionType->kind() == FunctionType::Kind::Internal &&
+			!functionType->hasBoundFirstArgument()
+		)
+			if (auto const* identifier = dynamic_cast<Identifier const*>(&_expression))
+				if (auto const* function = dynamic_cast<FunctionDefinition const*>(identifier->annotation().referencedDeclaration))
+					return function->functionType(true);
+
+	return dynamic_cast<FunctionType const*>(_expression.annotation().type);
+}
+
 Type const* closestType(Type const* _type, Type const* _targetType, bool _isShiftOp)
 {
 	if (_isShiftOp)
@@ -303,14 +326,12 @@ bool ExpressionCompiler::visit(Assignment const& _assignment)
 	CompilerContext::LocationSetter locationSetter(m_context, _assignment);
 	Token op = _assignment.assignmentOperator();
 	Token binOp = op == Token::Assign ? op : TokenTraits::AssignmentToBinaryOp(op);
-	Type const& leftType = *_assignment.leftHandSide().annotation().type;
+	Type const& leftType = effectiveType(_assignment.leftHandSide());
 	if (leftType.category() == Type::Category::Tuple)
 	{
 		solAssert(*_assignment.annotation().type == TupleType(), "");
 		solAssert(op == Token::Assign, "");
 	}
-	else
-		solAssert(*_assignment.annotation().type == leftType, "");
 	bool cleanupNeeded = false;
 	if (op != Token::Assign)
 		cleanupNeeded = cleanupNeededForOp(leftType.category(), binOp, m_context.arithmetic());
@@ -318,13 +339,13 @@ bool ExpressionCompiler::visit(Assignment const& _assignment)
 	// Perform some conversion already. This will convert storage types to memory and literals
 	// to their actual type, but will not convert e.g. memory to storage.
 	Type const* rightIntermediateType = closestType(
-		_assignment.rightHandSide().annotation().type,
-		_assignment.leftHandSide().annotation().type,
+		&effectiveType(_assignment.rightHandSide()),
+		&leftType,
 		op != Token::Assign && TokenTraits::isShiftOp(binOp)
 	);
 
 	solAssert(rightIntermediateType, "");
-	utils().convertType(*_assignment.rightHandSide().annotation().type, *rightIntermediateType, cleanupNeeded);
+	utils().convertType(effectiveType(_assignment.rightHandSide()), *rightIntermediateType, cleanupNeeded);
 
 	_assignment.leftHandSide().accept(*this);
 	solAssert(!!m_currentLValue, "LValue not retrieved.");
@@ -663,7 +684,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		functionType = structType.constructorType();
 	}
 	else
-		functionType = dynamic_cast<FunctionType const*>(_functionCall.expression().annotation().type);
+		functionType = effectiveFunctionType(_functionCall.expression());
 
 	TypePointers parameterTypes = functionType->parameterTypes();
 
@@ -1166,6 +1187,8 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				solAssert(paramType, "");
 
 				ArrayType const* arrayType = dynamic_cast<ArrayType const*>(function.selfType());
+				if (auto const* memberAccess = dynamic_cast<MemberAccess const*>(&_functionCall.expression()))
+					arrayType = dynamic_cast<ArrayType const*>(&effectiveType(memberAccess->expression()));
 				solAssert(arrayType, "");
 
 				// stack: ArrayReference
@@ -1187,6 +1210,8 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				solAssert(!!function.parameterTypes()[0], "");
 				Type const* paramType = function.parameterTypes()[0];
 				ArrayType const* arrayType = dynamic_cast<ArrayType const*>(function.selfType());
+				if (auto const* memberAccess = dynamic_cast<MemberAccess const*>(&_functionCall.expression()))
+					arrayType = dynamic_cast<ArrayType const*>(&effectiveType(memberAccess->expression()));
 				solAssert(arrayType, "");
 
 				// stack: ArrayReference
@@ -1226,6 +1251,8 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			solAssert(function.hasBoundFirstArgument(), "");
 			solAssert(function.parameterTypes().empty(), "");
 			ArrayType const* arrayType = dynamic_cast<ArrayType const*>(function.selfType());
+			if (auto const* memberAccess = dynamic_cast<MemberAccess const*>(&_functionCall.expression()))
+				arrayType = dynamic_cast<ArrayType const*>(&effectiveType(memberAccess->expression()));
 			solAssert(arrayType && arrayType->dataStoredIn(DataLocation::Storage), "");
 			ArrayUtils(m_context).popStorageArrayElement(*arrayType);
 			break;
@@ -2211,7 +2238,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 	}
 	case Type::Category::Array:
 	{
-		auto const& type = dynamic_cast<ArrayType const&>(*_memberAccess.expression().annotation().type);
+		auto const& type = dynamic_cast<ArrayType const&>(effectiveType(_memberAccess.expression()));
 		if (member == "length")
 		{
 			if (!type.isDynamicallySized())
@@ -2306,7 +2333,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 	CompilerContext::LocationSetter locationSetter(m_context, _indexAccess);
 	_indexAccess.baseExpression().accept(*this);
 
-	Type const& baseType = *_indexAccess.baseExpression().annotation().type;
+	Type const& baseType = effectiveType(_indexAccess.baseExpression());
 
 	switch (baseType.category())
 	{
@@ -3183,7 +3210,7 @@ bool ExpressionCompiler::cleanupNeededForOp(Type::Category _type, Token _op, Ari
 void ExpressionCompiler::acceptAndConvert(Expression const& _expression, Type const& _type, bool _cleanupNeeded)
 {
 	_expression.accept(*this);
-	utils().convertType(*_expression.annotation().type, _type, _cleanupNeeded);
+	utils().convertType(effectiveType(_expression), _type, _cleanupNeeded);
 }
 
 CompilerUtils ExpressionCompiler::utils()

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -54,6 +54,38 @@ std::optional<size_t> staticEncodingSize(std::vector<Type const*> const& _parame
 	return encodedSize;
 }
 
+std::string storageOpsIdentifierSuffix(bool _useShieldedStorageOps)
+{
+	return _useShieldedStorageOps ? "_shielded_storage_ops" : "";
+}
+
+bool isShieldedStorageAlias(ArrayType const& _type)
+{
+	return _type.isByteArrayOrString() && _type.hasShieldedStorageMarker();
+}
+
+std::string storageLoadOpcode(
+	Type const& _type,
+	VariableDeclaration::Location _location,
+	bool _useShieldedStorageOps
+)
+{
+	if (_location == VariableDeclaration::Location::Transient)
+		return "tload";
+	return (_useShieldedStorageOps || _type.isShielded()) ? "cload" : "sload";
+}
+
+std::string storageStoreOpcode(
+	Type const& _type,
+	VariableDeclaration::Location _location,
+	bool _useShieldedStorageOps
+)
+{
+	if (_location == VariableDeclaration::Location::Transient)
+		return "tstore";
+	return (_useShieldedStorageOps || _type.isShielded()) ? "cstore" : "sstore";
+}
+
 }
 
 std::string YulUtilFunctions::identityFunction()
@@ -1320,7 +1352,7 @@ std::string YulUtilFunctions::arrayLengthFunction(ArrayType const& _type)
 		)");
 		w("functionName", functionName);
 		w("dynamic", _type.isDynamicallySized());
-		w("loadOpcode", _type.isDynamicallySized() && _type.containsShieldedType() ? "cload" : "sload");
+		w("loadOpcode", _type.isDynamicallySized() && _type.usesShieldedStorage() ? "cload" : "sload");
 		if (!_type.isDynamicallySized()) w("length", toCompactHexWithPrefix(_type.length()));
 		w("memory", _type.location() == DataLocation::Memory);
 		w("storage", _type.location() == DataLocation::Storage);
@@ -1430,7 +1462,7 @@ std::string YulUtilFunctions::cleanUpStorageArrayEndFunction(ArrayType const& _t
 		("convertToSize", arrayConvertLengthToSize(_type))
 		("dataPosition", arrayDataAreaFunction(_type))
 		("clearStorageRange", clearStorageRangeFunction(
-			_type.baseType()->isShielded() ? *TypeProvider::shieldedUint256() : *_type.baseType()
+			_type.usesShieldedStorage() ? *TypeProvider::shieldedUint256() : *_type.baseType()
 		))
 		("packed", _type.baseType()->storageBytes() <= 16)
 		("itemsPerSlot", std::to_string(32 / _type.baseType()->storageBytes()))
@@ -1445,7 +1477,7 @@ std::string YulUtilFunctions::resizeDynamicByteArrayFunction(ArrayType const& _t
 	std::string functionName = "resize_array_" + _type.identifier();
 	return m_functionCollector.createFunction(functionName, [&](std::vector<std::string>& _args, std::vector<std::string>&) {
 		solAssert(
-			!_type.baseType()->isShielded() || m_evmVersion.supportShieldedStorage(),
+			!_type.usesShieldedStorage() || m_evmVersion.supportShieldedStorage(),
 			"Shielded storage types require Mercury EVM version. This should have been caught by type checker."
 		);
 		_args = {"array", "newLen"};
@@ -1462,7 +1494,7 @@ std::string YulUtilFunctions::resizeDynamicByteArrayFunction(ArrayType const& _t
 			}
 		)")
 		("extractLength", extractByteArrayLengthFunction())
-		("loadOpcode", _type.baseType()->isShielded() ? "cload" : "sload")
+		("loadOpcode", _type.usesShieldedStorage() ? "cload" : "sload")
 		("decreaseSize", decreaseByteArraySizeFunction(_type))
 		("increaseSize", increaseByteArraySizeFunction(_type))
 		.render();
@@ -1489,7 +1521,7 @@ std::string YulUtilFunctions::cleanUpDynamicByteArrayEndSlotsFunction(ArrayType 
 		("dataLocation", arrayDataAreaFunction(_type))
 		("div32Ceil", divide32CeilFunction())
 		("clearStorageRange", clearStorageRangeFunction(
-			_type.baseType()->isShielded() ? *TypeProvider::shieldedUint256() : *_type.baseType()
+			_type.usesShieldedStorage() ? *TypeProvider::shieldedUint256() : *_type.baseType()
 		))
 		.render();
 	});
@@ -1531,12 +1563,12 @@ std::string YulUtilFunctions::decreaseByteArraySizeFunction(ArrayType const& _ty
 			("dataPosition", arrayDataAreaFunction(_type))
 			("partialClearStorageSlot", partialClearStorageSlotFunction(_type))
 			("clearStorageRange", clearStorageRangeFunction(
-				_type.baseType()->isShielded() ? *TypeProvider::shieldedUint256() : *_type.baseType()
+				_type.usesShieldedStorage() ? *TypeProvider::shieldedUint256() : *_type.baseType()
 			))
 			("transitLongToShort", byteArrayTransitLongToShortFunction(_type))
 			("div32Ceil", divide32CeilFunction())
 			("encodeUsedSetLen", shortByteArrayEncodeUsedAreaSetLengthFunction())
-			("storeOpcode", _type.baseType()->isShielded() ? "cstore" : "sstore")
+			("storeOpcode", _type.usesShieldedStorage() ? "cstore" : "sstore")
 			.render();
 	});
 }
@@ -1572,7 +1604,7 @@ std::string YulUtilFunctions::increaseByteArraySizeFunction(ArrayType const& _ty
 		("maxArrayLength", (u256(1) << 64).str())
 		("dataPosition", arrayDataAreaFunction(_type))
 		("encodeUsedSetLen", shortByteArrayEncodeUsedAreaSetLengthFunction())
-		("storeOpcode", _type.baseType()->isShielded() ? "cstore" : "sstore")
+		("storeOpcode", _type.usesShieldedStorage() ? "cstore" : "sstore")
 		.render();
 	});
 }
@@ -1593,8 +1625,8 @@ std::string YulUtilFunctions::byteArrayTransitLongToShortFunction(ArrayType cons
 			("functionName", functionName)
 			("dataPosition", arrayDataAreaFunction(_type))
 			("extractUsedApplyLen", shortByteArrayEncodeUsedAreaSetLengthFunction())
-			("storeOpcode", _type.baseType()->isShielded() ? "cstore" : "sstore")
-			("loadOpcode", _type.baseType()->isShielded() ? "cload" : "sload")
+			("storeOpcode", _type.usesShieldedStorage() ? "cstore" : "sstore")
+			("loadOpcode", _type.usesShieldedStorage() ? "cload" : "sload")
 			.render();
 	});
 }
@@ -1709,9 +1741,13 @@ std::string YulUtilFunctions::storageByteArrayPopFunction(ArrayType const& _type
 			("transitLongToShort", byteArrayTransitLongToShortFunction(_type))
 			("encodeUsedSetLen", shortByteArrayEncodeUsedAreaSetLengthFunction())
 			("indexAccessNoChecks", longByteArrayStorageIndexAccessNoCheckFunction())
-			("storeOpcode", _type.baseType()->isShielded() ? "cstore" : "sstore")
-			("loadOpcode", _type.baseType()->isShielded() ? "cload" : "sload")
-			("setToZero", storageSetToZeroFunction(*_type.baseType(), VariableDeclaration::Location::Unspecified))
+			("storeOpcode", _type.usesShieldedStorage() ? "cstore" : "sstore")
+			("loadOpcode", _type.usesShieldedStorage() ? "cload" : "sload")
+			("setToZero", storageSetToZeroFunction(
+				*_type.baseType(),
+				VariableDeclaration::Location::Unspecified,
+				isShieldedStorageAlias(_type)
+			))
 			.render();
 	});
 }
@@ -1781,7 +1817,13 @@ std::string YulUtilFunctions::storageArrayPushFunction(ArrayType const& _type, T
 			("loadOpcode", _type.containsShieldedType() ? "cload" : "sload")
 			("isByteArrayOrString", _type.isByteArrayOrString())
 			("indexAccess", storageArrayIndexAccessFunction(_type))
-			("storeValue", updateStorageValueFunction(*_fromType, *_type.baseType(), VariableDeclaration::Location::Unspecified))
+			("storeValue", updateStorageValueFunction(
+				*_fromType,
+				*_type.baseType(),
+				VariableDeclaration::Location::Unspecified,
+				std::optional<unsigned>(),
+				isShieldedStorageAlias(_type)
+			))
 			("maxArrayLength", (u256(1) << 64).str())
 			("shl", shiftLeftFunctionDynamic())
 			.render();
@@ -2058,7 +2100,12 @@ std::string YulUtilFunctions::copyArrayToStorageFunction(ArrayType const& _fromT
 			0,
 			_fromType.baseType()->stackItems().size()
 		));
-		templ("updateStorageValue", updateStorageValueFunction(*_fromType.baseType(), *_toType.baseType(), VariableDeclaration::Location::Unspecified, 0));
+		templ("updateStorageValue", updateStorageValueFunction(
+			*_fromType.baseType(),
+			*_toType.baseType(),
+			VariableDeclaration::Location::Unspecified,
+			0
+		));
 		templ("srcStride",
 			fromCalldata ?
 			std::to_string(_fromType.calldataStride()) :
@@ -2142,10 +2189,10 @@ std::string YulUtilFunctions::copyByteArrayToStorageFunction(ArrayType const& _f
 			templ("srcDataLocation", arrayDataAreaFunction(_fromType));
 		templ("cleanUpEndArray", cleanUpDynamicByteArrayEndSlotsFunction(_toType));
 		templ("srcIncrement", std::to_string(fromStorage ? 1 : 0x20));
-		bool toIsShielded = _toType.baseType()->isShielded();
+		bool toIsShielded = _toType.usesShieldedStorage();
 		templ("storeOpcode", toIsShielded ? "cstore" : "sstore");
 		templ("loadOpcode", toIsShielded ? "cload" : "sload");
-		templ("read", fromStorage ? (_fromType.baseType()->isShielded() ? "cload" : "sload") : fromCalldata ? "calldataload" : "mload");
+		templ("read", fromStorage ? (_fromType.usesShieldedStorage() ? "cload" : "sload") : fromCalldata ? "calldataload" : "mload");
 		templ("maskBytes", maskBytesFunctionDynamic());
 		templ("byteArrayCombineShort", shortByteArrayEncodeUsedAreaSetLengthFunction());
 
@@ -2804,14 +2851,16 @@ std::string YulUtilFunctions::readFromStorage(
 	Type const& _type,
 	size_t _offset,
 	bool _splitFunctionTypes,
-	VariableDeclaration::Location _location
+	VariableDeclaration::Location _location,
+	bool _useShieldedStorageOps
 )
 {
 	if (_type.isValueType())
-		return readFromStorageValueType(_type, _offset, _splitFunctionTypes, _location);
+		return readFromStorageValueType(_type, _offset, _splitFunctionTypes, _location, _useShieldedStorageOps);
 	else
 	{
 		solAssert(_location != VariableDeclaration::Location::Transient);
+		solAssert(!_useShieldedStorageOps, "Shielded storage ops override is only supported for value types.");
 		solAssert(_offset == 0, "");
 		return readFromStorageReferenceType(_type);
 	}
@@ -2820,13 +2869,15 @@ std::string YulUtilFunctions::readFromStorage(
 std::string YulUtilFunctions::readFromStorageDynamic(
 	Type const& _type,
 	bool _splitFunctionTypes,
-	VariableDeclaration::Location _location
+	VariableDeclaration::Location _location,
+	bool _useShieldedStorageOps
 )
 {
 	if (_type.isValueType())
-		return readFromStorageValueType(_type, {}, _splitFunctionTypes, _location);
+		return readFromStorageValueType(_type, {}, _splitFunctionTypes, _location, _useShieldedStorageOps);
 
 	solAssert(_location != VariableDeclaration::Location::Transient);
+	solAssert(!_useShieldedStorageOps, "Shielded storage ops override is only supported for value types.");
 	std::string functionName =
 		"read_from_storage__dynamic_" +
 		std::string(_splitFunctionTypes ? "split_" : "") +
@@ -2850,7 +2901,8 @@ std::string YulUtilFunctions::readFromStorageValueType(
 	Type const& _type,
 	std::optional<size_t> _offset,
 	bool _splitFunctionTypes,
-	VariableDeclaration::Location _location
+	VariableDeclaration::Location _location,
+	bool _useShieldedStorageOps
 )
 {
 	solAssert(_type.isValueType(), "");
@@ -2858,6 +2910,10 @@ std::string YulUtilFunctions::readFromStorageValueType(
 		_location == VariableDeclaration::Location::Transient ||
 		_location == VariableDeclaration::Location::Unspecified,
 		"Variable location can only be transient or plain storage"
+	);
+	solAssert(
+		!(_location == VariableDeclaration::Location::Transient && _useShieldedStorageOps),
+		"Transient storage cannot use shielded storage op overrides."
 	);
 
 	std::string functionName =
@@ -2870,10 +2926,11 @@ std::string YulUtilFunctions::readFromStorageValueType(
 			"dynamic"
 		) +
 		"_" +
-		_type.identifier();
+		_type.identifier() +
+		storageOpsIdentifierSuffix(_useShieldedStorageOps);
 
 	return m_functionCollector.createFunction(functionName, [&] {
-		if (_type.isShielded() && !m_evmVersion.supportShieldedStorage())
+		if ((_type.isShielded() || _useShieldedStorageOps) && !m_evmVersion.supportShieldedStorage())
 		{
 			solAssert(false,
 				"Shielded storage types require Mercury EVM version. "
@@ -2890,8 +2947,7 @@ std::string YulUtilFunctions::readFromStorageValueType(
 		)");
 		templ("functionName", functionName);
 		templ("dynamic", !_offset.has_value());
-		templ("loadOpcode",
- 			_location == VariableDeclaration::Location::Transient ? "tload"  : (_type.isShielded() ? "cload" : "sload"));
+		templ("loadOpcode", storageLoadOpcode(_type, _location, _useShieldedStorageOps));
 		if (_offset.has_value())
 			templ("extract", extractFromStorageValue(_type, *_offset));
 		else
@@ -2972,13 +3028,18 @@ std::string YulUtilFunctions::updateStorageValueFunction(
 	Type const& _fromType,
 	Type const& _toType,
 	VariableDeclaration::Location _location,
-	std::optional<unsigned> const& _offset
+	std::optional<unsigned> const& _offset,
+	bool _useShieldedStorageOps
 )
 {
 	solAssert(
 		_location == VariableDeclaration::Location::Transient ||
 		_location == VariableDeclaration::Location::Unspecified,
 		"Variable location can only be transient or plain storage"
+	);
+	solAssert(
+		!(_location == VariableDeclaration::Location::Transient && _useShieldedStorageOps),
+		"Transient storage cannot use shielded storage op overrides."
 	);
 
 	std::string const functionName =
@@ -2988,7 +3049,8 @@ std::string YulUtilFunctions::updateStorageValueFunction(
 		(_offset.has_value() ? ("offset_" + std::to_string(*_offset)) + "_" : "") +
 		_fromType.identifier() +
 		"_to_" +
-		_toType.identifier();
+		_toType.identifier() +
+		storageOpsIdentifierSuffix(_useShieldedStorageOps);
 
 	return m_functionCollector.createFunction(functionName, [&] {
 		if (_toType.isValueType())
@@ -3019,15 +3081,14 @@ std::string YulUtilFunctions::updateStorageValueFunction(
 			("convert", conversionFunction(_fromType, _toType))
 			("fromValues", suffixedVariableNameList("value_", 0, _fromType.sizeOnStack()))
 			("toValues", suffixedVariableNameList("convertedValue_", 0, _toType.sizeOnStack()))
-			("storeOpcode",
-			_location == VariableDeclaration::Location::Transient ? "tstore" : (_toType.isShielded() ? "cstore" : "sstore"))
-			("loadOpcode",
-			_location == VariableDeclaration::Location::Transient ? "tload"  : (_toType.isShielded() ? "cload" : "sload"))
+			("storeOpcode", storageStoreOpcode(_toType, _location, _useShieldedStorageOps))
+			("loadOpcode", storageLoadOpcode(_toType, _location, _useShieldedStorageOps))
 			("prepare", prepareStoreFunction(_toType))
 			.render();
 		}
 
 		solAssert(_location != VariableDeclaration::Location::Transient);
+		solAssert(!_useShieldedStorageOps, "Shielded storage ops override is only supported for value types.");
 		auto const* toReferenceType = dynamic_cast<ReferenceType const*>(&_toType);
 		auto const* fromReferenceType = dynamic_cast<ReferenceType const*>(&_fromType);
 		solAssert(toReferenceType, "");
@@ -4500,7 +4561,11 @@ std::string YulUtilFunctions::zeroValueFunction(Type const& _type, bool _splitFu
 	});
 }
 
-std::string YulUtilFunctions::storageSetToZeroFunction(Type const& _type, VariableDeclaration::Location _location)
+std::string YulUtilFunctions::storageSetToZeroFunction(
+	Type const& _type,
+	VariableDeclaration::Location _location,
+	bool _useShieldedStorageOps
+)
 {
 	// SEISMIC: Cherry-picked fix for TransientStorageClearingHelperCollision (SOL-2026-1)
 	// from upstream commit 12ede4f26 (Solidity 0.8.34).
@@ -4516,17 +4581,24 @@ std::string YulUtilFunctions::storageSetToZeroFunction(Type const& _type, Variab
 		_location == VariableDeclaration::Location::Unspecified,
 		"Invalid location for the storage_set_to_zero function"
 	);
+	solAssert(
+		!(_location == VariableDeclaration::Location::Transient && _useShieldedStorageOps),
+		"Transient storage cannot use shielded storage op overrides."
+	);
 
 	if (dynamic_cast<ReferenceType const*>(&_type))
 		solAssert(
 			_location == VariableDeclaration::Location::Unspecified &&
 			_type.dataStoredIn(DataLocation::Storage)
 		);
+	if (!_type.isValueType())
+		solAssert(!_useShieldedStorageOps, "Shielded storage ops override is only supported for value types.");
 
 	std::string const functionName =
 		(_location == VariableDeclaration::Location::Transient ? "transient_"s : "") +
 		"storage_set_to_zero_" +
-		_type.identifier();
+		_type.identifier() +
+		storageOpsIdentifierSuffix(_useShieldedStorageOps);
 
 	return m_functionCollector.createFunction(functionName, [&]() {
 		if (_type.isValueType())
@@ -4537,7 +4609,7 @@ std::string YulUtilFunctions::storageSetToZeroFunction(Type const& _type, Variab
 				}
 			)")
 			("functionName", functionName)
-			("store", updateStorageValueFunction(_type, _type, _location))
+			("store", updateStorageValueFunction(_type, _type, _location, std::optional<unsigned>(), _useShieldedStorageOps))
 			("values", suffixedVariableNameList("zero_", 0, _type.sizeOnStack()))
 			("zeroValue", zeroValueFunction(_type))
 			.render();

--- a/libsolidity/codegen/YulUtilFunctions.h
+++ b/libsolidity/codegen/YulUtilFunctions.h
@@ -352,16 +352,21 @@ public:
 	/// @returns a function that reads a type from storage.
 	/// @param _splitFunctionTypes if false, returns the address and function signature in a
 	/// single variable.
+	/// @param _useShieldedStorageOps force cload/cstore-style access even for unshielded value
+	/// types. This is used for values reached through aliases like bytes(sbytesRef)[i], where the
+	/// element type is bytes1 but the underlying storage is still shielded.
 	std::string readFromStorage(
 		Type const& _type,
 		size_t _offset,
 		bool _splitFunctionTypes,
-		VariableDeclaration::Location _location
+		VariableDeclaration::Location _location,
+		bool _useShieldedStorageOps = false
 	);
 	std::string readFromStorageDynamic(
 		Type const& _type,
 		bool _splitFunctionTypes,
-		VariableDeclaration::Location _location
+		VariableDeclaration::Location _location,
+		bool _useShieldedStorageOps = false
 	);
 
 	/// @returns a function that reads a value type from memory. Performs cleanup.
@@ -384,12 +389,14 @@ public:
 	/// the specified slot and offset. If offset is not given, it is expected as
 	/// runtime parameter.
 	/// For reference types, offset is checked to be zero at runtime.
+	/// `_useShieldedStorageOps` has the same meaning as in readFromStorage().
 	/// signature: (slot, [offset,] value)
 	std::string updateStorageValueFunction(
 		Type const& _fromType,
 		Type const& _toType,
 		VariableDeclaration::Location _location,
-		std::optional<unsigned> const& _offset = std::optional<unsigned>()
+		std::optional<unsigned> const& _offset = std::optional<unsigned>(),
+		bool _useShieldedStorageOps = false
 	);
 
 	/// Returns the name of a function that will write the given value to
@@ -509,7 +516,12 @@ public:
 	/// @returns the name of a function that will set the given storage item to
 	/// zero
 	/// signature: (slot, offset) ->
-	std::string storageSetToZeroFunction(Type const& _type, VariableDeclaration::Location _location);
+	/// `_useShieldedStorageOps` has the same meaning as in readFromStorage().
+	std::string storageSetToZeroFunction(
+		Type const& _type,
+		VariableDeclaration::Location _location,
+		bool _useShieldedStorageOps = false
+	);
 
 	/// If revertStrings is debug, @returns the name of a function that
 	/// stores @param _message in memory position 0 and reverts.
@@ -591,7 +603,8 @@ private:
 		Type const& _type,
 		std::optional<size_t> _offset,
 		bool _splitFunctionTypes,
-		VariableDeclaration::Location _location
+		VariableDeclaration::Location _location,
+		bool _useShieldedStorageOps = false
 	);
 	/// @returns a function that reads a reference type from storage to memory (performing a deep copy).
 	std::string readFromStorageReferenceType(Type const& _type);

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -59,6 +59,29 @@ using namespace std::string_literals;
 namespace
 {
 
+Type const& effectiveType(Expression const& _expression)
+{
+	if (auto const* identifier = dynamic_cast<Identifier const*>(&_expression))
+		if (auto const* variable = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration))
+			return *variable->annotation().type;
+
+	return *_expression.annotation().type;
+}
+
+FunctionTypePointer effectiveFunctionType(Expression const& _expression)
+{
+	if (auto const* functionType = dynamic_cast<FunctionType const*>(_expression.annotation().type))
+		if (
+			functionType->kind() == FunctionType::Kind::Internal &&
+			!functionType->hasBoundFirstArgument()
+		)
+			if (auto const* identifier = dynamic_cast<Identifier const*>(&_expression))
+				if (auto const* function = dynamic_cast<FunctionDefinition const*>(identifier->annotation().referencedDeclaration))
+					return function->functionType(true);
+
+	return dynamic_cast<FunctionType const*>(_expression.annotation().type);
+}
+
 struct CopyTranslate: public yul::ASTCopier
 {
 	using ExternalRefsMap = std::map<yul::Identifier const*, InlineAssemblyAnnotation::ExternalIdentifierInfo>;
@@ -277,6 +300,7 @@ void IRGeneratorForStatements::initializeStateVar(VariableDeclaration const& _va
 			IRLValue{*_varDecl.annotation().type, IRLValue::Immutable{&_varDecl}} :
 			IRLValue{*_varDecl.annotation().type, IRLValue::Storage{
 				toCompactHexWithPrefix(m_context.storageLocationOfStateVariable(_varDecl).first),
+				false,
 				m_context.storageLocationOfStateVariable(_varDecl).second
 			}},
 			*_varDecl.value()
@@ -441,12 +465,12 @@ bool IRGeneratorForStatements::visit(Assignment const& _assignment)
 		TokenTraits::AssignmentToBinaryOp(assignmentOperator);
 
 	if (TokenTraits::isShiftOp(binaryOperator))
-		solAssert(type(_assignment.rightHandSide()).mobileType());
+		solAssert(effectiveType(_assignment.rightHandSide()).mobileType());
 	IRVariable value =
-		type(_assignment.leftHandSide()).isValueType() ?
+		effectiveType(_assignment.leftHandSide()).isValueType() ?
 		convert(
 			_assignment.rightHandSide(),
-			TokenTraits::isShiftOp(binaryOperator) ? *type(_assignment.rightHandSide()).mobileType() : type(_assignment)
+			TokenTraits::isShiftOp(binaryOperator) ? *effectiveType(_assignment.rightHandSide()).mobileType() : effectiveType(_assignment.leftHandSide())
 		) :
 		_assignment.rightHandSide();
 
@@ -457,17 +481,16 @@ bool IRGeneratorForStatements::visit(Assignment const& _assignment)
 
 	if (assignmentOperator != Token::Assign)
 	{
-		solAssert(type(_assignment.leftHandSide()).isValueType(), "Compound operators only available for value types.");
+		solAssert(effectiveType(_assignment.leftHandSide()).isValueType(), "Compound operators only available for value types.");
 		solAssert(binaryOperator != Token::Exp);
-		solAssert(type(_assignment) == type(_assignment.leftHandSide()));
 
 		IRVariable leftIntermediate = readFromLValue(*m_currentLValue);
-		solAssert(type(_assignment) == leftIntermediate.type());
+		solAssert(effectiveType(_assignment.leftHandSide()) == leftIntermediate.type());
 
 		define(_assignment) << (
 			TokenTraits::isShiftOp(binaryOperator) ?
 			shiftOperation(binaryOperator, leftIntermediate, value) :
-			binaryOperation(binaryOperator, type(_assignment), leftIntermediate.name(), value.name())
+			binaryOperation(binaryOperator, effectiveType(_assignment.leftHandSide()), leftIntermediate.name(), value.name())
 		) << "\n";
 
 		writeToLValue(*m_currentLValue, IRVariable(_assignment));
@@ -716,7 +739,11 @@ bool IRGeneratorForStatements::visit(UnaryOperation const& _unaryOperation)
 			util::GenericVisitor{
 				[&](IRLValue::Storage const& _storage) {
 					appendCode() <<
-						m_utils.storageSetToZeroFunction(m_currentLValue->type, VariableDeclaration::Location::Unspecified) <<
+						m_utils.storageSetToZeroFunction(
+							m_currentLValue->type,
+							VariableDeclaration::Location::Unspecified,
+							_storage.usesShieldedStorage
+						) <<
 						"(" <<
 						_storage.slot <<
 						", " <<
@@ -978,7 +1005,7 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		functionType = structType.constructorType();
 	}
 	else
-		functionType = dynamic_cast<FunctionType const*>(_functionCall.expression().annotation().type);
+		functionType = effectiveFunctionType(_functionCall.expression());
 
 	TypePointers parameterTypes = functionType->parameterTypes();
 
@@ -1431,6 +1458,8 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		solAssert(functionType->hasBoundFirstArgument());
 		solAssert(functionType->parameterTypes().empty());
 		ArrayType const* arrayType = dynamic_cast<ArrayType const*>(functionType->selfType());
+		if (auto const* memberAccess = dynamic_cast<MemberAccess const*>(&_functionCall.expression()))
+			arrayType = dynamic_cast<ArrayType const*>(&effectiveType(memberAccess->expression()));
 		solAssert(arrayType);
 		define(_functionCall) <<
 			m_utils.storageArrayPopFunction(*arrayType) <<
@@ -1442,6 +1471,8 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 	case FunctionType::Kind::ArrayPush:
 	{
 		ArrayType const* arrayType = dynamic_cast<ArrayType const*>(functionType->selfType());
+		if (auto const* memberAccess = dynamic_cast<MemberAccess const*>(&_functionCall.expression()))
+			arrayType = dynamic_cast<ArrayType const*>(&effectiveType(memberAccess->expression()));
 		solAssert(arrayType);
 
 		if (arguments.empty())
@@ -1455,6 +1486,7 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 				*arrayType->baseType(),
 				IRLValue::Storage{
 					slotName,
+					arrayType->usesShieldedStorage(),
 					offsetName,
 				}
 			});
@@ -2339,7 +2371,7 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 				("add(" + expression.part("slot").name() + ", " + offsets.first.str() + ")\n");
 			setLValue(_memberAccess, IRLValue{
 				type(_memberAccess),
-				IRLValue::Storage{slot, offsets.second}
+				IRLValue::Storage{slot, false, offsets.second}
 			});
 			break;
 		}
@@ -2393,7 +2425,7 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 	}
 	case Type::Category::Array:
 	{
-		auto const& type = dynamic_cast<ArrayType const&>(*_memberAccess.expression().annotation().type);
+		auto const& type = dynamic_cast<ArrayType const&>(effectiveType(_memberAccess.expression()));
 		if (member == "length")
 		{
 			// shortcut for <address>.code.length
@@ -2592,7 +2624,7 @@ bool IRGeneratorForStatements::visit(InlineAssembly const& _inlineAsm)
 void IRGeneratorForStatements::endVisit(IndexAccess const& _indexAccess)
 {
 	setLocation(_indexAccess);
-	Type const& baseType = *_indexAccess.baseExpression().annotation().type;
+	Type const& baseType = effectiveType(_indexAccess.baseExpression());
 
 	if (baseType.category() == Type::Category::Mapping)
 	{
@@ -2612,6 +2644,7 @@ void IRGeneratorForStatements::endVisit(IndexAccess const& _indexAccess)
 			*_indexAccess.annotation().type,
 			IRLValue::Storage{
 				slot,
+				false,
 				0u
 			}
 		});
@@ -2647,7 +2680,7 @@ void IRGeneratorForStatements::endVisit(IndexAccess const& _indexAccess)
 
 				setLValue(_indexAccess, IRLValue{
 					*_indexAccess.annotation().type,
-					IRLValue::Storage{slot, offset}
+					IRLValue::Storage{slot, arrayType.usesShieldedStorage(), offset}
 				});
 
 				break;
@@ -2893,6 +2926,7 @@ void IRGeneratorForStatements::handleVariableReference(
 			*_variable.annotation().type,
 			IRLValue::TransientStorage{
 				toCompactHexWithPrefix(m_context.storageLocationOfStateVariable(_variable).first),
+				false,
 				m_context.storageLocationOfStateVariable(_variable).second
 			}
 		});
@@ -2903,6 +2937,7 @@ void IRGeneratorForStatements::handleVariableReference(
 			*_variable.annotation().type,
 			IRLValue::Storage{
 				toCompactHexWithPrefix(m_context.storageLocationOfStateVariable(_variable).first),
+				false,
 				m_context.storageLocationOfStateVariable(_variable).second
 			}
 		});
@@ -3436,7 +3471,13 @@ void IRGeneratorForStatements::writeToLValue(IRLValue const& _lvalue, IRVariable
 				}, _storage.offset);
 
 				appendCode() <<
-					m_utils.updateStorageValueFunction(_value.type(), _lvalue.type, VariableDeclaration::Location::Unspecified, offsetStatic) <<
+					m_utils.updateStorageValueFunction(
+						_value.type(),
+						_lvalue.type,
+						VariableDeclaration::Location::Unspecified,
+						offsetStatic,
+						_storage.usesShieldedStorage
+					) <<
 					"(" <<
 					_storage.slot <<
 					offsetArgument <<
@@ -3542,7 +3583,12 @@ IRVariable IRGeneratorForStatements::readFromLValue(IRLValue const& _lvalue)
 				define(result) << _storage.slot << "\n";
 			else if (std::holds_alternative<std::string>(_storage.offset))
 				define(result) <<
-					m_utils.readFromStorageDynamic(_lvalue.type, true, VariableDeclaration::Location::Unspecified) <<
+					m_utils.readFromStorageDynamic(
+						_lvalue.type,
+						true,
+						VariableDeclaration::Location::Unspecified,
+						_storage.usesShieldedStorage
+					) <<
 					"(" <<
 					_storage.slot <<
 					", " <<
@@ -3550,7 +3596,13 @@ IRVariable IRGeneratorForStatements::readFromLValue(IRLValue const& _lvalue)
 					")\n";
 			else
 				define(result) <<
-					m_utils.readFromStorage(_lvalue.type, std::get<unsigned>(_storage.offset), true, VariableDeclaration::Location::Unspecified) <<
+					m_utils.readFromStorage(
+						_lvalue.type,
+						std::get<unsigned>(_storage.offset),
+						true,
+						VariableDeclaration::Location::Unspecified,
+						_storage.usesShieldedStorage
+					) <<
 					"(" <<
 					_storage.slot <<
 					")\n";

--- a/libsolidity/codegen/ir/IRLValue.h
+++ b/libsolidity/codegen/ir/IRLValue.h
@@ -43,6 +43,9 @@ struct IRLValue
 	struct GenericStorage
 	{
 		std::string const slot;
+		/// Some unshielded value types (for example bytes1 reached through bytes(sbytesRef)[i])
+		/// still have to use cload/cstore because the containing storage they point at is shielded.
+		bool usesShieldedStorage = false;
 		/// unsigned: Used when the offset is known at compile time, uses optimized
 		///           functions
 		/// string: Used when the offset is determined at run time

--- a/libsolidity/codegen/ir/IRVariable.cpp
+++ b/libsolidity/codegen/ir/IRVariable.cpp
@@ -24,6 +24,20 @@ using namespace solidity;
 using namespace solidity::frontend;
 using namespace solidity::util;
 
+namespace
+{
+
+Type const& effectiveType(Expression const& _expression)
+{
+	if (auto const* identifier = dynamic_cast<Identifier const*>(&_expression))
+		if (auto const* variable = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration))
+			return *variable->annotation().type;
+
+	return *_expression.annotation().type;
+}
+
+}
+
 IRVariable::IRVariable(std::string _baseName, Type const& _type):
 	m_baseName(std::move(_baseName)), m_type(_type)
 {
@@ -36,7 +50,7 @@ IRVariable::IRVariable(VariableDeclaration const& _declaration):
 }
 
 IRVariable::IRVariable(Expression const& _expression):
-	IRVariable(IRNames::localVariable(_expression), *_expression.annotation().type)
+	IRVariable(IRNames::localVariable(_expression), effectiveType(_expression))
 {
 }
 

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -296,6 +296,25 @@ Json generateStandardJson(bool _viaIr, Json const& _debugInfoSelection, Json con
 	return result;
 }
 
+std::string const shieldedAliasPushSource = R"(
+	pragma solidity >=0.0;
+	contract C {
+		sbytes plain;
+		function pushAlias() external {
+			bytes storage v = bytes(plain);
+			v.push(bytes1(0x42));
+		}
+		function setAlias(uint256 i, bytes1 value) external {
+			bytes storage v = bytes(plain);
+			v[i] = value;
+		}
+		function getAlias(uint256 i) external view returns (bytes1) {
+			bytes storage v = bytes(plain);
+			return v[i];
+		}
+	}
+)";
+
 } // end anonymous namespace
 
 BOOST_AUTO_TEST_SUITE(StandardCompiler)
@@ -1868,6 +1887,55 @@ BOOST_AUTO_TEST_CASE(dependency_tracking_of_abstract_contract_yul)
 
 	BOOST_REQUIRE(result["sources"].is_object());
 	BOOST_REQUIRE(result["sources"].size() == 1);
+}
+
+BOOST_AUTO_TEST_CASE(shielded_storage_alias_legacy_uses_shielded_ops, *boost::unit_test::precondition(solidity::test::minEVMVersionCheck(langutil::EVMVersion::mercury())))
+{
+	Json input = generateStandardJson(
+		false,
+		{},
+		Json::array({"evm.assembly"}),
+		SolidityCode({{"A.sol", shieldedAliasPushSource}})
+	);
+	input["settings"]["evmVersion"] = "mercury";
+
+	Json result = compile(util::jsonCompactPrint(input));
+	BOOST_REQUIRE(containsAtMostWarnings(result));
+
+	Json contract = getContractResult(result, "A.sol", "C");
+	BOOST_REQUIRE(contract.is_object());
+	BOOST_REQUIRE(contract["evm"]["assembly"].is_string());
+
+	std::string const& assembly = contract["evm"]["assembly"].get<std::string>();
+	BOOST_REQUIRE(assembly.find("cload") != std::string::npos);
+	BOOST_REQUIRE(assembly.find("cstore") != std::string::npos);
+	BOOST_REQUIRE(assembly.find("sstore") == std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(shielded_storage_alias_via_ir_uses_shielded_ops, *boost::unit_test::precondition(solidity::test::minEVMVersionCheck(langutil::EVMVersion::mercury())))
+{
+	Json input = generateStandardJson(
+		true,
+		{},
+		Json::array({"ir"}),
+		SolidityCode({{"A.sol", shieldedAliasPushSource}})
+	);
+	input["settings"]["evmVersion"] = "mercury";
+	input["settings"]["unsafeViaIR"] = true;
+
+	Json result = compile(util::jsonCompactPrint(input));
+	BOOST_REQUIRE(containsAtMostWarnings(result));
+
+	Json contract = getContractResult(result, "A.sol", "C");
+	BOOST_REQUIRE(contract.is_object());
+	BOOST_REQUIRE(contract["ir"].is_string());
+
+	std::string const& irCode = contract["ir"].get<std::string>();
+	BOOST_REQUIRE(irCode.find("array_push_from_t_bytes1_to_t_bytes_shielded_storage_marker_storage_ptr") != std::string::npos);
+	BOOST_REQUIRE(irCode.find("update_storage_value_t_bytes1_to_t_bytes1_shielded_storage_ops") != std::string::npos);
+	BOOST_REQUIRE(irCode.find("read_from_storage_split_dynamic_t_bytes1_shielded_storage_ops") != std::string::npos);
+	BOOST_REQUIRE(irCode.find("cload(") != std::string::npos);
+	BOOST_REQUIRE(irCode.find("cstore(") != std::string::npos);
 }
 
 BOOST_AUTO_TEST_CASE(source_location_of_bare_block)

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_saddress.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_saddress.sol
@@ -1,0 +1,51 @@
+// Test inline address(saddress) casts from all container types.
+contract C {
+    saddress private plain;
+    mapping(uint256 => saddress) m;
+    saddress[] arr;
+    struct S { saddress a; }
+    S private s;
+    mapping(uint256 => S) sm;
+
+    function store() public {
+        plain = saddress(address(0xBEEF));
+        m[0] = saddress(address(0xBEEF));
+        arr.push(saddress(address(0xBEEF)));
+        s.a = saddress(address(0xBEEF));
+        sm[0].a = saddress(address(0xBEEF));
+    }
+
+    // --- Plain ---
+    function plainInline() public view returns (address) { return address(plain); }
+    function plainTwoStep() public view returns (address) { saddress v = plain; return address(v); }
+
+    // --- Mapping ---
+    function mapInline() public view returns (address) { return address(m[0]); }
+    function mapInlineAssigned() public view returns (address) { address v = address(m[0]); return v; }
+    function mapTwoStep() public view returns (address) { saddress v = m[0]; return address(v); }
+
+    // --- Array ---
+    function arrInline() public view returns (address) { return address(arr[0]); }
+    function arrTwoStep() public view returns (address) { saddress v = arr[0]; return address(v); }
+
+    // --- Struct ---
+    function structInline() public view returns (address) { return address(s.a); }
+    function structTwoStep() public view returns (address) { saddress v = s.a; return address(v); }
+
+    // --- Mapping of struct ---
+    function mapStructInline() public view returns (address) { return address(sm[0].a); }
+    function mapStructTwoStep() public view returns (address) { saddress v = sm[0].a; return address(v); }
+}
+// ----
+// store() ->
+// plainTwoStep() -> 0xbeef
+// plainInline() -> 0xbeef
+// mapTwoStep() -> 0xbeef
+// mapInline() -> 0xbeef
+// mapInlineAssigned() -> 0xbeef
+// arrTwoStep() -> 0xbeef
+// arrInline() -> 0xbeef
+// structTwoStep() -> 0xbeef
+// structInline() -> 0xbeef
+// mapStructTwoStep() -> 0xbeef
+// mapStructInline() -> 0xbeef

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sbool.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sbool.sol
@@ -1,0 +1,51 @@
+// Test inline bool(sbool) casts from all container types.
+contract C {
+    sbool private plain;
+    mapping(uint256 => sbool) m;
+    sbool[] arr;
+    struct S { sbool b; }
+    S private s;
+    mapping(uint256 => S) sm;
+
+    function store() public {
+        plain = sbool(true);
+        m[0] = sbool(true);
+        arr.push(sbool(true));
+        s.b = sbool(true);
+        sm[0].b = sbool(true);
+    }
+
+    // --- Plain ---
+    function plainInline() public view returns (bool) { return bool(plain); }
+    function plainTwoStep() public view returns (bool) { sbool v = plain; return bool(v); }
+
+    // --- Mapping ---
+    function mapInline() public view returns (bool) { return bool(m[0]); }
+    function mapInlineAssigned() public view returns (bool) { bool v = bool(m[0]); return v; }
+    function mapTwoStep() public view returns (bool) { sbool v = m[0]; return bool(v); }
+
+    // --- Array ---
+    function arrInline() public view returns (bool) { return bool(arr[0]); }
+    function arrTwoStep() public view returns (bool) { sbool v = arr[0]; return bool(v); }
+
+    // --- Struct ---
+    function structInline() public view returns (bool) { return bool(s.b); }
+    function structTwoStep() public view returns (bool) { sbool v = s.b; return bool(v); }
+
+    // --- Mapping of struct ---
+    function mapStructInline() public view returns (bool) { return bool(sm[0].b); }
+    function mapStructTwoStep() public view returns (bool) { sbool v = sm[0].b; return bool(v); }
+}
+// ----
+// store() ->
+// plainTwoStep() -> true
+// plainInline() -> true
+// mapTwoStep() -> true
+// mapInline() -> true
+// mapInlineAssigned() -> true
+// arrTwoStep() -> true
+// arrInline() -> true
+// structTwoStep() -> true
+// structInline() -> true
+// mapStructTwoStep() -> true
+// mapStructInline() -> true

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic.sol
@@ -1,0 +1,101 @@
+// Test inline bytes(sbytes) casts for dynamic sbytes from all container types.
+// BUG: inline cast generates SLOAD instead of CLOAD, causing InvalidPrivateStorageAccess.
+// Two-step (assign to sbytes memory first) works correctly.
+contract C {
+    sbytes private plain;
+    mapping(uint256 => sbytes) m;
+    sbytes[] arr;
+    struct S { sbytes data; }
+    S private s;
+    mapping(uint256 => S) sm;
+    mapping(uint256 => mapping(uint256 => sbytes)) nested;
+
+    function storePlain() public {
+        plain.push(sbytes1(0x11));
+        plain.push(sbytes1(0x22));
+    }
+
+    function storeMap() public {
+        m[0].push(sbytes1(0xDE));
+        m[0].push(sbytes1(0xAD));
+        m[0].push(sbytes1(0xBE));
+        m[0].push(sbytes1(0xEF));
+    }
+
+    function storeArr() public {
+        arr.push();
+        arr[0].push(sbytes1(0xAA));
+        arr[0].push(sbytes1(0xBB));
+        arr[0].push(sbytes1(0xCC));
+    }
+
+    function storeStruct() public {
+        s.data.push(sbytes1(0xF0));
+        s.data.push(sbytes1(0x0D));
+    }
+
+    function storeMapStruct() public {
+        sm[0].data.push(sbytes1(0xCA));
+        sm[0].data.push(sbytes1(0xFE));
+    }
+
+    function storeNested() public {
+        nested[0][1].push(sbytes1(0xBE));
+        nested[0][1].push(sbytes1(0xEF));
+    }
+
+    // --- Plain ---
+    function plainInline() public view returns (bytes memory) { return bytes(plain); }
+    function plainTwoStep() public view returns (bytes memory) { sbytes memory v = plain; return bytes(v); }
+    function plainAliasStorageRead() public view returns (bytes memory) { bytes storage v = bytes(plain); return v; }
+
+    // --- Mapping ---
+    function mapInline() public view returns (bytes memory) { return bytes(m[0]); }
+    function mapTwoStep() public view returns (bytes memory) { sbytes memory v = m[0]; return bytes(v); }
+    function mapAliasStorageRead() public view returns (bytes memory) { bytes storage v = bytes(m[0]); return v; }
+
+    // --- Array ---
+    function arrInline() public view returns (bytes memory) { return bytes(arr[0]); }
+    function arrTwoStep() public view returns (bytes memory) { sbytes memory v = arr[0]; return bytes(v); }
+    function arrAliasStorageRead() public view returns (bytes memory) { bytes storage v = bytes(arr[0]); return v; }
+
+    // --- Struct ---
+    function structInline() public view returns (bytes memory) { return bytes(s.data); }
+    function structTwoStep() public view returns (bytes memory) { sbytes memory v = s.data; return bytes(v); }
+    function structAliasStorageRead() public view returns (bytes memory) { bytes storage v = bytes(s.data); return v; }
+
+    // --- Mapping of struct ---
+    function mapStructInline() public view returns (bytes memory) { return bytes(sm[0].data); }
+    function mapStructTwoStep() public view returns (bytes memory) { sbytes memory v = sm[0].data; return bytes(v); }
+    function mapStructAliasStorageRead() public view returns (bytes memory) { bytes storage v = bytes(sm[0].data); return v; }
+
+    // --- Nested mapping ---
+    function nestedInline() public view returns (bytes memory) { return bytes(nested[0][1]); }
+    function nestedTwoStep() public view returns (bytes memory) { sbytes memory v = nested[0][1]; return bytes(v); }
+    function nestedAliasStorageRead() public view returns (bytes memory) { bytes storage v = bytes(nested[0][1]); return v; }
+}
+// ----
+// storePlain() ->
+// plainTwoStep() -> 0x20, 2, left(0x1122)
+// plainInline() -> 0x20, 2, left(0x1122)
+// plainAliasStorageRead() -> 0x20, 2, left(0x1122)
+// storeMap() ->
+// mapTwoStep() -> 0x20, 4, left(0xdeadbeef)
+// mapInline() -> 0x20, 4, left(0xdeadbeef)
+// mapAliasStorageRead() -> 0x20, 4, left(0xdeadbeef)
+// storeArr() ->
+// arrTwoStep() -> 0x20, 3, left(0xaabbcc)
+// arrInline() -> 0x20, 3, left(0xaabbcc)
+// arrAliasStorageRead() -> 0x20, 3, left(0xaabbcc)
+// storeStruct() ->
+// structTwoStep() -> 0x20, 2, left(0xf00d)
+// structInline() -> 0x20, 2, left(0xf00d)
+// structAliasStorageRead() -> 0x20, 2, left(0xf00d)
+// storeMapStruct() ->
+// mapStructTwoStep() -> 0x20, 2, left(0xcafe)
+// mapStructInline() -> 0x20, 2, left(0xcafe)
+// mapStructAliasStorageRead() -> 0x20, 2, left(0xcafe)
+// storeNested() ->
+// nestedTwoStep() -> 0x20, 2, left(0xbeef)
+// nestedInline() -> 0x20, 2, left(0xbeef)
+// nestedAliasStorageRead() -> 0x20, 2, left(0xbeef)

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_alias_flows.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_alias_flows.sol
@@ -1,0 +1,56 @@
+// Chained aliases and modifier-local aliases must preserve shielded storage ops.
+contract C {
+    sbytes private data;
+
+    function setup() public {
+        data.push(sbytes1(0x10));
+        data.push(sbytes1(0x20));
+    }
+
+    modifier appendViaAlias(bytes1 value) {
+        bytes storage ref = bytes(data);
+        ref.push(value);
+        _;
+    }
+
+    function writeViaModifier() public appendViaAlias(0x30) {}
+
+    function readViaChain() public view returns (bytes memory) {
+        bytes storage a = bytes(data);
+        bytes storage b = a;
+        return b;
+    }
+
+    function readViaChainAt(uint256 i) public view returns (bytes1) {
+        bytes storage a = bytes(data);
+        bytes storage b = a;
+        return b[i];
+    }
+
+    function pushViaChain() public {
+        bytes storage a = bytes(data);
+        bytes storage b = a;
+        b.push(0x40);
+    }
+
+    function writeViaChainAt0() public {
+        bytes storage a = bytes(data);
+        bytes storage b = a;
+        b[0] = 0xAA;
+    }
+
+    function readDirect() public view returns (bytes memory) {
+        sbytes memory v = data;
+        return bytes(v);
+    }
+}
+// ----
+// setup() ->
+// readViaChain() -> 0x20, 2, left(0x1020)
+// readViaChainAt(uint256): 1 -> left(0x20)
+// pushViaChain() ->
+// readDirect() -> 0x20, 3, left(0x102040)
+// writeViaChainAt0() ->
+// readDirect() -> 0x20, 3, left(0xaa2040)
+// writeViaModifier() ->
+// readDirect() -> 0x20, 4, left(0xaa204030)

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_edge_cases.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_edge_cases.sol
@@ -1,0 +1,48 @@
+// Edge cases around bytes aliases to shielded storage.
+contract C {
+    sbytes private data;
+    bytes private publicData;
+
+    function setup() public {
+        data.push(sbytes1(0xAA));
+        data.push(sbytes1(0xBB));
+
+        publicData.push(0x11);
+        publicData.push(0x22);
+    }
+
+    function copyToPublic() public {
+        publicData = bytes(data);
+    }
+
+    function appendToPublicAfterCopy() public {
+        publicData = bytes(data);
+        publicData.push(0x33);
+    }
+
+    function readPublic() public view returns (bytes memory) {
+        return publicData;
+    }
+
+    function passToInternal() public view returns (bytes memory) {
+        bytes storage ref = bytes(data);
+        return internalRead(ref);
+    }
+
+    function passToInternalDirect() public view returns (bytes memory) {
+        return internalRead(bytes(data));
+    }
+
+    function internalRead(bytes storage ref) internal view returns (bytes memory) {
+        return ref;
+    }
+}
+// ----
+// setup() ->
+// readPublic() -> 0x20, 2, left(0x1122)
+// passToInternal() -> 0x20, 2, left(0xaabb)
+// passToInternalDirect() -> 0x20, 2, left(0xaabb)
+// copyToPublic() ->
+// readPublic() -> 0x20, 2, left(0xaabb)
+// appendToPublicAfterCopy() ->
+// readPublic() -> 0x20, 3, left(0xaabb33)

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_internal_params.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_internal_params.sol
@@ -1,0 +1,152 @@
+// Internal helpers that take bytes storage aliases must preserve shielded storage ops.
+contract C {
+    sbytes private shortData;
+    sbytes private longPushData;
+    sbytes private longIndexData;
+
+    function setup() public {
+        shortData.push(sbytes1(0xAA));
+        shortData.push(sbytes1(0xBB));
+
+        for (uint256 i = 0; i < 32; ++i)
+            longPushData.push(sbytes1(bytes1(uint8(i + 1))));
+
+        for (uint256 i = 0; i < 33; ++i)
+            longIndexData.push(sbytes1(bytes1(uint8(i + 1))));
+    }
+
+    function readAll(bytes storage ref) internal view returns (bytes memory) {
+        return ref;
+    }
+
+    function readOne(bytes storage ref, uint256 i) internal view returns (bytes1) {
+        return ref[i];
+    }
+
+    function pushOne(bytes storage ref, bytes1 value) internal {
+        ref.push(value);
+    }
+
+    function setOne(bytes storage ref, uint256 i, bytes1 value) internal {
+        ref[i] = value;
+    }
+
+    function readShortViaParam() public view returns (bytes memory) {
+        return readAll(bytes(shortData));
+    }
+
+    function readShortViaLocalParam() public view returns (bytes memory) {
+        bytes storage ref = bytes(shortData);
+        return readAll(ref);
+    }
+
+    function readShortAtViaParam(uint256 i) public view returns (bytes1) {
+        return readOne(bytes(shortData), i);
+    }
+
+    function readShortAtViaLocalParam(uint256 i) public view returns (bytes1) {
+        bytes storage ref = bytes(shortData);
+        return readOne(ref, i);
+    }
+
+    function pushShortViaParam() public {
+        pushOne(bytes(shortData), 0xCC);
+    }
+
+    function pushShortViaLocalParam() public {
+        bytes storage ref = bytes(shortData);
+        pushOne(ref, 0xCD);
+    }
+
+    function writeShortAtViaParam() public {
+        setOne(bytes(shortData), 0, 0xDD);
+    }
+
+    function writeShortAtViaLocalParam() public {
+        bytes storage ref = bytes(shortData);
+        setOne(ref, 1, 0xEE);
+    }
+
+    function readDirectShort() public view returns (bytes memory) {
+        sbytes memory v = shortData;
+        return bytes(v);
+    }
+
+    function readLongViaParam() public view returns (bytes memory) {
+        return readAll(bytes(longPushData));
+    }
+
+    function readLongViaLocalParam() public view returns (bytes memory) {
+        bytes storage ref = bytes(longPushData);
+        return readAll(ref);
+    }
+
+    function pushLongViaParam() public {
+        pushOne(bytes(longPushData), 0x21);
+    }
+
+    function pushLongViaLocalParam() public {
+        bytes storage ref = bytes(longPushData);
+        pushOne(ref, 0x22);
+    }
+
+    function readDirectLongPush() public view returns (bytes memory) {
+        sbytes memory v = longPushData;
+        return bytes(v);
+    }
+
+    function readLongIndexAtViaParam(uint256 i) public view returns (bytes1) {
+        return readOne(bytes(longIndexData), i);
+    }
+
+    function readLongIndexAtViaLocalParam(uint256 i) public view returns (bytes1) {
+        bytes storage ref = bytes(longIndexData);
+        return readOne(ref, i);
+    }
+
+    function writeLongIndicesViaParam() public {
+        setOne(bytes(longIndexData), 0, 0xAA);
+        setOne(bytes(longIndexData), 31, 0xBB);
+        setOne(bytes(longIndexData), 32, 0xCC);
+    }
+
+    function writeLongIndicesViaLocalParam() public {
+        bytes storage ref = bytes(longIndexData);
+        setOne(ref, 1, 0xAB);
+        setOne(ref, 30, 0xBC);
+        setOne(ref, 32, 0xCD);
+    }
+
+    function readDirectLongIndex() public view returns (bytes memory) {
+        sbytes memory v = longIndexData;
+        return bytes(v);
+    }
+}
+// ----
+// setup() ->
+// readShortViaParam() -> 0x20, 2, left(0xaabb)
+// readShortViaLocalParam() -> 0x20, 2, left(0xaabb)
+// readShortAtViaParam(uint256): 1 -> left(0xbb)
+// readShortAtViaLocalParam(uint256): 0 -> left(0xaa)
+// pushShortViaParam() ->
+// readDirectShort() -> 0x20, 3, left(0xaabbcc)
+// pushShortViaLocalParam() ->
+// readDirectShort() -> 0x20, 4, left(0xaabbcccd)
+// writeShortAtViaParam() ->
+// readDirectShort() -> 0x20, 4, left(0xddbbcccd)
+// writeShortAtViaLocalParam() ->
+// readDirectShort() -> 0x20, 4, left(0xddeecccd)
+// readLongViaParam() -> 0x20, 32, 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20
+// readLongViaLocalParam() -> 0x20, 32, 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20
+// pushLongViaParam() ->
+// readDirectLongPush() -> 0x20, 33, 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20, left(0x21)
+// pushLongViaLocalParam() ->
+// readDirectLongPush() -> 0x20, 34, 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20, left(0x2122)
+// readLongIndexAtViaParam(uint256): 0 -> left(0x01)
+// readLongIndexAtViaParam(uint256): 31 -> left(0x20)
+// readLongIndexAtViaParam(uint256): 32 -> left(0x21)
+// readLongIndexAtViaLocalParam(uint256): 32 -> left(0x21)
+// writeLongIndicesViaParam() ->
+// readDirectLongIndex() -> 0x20, 33, 0xaa02030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fbb, left(0xcc)
+// writeLongIndicesViaLocalParam() ->
+// readDirectLongIndex() -> 0x20, 33, 0xaaab030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1ebcbb, left(0xcd)

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_internal_returns.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_internal_returns.sol
@@ -1,0 +1,150 @@
+// Internal functions that return bytes storage aliases must preserve shielded storage ops.
+contract C {
+    sbytes private left;
+    sbytes private right;
+    sbytes private longLeft;
+    sbytes private longRight;
+
+    function setup() public {
+        left.push(sbytes1(0x11));
+        left.push(sbytes1(0x22));
+
+        right.push(sbytes1(0x33));
+        right.push(sbytes1(0x44));
+        right.push(sbytes1(0x55));
+
+        for (uint256 i = 0; i < 32; ++i)
+            longLeft.push(sbytes1(bytes1(uint8(i + 1))));
+
+        for (uint256 i = 0; i < 33; ++i)
+            longRight.push(sbytes1(bytes1(uint8(i + 0x31))));
+    }
+
+    function pick(bool which) internal view returns (bytes storage ref) {
+        if (which)
+            ref = bytes(left);
+        else
+            ref = bytes(right);
+    }
+
+    function pickTagged(bool which) internal view returns (uint256, bytes storage ref) {
+        if (which)
+            return (1, bytes(left));
+        return (2, bytes(right));
+    }
+
+    function pickLong(bool which) internal view returns (bytes storage ref) {
+        if (which)
+            ref = bytes(longLeft);
+        else
+            ref = bytes(longRight);
+    }
+
+    function readPick(bool which) public view returns (bytes memory) {
+        bytes storage ref = pick(which);
+        return ref;
+    }
+
+    function readPickDirect(bool which) public view returns (bytes memory) {
+        return pick(which);
+    }
+
+    function readViaTernary(bool which) public view returns (bytes memory) {
+        bytes storage ref = which ? bytes(left) : bytes(right);
+        return ref;
+    }
+
+    function readViaTernaryAt(bool which, uint256 i) public view returns (bytes1) {
+        bytes storage ref = which ? bytes(left) : bytes(right);
+        return ref[i];
+    }
+
+    function pushPick(bool which, bytes1 value) public {
+        bytes storage ref = pick(which);
+        ref.push(value);
+    }
+
+    function pushViaTernary(bool which, bytes1 value) public {
+        bytes storage ref = which ? bytes(left) : bytes(right);
+        ref.push(value);
+    }
+
+    function readViaReassignment(bool which) public view returns (bytes memory) {
+        bytes storage ref = bytes(left);
+        if (!which)
+            ref = bytes(right);
+        return ref;
+    }
+
+    function pushViaReassignment(bool which, bytes1 value) public {
+        bytes storage ref = bytes(left);
+        if (!which)
+            ref = bytes(right);
+        ref.push(value);
+    }
+
+    function readTaggedTag(bool which) public view returns (uint256) {
+        (uint256 tag, ) = pickTagged(which);
+        return tag;
+    }
+
+    function readTaggedBytes(bool which) public view returns (bytes memory) {
+        (, bytes storage ref) = pickTagged(which);
+        return ref;
+    }
+
+    function readPickLong(bool which) public view returns (bytes memory) {
+        return pickLong(which);
+    }
+
+    function readPickLongAt(bool which, uint256 i) public view returns (bytes1) {
+        bytes storage ref = pickLong(which);
+        return ref[i];
+    }
+
+    function pushPickLong(bool which, bytes1 value) public {
+        bytes storage ref = pickLong(which);
+        ref.push(value);
+    }
+
+    function readDirectLongLeft() public view returns (bytes memory) {
+        sbytes memory v = longLeft;
+        return bytes(v);
+    }
+
+    function readDirectLongRight() public view returns (bytes memory) {
+        sbytes memory v = longRight;
+        return bytes(v);
+    }
+}
+// ----
+// setup() ->
+// readPick(bool): true -> 0x20, 2, left(0x1122)
+// readPick(bool): false -> 0x20, 3, left(0x334455)
+// readPickDirect(bool): true -> 0x20, 2, left(0x1122)
+// readPickDirect(bool): false -> 0x20, 3, left(0x334455)
+// readViaTernary(bool): true -> 0x20, 2, left(0x1122)
+// readViaTernary(bool): false -> 0x20, 3, left(0x334455)
+// readViaTernaryAt(bool,uint256): false, 1 -> left(0x44)
+// readTaggedTag(bool): true -> 1
+// readTaggedTag(bool): false -> 2
+// readTaggedBytes(bool): true -> 0x20, 2, left(0x1122)
+// readTaggedBytes(bool): false -> 0x20, 3, left(0x334455)
+// pushPick(bool,bytes1): true, left(0x99) ->
+// readPick(bool): true -> 0x20, 3, left(0x112299)
+// pushPick(bool,bytes1): false, left(0x66) ->
+// readPick(bool): false -> 0x20, 4, left(0x33445566)
+// pushViaTernary(bool,bytes1): true, left(0x77) ->
+// readPick(bool): true -> 0x20, 4, left(0x11229977)
+// pushViaReassignment(bool,bytes1): false, left(0x88) ->
+// readPick(bool): false -> 0x20, 5, left(0x3344556688)
+// readViaReassignment(bool): true -> 0x20, 4, left(0x11229977)
+// readViaReassignment(bool): false -> 0x20, 5, left(0x3344556688)
+// readPickLong(bool): true -> 0x20, 32, 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20
+// readPickLong(bool): false -> 0x20, 33, 0x3132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f50, left(0x51)
+// readPickLongAt(bool,uint256): true, 31 -> left(0x20)
+// readPickLongAt(bool,uint256): false, 32 -> left(0x51)
+// pushPickLong(bool,bytes1): true, left(0xaa) ->
+// readDirectLongLeft() -> 0x20, 33, 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20, left(0xaa)
+// pushPickLong(bool,bytes1): false, left(0xbb) ->
+// readDirectLongRight() -> 0x20, 34, 0x3132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f50, left(0x51bb)

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_length.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_length.sol
@@ -1,0 +1,25 @@
+// bytes aliases to shielded storage must still expose plain bytes metadata types.
+contract C {
+    sbytes private data;
+    bytes private publicData;
+
+    function setup() public {
+        data.push(sbytes1(0xAA));
+        data.push(sbytes1(0xBB));
+
+        publicData.push(0x11);
+    }
+
+    function publicLength() public view returns (uint256) {
+        return publicData.length;
+    }
+
+    function aliasLength() public view returns (uint256) {
+        bytes storage ref = bytes(data);
+        return ref.length;
+    }
+}
+// ----
+// setup() ->
+// publicLength() -> 1
+// aliasLength() -> 2

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_write_alias.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_write_alias.sol
@@ -1,0 +1,38 @@
+// Writing through a bytes alias to shielded storage must keep using shielded storage ops.
+contract C {
+    sbytes private data;
+
+    function setup() public {
+        data.push(sbytes1(0xAA));
+        data.push(sbytes1(0xBB));
+    }
+
+    function readAlias() public view returns (bytes memory) {
+        bytes storage ref = bytes(data);
+        return ref;
+    }
+
+    function readAliasAt(uint256 i) public view returns (bytes1) {
+        bytes storage ref = bytes(data);
+        return ref[i];
+    }
+
+    function pushThroughAlias() public {
+        bytes storage ref = bytes(data);
+        ref.push(0xCC);
+    }
+
+    function readDirect() public view returns (bytes memory) {
+        sbytes memory v = data;
+        return bytes(v);
+    }
+}
+// ----
+// setup() ->
+// readDirect() -> 0x20, 2, left(0xaabb)
+// readAlias() -> 0x20, 2, left(0xaabb)
+// readAliasAt(uint256): 0 -> left(0xaa)
+// readAliasAt(uint256): 1 -> left(0xbb)
+// pushThroughAlias() ->
+// readDirect() -> 0x20, 3, left(0xaabbcc)
+// readAliasAt(uint256): 2 -> left(0xcc)

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_write_alias_containers.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_write_alias_containers.sol
@@ -1,0 +1,95 @@
+// Storage aliases created from different sbytes containers must preserve shielded storage ops.
+contract C {
+    mapping(uint256 => sbytes) m;
+    sbytes[] arr;
+    struct S { sbytes data; }
+    S private s;
+    mapping(uint256 => S) sm;
+    mapping(uint256 => mapping(uint256 => sbytes)) nested;
+
+    function setup() public {
+        m[0].push(sbytes1(0x11));
+        m[0].push(sbytes1(0x22));
+
+        arr.push();
+        arr[0].push(sbytes1(0xAA));
+        arr[0].push(sbytes1(0xBB));
+        arr[0].push(sbytes1(0xCC));
+
+        s.data.push(sbytes1(0xF0));
+        s.data.push(sbytes1(0x0D));
+
+        sm[0].data.push(sbytes1(0xCA));
+        sm[0].data.push(sbytes1(0xFE));
+
+        nested[0][1].push(sbytes1(0xBE));
+        nested[0][1].push(sbytes1(0xEF));
+    }
+
+    function mapPush() public {
+        bytes storage ref = bytes(m[0]);
+        ref.push(0x33);
+    }
+
+    function arrIndexWrite() public {
+        bytes storage ref = bytes(arr[0]);
+        ref[1] = 0xDD;
+    }
+
+    function structPop() public {
+        bytes storage ref = bytes(s.data);
+        ref.pop();
+    }
+
+    function mapStructPop() public {
+        bytes storage ref = bytes(sm[0].data);
+        ref.pop();
+    }
+
+    function nestedPush() public {
+        bytes storage ref = bytes(nested[0][1]);
+        ref.push(0xAA);
+    }
+
+    function readMap() public view returns (bytes memory) {
+        sbytes memory v = m[0];
+        return bytes(v);
+    }
+
+    function readArr() public view returns (bytes memory) {
+        sbytes memory v = arr[0];
+        return bytes(v);
+    }
+
+    function readStruct() public view returns (bytes memory) {
+        sbytes memory v = s.data;
+        return bytes(v);
+    }
+
+    function readMapStruct() public view returns (bytes memory) {
+        sbytes memory v = sm[0].data;
+        return bytes(v);
+    }
+
+    function readNested() public view returns (bytes memory) {
+        sbytes memory v = nested[0][1];
+        return bytes(v);
+    }
+}
+// ----
+// setup() ->
+// readMap() -> 0x20, 2, left(0x1122)
+// readArr() -> 0x20, 3, left(0xaabbcc)
+// readStruct() -> 0x20, 2, left(0xf00d)
+// readMapStruct() -> 0x20, 2, left(0xcafe)
+// readNested() -> 0x20, 2, left(0xbeef)
+// mapPush() ->
+// readMap() -> 0x20, 3, left(0x112233)
+// arrIndexWrite() ->
+// readArr() -> 0x20, 3, left(0xaaddcc)
+// structPop() ->
+// readStruct() -> 0x20, 1, left(0xf0)
+// mapStructPop() ->
+// readMapStruct() -> 0x20, 1, left(0xca)
+// nestedPush() ->
+// readNested() -> 0x20, 3, left(0xbeefaa)

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_write_alias_long.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_write_alias_long.sol
@@ -1,0 +1,39 @@
+// Long byte-array aliases must keep using shielded storage ops for reads and writes too.
+contract C {
+    sbytes private data;
+
+    function setup() public {
+        for (uint256 i = 0; i < 32; ++i)
+            data.push(sbytes1(bytes1(uint8(i + 1))));
+    }
+
+    function readAlias() public view returns (bytes memory) {
+        bytes storage ref = bytes(data);
+        return ref;
+    }
+
+    function readAliasAt(uint256 i) public view returns (bytes1) {
+        bytes storage ref = bytes(data);
+        return ref[i];
+    }
+
+    function pushThroughAlias() public {
+        bytes storage ref = bytes(data);
+        ref.push(0x21);
+    }
+
+    function readDirect() public view returns (bytes memory) {
+        sbytes memory v = data;
+        return bytes(v);
+    }
+}
+// ----
+// setup() ->
+// readDirect() -> 0x20, 32, 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20
+// readAlias() -> 0x20, 32, 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20
+// readAliasAt(uint256): 0 -> left(0x01)
+// readAliasAt(uint256): 31 -> left(0x20)
+// pushThroughAlias() ->
+// readDirect() -> 0x20, 33, 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20, left(0x21)
+// readAlias() -> 0x20, 33, 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20, left(0x21)
+// readAliasAt(uint256): 32 -> left(0x21)

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_write_alias_long_variants.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_write_alias_long_variants.sol
@@ -1,0 +1,51 @@
+// Long byte-array alias operations must keep using shielded storage ops for element updates too.
+contract C {
+    sbytes private data;
+
+    function setup() public {
+        for (uint256 i = 0; i < 33; ++i)
+            data.push(sbytes1(bytes1(uint8(i + 1))));
+    }
+
+    function readAliasAt(uint256 i) public view returns (bytes1) {
+        bytes storage ref = bytes(data);
+        return ref[i];
+    }
+
+    function indexWriteAlias() public {
+        bytes storage ref = bytes(data);
+        ref[0] = 0xAA;
+        ref[31] = 0xBB;
+        ref[32] = 0xCC;
+    }
+
+    function popAlias() public {
+        bytes storage ref = bytes(data);
+        ref.pop();
+    }
+
+    function pushAfterPop() public {
+        bytes storage ref = bytes(data);
+        ref.push(0xDD);
+    }
+
+    function readDirect() public view returns (bytes memory) {
+        sbytes memory v = data;
+        return bytes(v);
+    }
+}
+// ----
+// setup() ->
+// readAliasAt(uint256): 0 -> left(0x01)
+// readAliasAt(uint256): 31 -> left(0x20)
+// readAliasAt(uint256): 32 -> left(0x21)
+// indexWriteAlias() ->
+// readAliasAt(uint256): 0 -> left(0xaa)
+// readAliasAt(uint256): 31 -> left(0xbb)
+// readAliasAt(uint256): 32 -> left(0xcc)
+// readDirect() -> 0x20, 33, 0xaa02030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fbb, left(0xcc)
+// popAlias() ->
+// readDirect() -> 0x20, 32, 0xaa02030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fbb
+// pushAfterPop() ->
+// readDirect() -> 0x20, 33, 0xaa02030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fbb, left(0xdd)
+// readAliasAt(uint256): 32 -> left(0xdd)

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_write_alias_variants.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_write_alias_variants.sol
@@ -1,0 +1,48 @@
+// Write variants through a bytes alias to shielded storage must keep using shielded storage ops.
+contract C {
+    sbytes private data;
+
+    function setup() public {
+        data.push(sbytes1(0xAA));
+        data.push(sbytes1(0xBB));
+        data.push(sbytes1(0xCC));
+    }
+
+    function indexWrite() public {
+        bytes storage ref = bytes(data);
+        ref[0] = 0xDD;
+    }
+
+    function popAlias() public {
+        bytes storage ref = bytes(data);
+        ref.pop();
+    }
+
+    function pushAfterPop() public {
+        bytes storage ref = bytes(data);
+        ref.push(0xEE);
+    }
+
+    function readAliasAt(uint256 i) public view returns (bytes1) {
+        bytes storage ref = bytes(data);
+        return ref[i];
+    }
+
+    function readDirect() public view returns (bytes memory) {
+        sbytes memory v = data;
+        return bytes(v);
+    }
+}
+// ----
+// setup() ->
+// readDirect() -> 0x20, 3, left(0xaabbcc)
+// indexWrite() ->
+// readDirect() -> 0x20, 3, left(0xddbbcc)
+// readAliasAt(uint256): 0 -> left(0xdd)
+// readAliasAt(uint256): 2 -> left(0xcc)
+// popAlias() ->
+// readDirect() -> 0x20, 2, left(0xddbb)
+// readAliasAt(uint256): 1 -> left(0xbb)
+// pushAfterPop() ->
+// readDirect() -> 0x20, 3, left(0xddbbee)
+// readAliasAt(uint256): 2 -> left(0xee)

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_fixed.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_fixed.sol
@@ -1,0 +1,82 @@
+// Test inline bytesN(sbytesN) casts from all container types.
+// Covers sbytes1 and sbytes32 as representative fixed-size shielded bytes.
+contract C {
+    sbytes1 private plain1;
+    sbytes32 private plain32;
+    mapping(uint256 => sbytes1) m1;
+    mapping(uint256 => sbytes32) m32;
+    sbytes1[] arr1;
+    sbytes32[] arr32;
+    struct S { sbytes1 b1; sbytes32 b32; }
+    S private s;
+    mapping(uint256 => S) sm;
+
+    function store() public {
+        plain1 = sbytes1(bytes1(0xAB));
+        plain32 = sbytes32(bytes32(uint256(0xDEAD)));
+        m1[0] = sbytes1(bytes1(0xAB));
+        m32[0] = sbytes32(bytes32(uint256(0xDEAD)));
+        arr1.push(sbytes1(bytes1(0xAB)));
+        arr32.push(sbytes32(bytes32(uint256(0xDEAD))));
+        s.b1 = sbytes1(bytes1(0xAB));
+        s.b32 = sbytes32(bytes32(uint256(0xDEAD)));
+        sm[0].b1 = sbytes1(bytes1(0xAB));
+        sm[0].b32 = sbytes32(bytes32(uint256(0xDEAD)));
+    }
+
+    // --- Plain ---
+    function plainInline1() public view returns (bytes1) { return bytes1(plain1); }
+    function plainTwoStep1() public view returns (bytes1) { sbytes1 v = plain1; return bytes1(v); }
+    function plainInline32() public view returns (bytes32) { return bytes32(plain32); }
+    function plainTwoStep32() public view returns (bytes32) { sbytes32 v = plain32; return bytes32(v); }
+
+    // --- Mapping ---
+    function mapInline1() public view returns (bytes1) { return bytes1(m1[0]); }
+    function mapInlineAssigned1() public view returns (bytes1) { bytes1 v = bytes1(m1[0]); return v; }
+    function mapTwoStep1() public view returns (bytes1) { sbytes1 v = m1[0]; return bytes1(v); }
+    function mapInline32() public view returns (bytes32) { return bytes32(m32[0]); }
+    function mapInlineAssigned32() public view returns (bytes32) { bytes32 v = bytes32(m32[0]); return v; }
+    function mapTwoStep32() public view returns (bytes32) { sbytes32 v = m32[0]; return bytes32(v); }
+
+    // --- Array ---
+    function arrInline1() public view returns (bytes1) { return bytes1(arr1[0]); }
+    function arrTwoStep1() public view returns (bytes1) { sbytes1 v = arr1[0]; return bytes1(v); }
+    function arrInline32() public view returns (bytes32) { return bytes32(arr32[0]); }
+    function arrTwoStep32() public view returns (bytes32) { sbytes32 v = arr32[0]; return bytes32(v); }
+
+    // --- Struct ---
+    function structInline1() public view returns (bytes1) { return bytes1(s.b1); }
+    function structTwoStep1() public view returns (bytes1) { sbytes1 v = s.b1; return bytes1(v); }
+    function structInline32() public view returns (bytes32) { return bytes32(s.b32); }
+    function structTwoStep32() public view returns (bytes32) { sbytes32 v = s.b32; return bytes32(v); }
+
+    // --- Mapping of struct ---
+    function mapStructInline1() public view returns (bytes1) { return bytes1(sm[0].b1); }
+    function mapStructTwoStep1() public view returns (bytes1) { sbytes1 v = sm[0].b1; return bytes1(v); }
+    function mapStructInline32() public view returns (bytes32) { return bytes32(sm[0].b32); }
+    function mapStructTwoStep32() public view returns (bytes32) { sbytes32 v = sm[0].b32; return bytes32(v); }
+}
+// ----
+// store() ->
+// plainTwoStep1() -> left(0xab)
+// plainInline1() -> left(0xab)
+// plainTwoStep32() -> 0xdead
+// plainInline32() -> 0xdead
+// mapTwoStep1() -> left(0xab)
+// mapInline1() -> left(0xab)
+// mapInlineAssigned1() -> left(0xab)
+// mapTwoStep32() -> 0xdead
+// mapInline32() -> 0xdead
+// mapInlineAssigned32() -> 0xdead
+// arrTwoStep1() -> left(0xab)
+// arrInline1() -> left(0xab)
+// arrTwoStep32() -> 0xdead
+// arrInline32() -> 0xdead
+// structTwoStep1() -> left(0xab)
+// structInline1() -> left(0xab)
+// structTwoStep32() -> 0xdead
+// structInline32() -> 0xdead
+// mapStructTwoStep1() -> left(0xab)
+// mapStructInline1() -> left(0xab)
+// mapStructTwoStep32() -> 0xdead
+// mapStructInline32() -> 0xdead

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sint.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sint.sol
@@ -1,0 +1,81 @@
+// Test inline int(sint) casts from all container types.
+contract C {
+    sint256 private plain256;
+    sint8 private plain8;
+    mapping(uint256 => sint256) m256;
+    mapping(uint256 => sint8) m8;
+    sint256[] arr256;
+    sint8[] arr8;
+    struct S { sint256 i256; sint8 i8; }
+    S private s;
+    mapping(uint256 => S) sm;
+
+    function store() public {
+        plain256 = sint256(-9999);
+        plain8 = sint8(-1);
+        m256[0] = sint256(-9999);
+        m8[0] = sint8(-1);
+        arr256.push(sint256(-9999));
+        arr8.push(sint8(-1));
+        s.i256 = sint256(-9999);
+        s.i8 = sint8(-1);
+        sm[0].i256 = sint256(-9999);
+        sm[0].i8 = sint8(-1);
+    }
+
+    // --- Plain ---
+    function plainInline256() public view returns (int256) { return int256(plain256); }
+    function plainTwoStep256() public view returns (int256) { sint256 v = plain256; return int256(v); }
+    function plainInline8() public view returns (int8) { return int8(plain8); }
+    function plainTwoStep8() public view returns (int8) { sint8 v = plain8; return int8(v); }
+
+    // --- Mapping ---
+    function mapInline256() public view returns (int256) { return int256(m256[0]); }
+    function mapInlineAssigned256() public view returns (int256) { int256 v = int256(m256[0]); return v; }
+    function mapTwoStep256() public view returns (int256) { sint256 v = m256[0]; return int256(v); }
+    function mapInline8() public view returns (int8) { return int8(m8[0]); }
+    function mapInlineAssigned8() public view returns (int8) { int8 v = int8(m8[0]); return v; }
+    function mapTwoStep8() public view returns (int8) { sint8 v = m8[0]; return int8(v); }
+
+    // --- Array ---
+    function arrInline256() public view returns (int256) { return int256(arr256[0]); }
+    function arrTwoStep256() public view returns (int256) { sint256 v = arr256[0]; return int256(v); }
+    function arrInline8() public view returns (int8) { return int8(arr8[0]); }
+    function arrTwoStep8() public view returns (int8) { sint8 v = arr8[0]; return int8(v); }
+
+    // --- Struct ---
+    function structInline256() public view returns (int256) { return int256(s.i256); }
+    function structTwoStep256() public view returns (int256) { sint256 v = s.i256; return int256(v); }
+    function structInline8() public view returns (int8) { return int8(s.i8); }
+    function structTwoStep8() public view returns (int8) { sint8 v = s.i8; return int8(v); }
+
+    // --- Mapping of struct ---
+    function mapStructInline256() public view returns (int256) { return int256(sm[0].i256); }
+    function mapStructTwoStep256() public view returns (int256) { sint256 v = sm[0].i256; return int256(v); }
+    function mapStructInline8() public view returns (int8) { return int8(sm[0].i8); }
+    function mapStructTwoStep8() public view returns (int8) { sint8 v = sm[0].i8; return int8(v); }
+}
+// ----
+// store() ->
+// plainTwoStep256() -> -9999
+// plainInline256() -> -9999
+// plainTwoStep8() -> -1
+// plainInline8() -> -1
+// mapTwoStep256() -> -9999
+// mapInline256() -> -9999
+// mapInlineAssigned256() -> -9999
+// mapTwoStep8() -> -1
+// mapInline8() -> -1
+// mapInlineAssigned8() -> -1
+// arrTwoStep256() -> -9999
+// arrInline256() -> -9999
+// arrTwoStep8() -> -1
+// arrInline8() -> -1
+// structTwoStep256() -> -9999
+// structInline256() -> -9999
+// structTwoStep8() -> -1
+// structInline8() -> -1
+// mapStructTwoStep256() -> -9999
+// mapStructInline256() -> -9999
+// mapStructTwoStep8() -> -1
+// mapStructInline8() -> -1

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_suint.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_suint.sol
@@ -1,0 +1,81 @@
+// Test inline uint(suint) casts from all container types.
+contract C {
+    suint256 private plain256;
+    suint8 private plain8;
+    mapping(uint256 => suint256) m256;
+    mapping(uint256 => suint8) m8;
+    suint256[] arr256;
+    suint8[] arr8;
+    struct S { suint256 u256; suint8 u8; }
+    S private s;
+    mapping(uint256 => S) sm;
+
+    function store() public {
+        plain256 = suint256(42);
+        plain8 = suint8(255);
+        m256[0] = suint256(42);
+        m8[0] = suint8(255);
+        arr256.push(suint256(42));
+        arr8.push(suint8(255));
+        s.u256 = suint256(42);
+        s.u8 = suint8(255);
+        sm[0].u256 = suint256(42);
+        sm[0].u8 = suint8(255);
+    }
+
+    // --- Plain ---
+    function plainInline256() public view returns (uint256) { return uint256(plain256); }
+    function plainTwoStep256() public view returns (uint256) { suint256 v = plain256; return uint256(v); }
+    function plainInline8() public view returns (uint8) { return uint8(plain8); }
+    function plainTwoStep8() public view returns (uint8) { suint8 v = plain8; return uint8(v); }
+
+    // --- Mapping ---
+    function mapInline256() public view returns (uint256) { return uint256(m256[0]); }
+    function mapInlineAssigned256() public view returns (uint256) { uint256 v = uint256(m256[0]); return v; }
+    function mapTwoStep256() public view returns (uint256) { suint256 v = m256[0]; return uint256(v); }
+    function mapInline8() public view returns (uint8) { return uint8(m8[0]); }
+    function mapInlineAssigned8() public view returns (uint8) { uint8 v = uint8(m8[0]); return v; }
+    function mapTwoStep8() public view returns (uint8) { suint8 v = m8[0]; return uint8(v); }
+
+    // --- Array ---
+    function arrInline256() public view returns (uint256) { return uint256(arr256[0]); }
+    function arrTwoStep256() public view returns (uint256) { suint256 v = arr256[0]; return uint256(v); }
+    function arrInline8() public view returns (uint8) { return uint8(arr8[0]); }
+    function arrTwoStep8() public view returns (uint8) { suint8 v = arr8[0]; return uint8(v); }
+
+    // --- Struct ---
+    function structInline256() public view returns (uint256) { return uint256(s.u256); }
+    function structTwoStep256() public view returns (uint256) { suint256 v = s.u256; return uint256(v); }
+    function structInline8() public view returns (uint8) { return uint8(s.u8); }
+    function structTwoStep8() public view returns (uint8) { suint8 v = s.u8; return uint8(v); }
+
+    // --- Mapping of struct ---
+    function mapStructInline256() public view returns (uint256) { return uint256(sm[0].u256); }
+    function mapStructTwoStep256() public view returns (uint256) { suint256 v = sm[0].u256; return uint256(v); }
+    function mapStructInline8() public view returns (uint8) { return uint8(sm[0].u8); }
+    function mapStructTwoStep8() public view returns (uint8) { suint8 v = sm[0].u8; return uint8(v); }
+}
+// ----
+// store() ->
+// plainTwoStep256() -> 42
+// plainInline256() -> 42
+// plainTwoStep8() -> 255
+// plainInline8() -> 255
+// mapTwoStep256() -> 42
+// mapInline256() -> 42
+// mapInlineAssigned256() -> 42
+// mapTwoStep8() -> 255
+// mapInline8() -> 255
+// mapInlineAssigned8() -> 255
+// arrTwoStep256() -> 42
+// arrInline256() -> 42
+// arrTwoStep8() -> 255
+// arrInline8() -> 255
+// structTwoStep256() -> 42
+// structInline256() -> 42
+// structTwoStep8() -> 255
+// structInline8() -> 255
+// mapStructTwoStep256() -> 42
+// mapStructInline256() -> 42
+// mapStructTwoStep8() -> 255
+// mapStructInline8() -> 255

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_udvt.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_udvt.sol
@@ -1,0 +1,147 @@
+// Test inline unwrap/cast for user-defined value types wrapping shielded primitives.
+type ShieldedUint is suint256;
+type ShieldedInt is sint256;
+type ShieldedBool is sbool;
+type ShieldedAddr is saddress;
+type ShieldedB32 is sbytes32;
+
+contract C {
+    ShieldedUint private plain;
+    mapping(uint256 => ShieldedUint) m;
+    ShieldedUint[] arr;
+    struct S { ShieldedUint u; ShieldedBool b; ShieldedAddr a; ShieldedB32 b32; }
+    S private s;
+    mapping(uint256 => S) sm;
+
+    // Also test non-uint UDVTs in mappings
+    mapping(uint256 => ShieldedBool) mBool;
+    mapping(uint256 => ShieldedAddr) mAddr;
+    mapping(uint256 => ShieldedB32) mB32;
+    mapping(uint256 => ShieldedInt) mInt;
+
+    function store() public {
+        plain = ShieldedUint.wrap(suint256(42));
+        m[0] = ShieldedUint.wrap(suint256(42));
+        arr.push(ShieldedUint.wrap(suint256(42)));
+        s.u = ShieldedUint.wrap(suint256(42));
+        s.b = ShieldedBool.wrap(sbool(true));
+        s.a = ShieldedAddr.wrap(saddress(address(0xBEEF)));
+        s.b32 = ShieldedB32.wrap(sbytes32(bytes32(uint256(0xFF))));
+        sm[0].u = ShieldedUint.wrap(suint256(42));
+        sm[0].b = ShieldedBool.wrap(sbool(true));
+        sm[0].a = ShieldedAddr.wrap(saddress(address(0xBEEF)));
+        sm[0].b32 = ShieldedB32.wrap(sbytes32(bytes32(uint256(0xFF))));
+        mBool[0] = ShieldedBool.wrap(sbool(true));
+        mAddr[0] = ShieldedAddr.wrap(saddress(address(0xBEEF)));
+        mB32[0] = ShieldedB32.wrap(sbytes32(bytes32(uint256(0xFF))));
+        mInt[0] = ShieldedInt.wrap(sint256(-7));
+    }
+
+    // --- Plain: inline unwrap+cast ---
+    function plainInline() public view returns (uint256) {
+        return uint256(ShieldedUint.unwrap(plain));
+    }
+    function plainTwoStep() public view returns (uint256) {
+        ShieldedUint v = plain;
+        return uint256(ShieldedUint.unwrap(v));
+    }
+
+    // --- Mapping: inline unwrap+cast ---
+    function mapInline() public view returns (uint256) {
+        return uint256(ShieldedUint.unwrap(m[0]));
+    }
+    function mapInlineAssigned() public view returns (uint256) {
+        uint256 v = uint256(ShieldedUint.unwrap(m[0]));
+        return v;
+    }
+    function mapTwoStep() public view returns (uint256) {
+        ShieldedUint v = m[0];
+        return uint256(ShieldedUint.unwrap(v));
+    }
+
+    // --- Array: inline unwrap+cast ---
+    function arrInline() public view returns (uint256) {
+        return uint256(ShieldedUint.unwrap(arr[0]));
+    }
+    function arrTwoStep() public view returns (uint256) {
+        ShieldedUint v = arr[0];
+        return uint256(ShieldedUint.unwrap(v));
+    }
+
+    // --- Struct: inline unwrap+cast ---
+    function structInline() public view returns (uint256) {
+        return uint256(ShieldedUint.unwrap(s.u));
+    }
+    function structTwoStep() public view returns (uint256) {
+        ShieldedUint v = s.u;
+        return uint256(ShieldedUint.unwrap(v));
+    }
+
+    // --- Mapping-of-struct: inline unwrap+cast ---
+    function mapStructInline() public view returns (uint256) {
+        return uint256(ShieldedUint.unwrap(sm[0].u));
+    }
+    function mapStructTwoStep() public view returns (uint256) {
+        ShieldedUint v = sm[0].u;
+        return uint256(ShieldedUint.unwrap(v));
+    }
+
+    // --- Other UDVT types from mappings (inline) ---
+    function mapBoolInline() public view returns (bool) {
+        return bool(ShieldedBool.unwrap(mBool[0]));
+    }
+    function mapAddrInline() public view returns (address) {
+        return address(ShieldedAddr.unwrap(mAddr[0]));
+    }
+    function mapB32Inline() public view returns (bytes32) {
+        return bytes32(ShieldedB32.unwrap(mB32[0]));
+    }
+    function mapIntInline() public view returns (int256) {
+        return int256(ShieldedInt.unwrap(mInt[0]));
+    }
+
+    // --- Struct fields: other UDVT types (inline) ---
+    function structBoolInline() public view returns (bool) {
+        return bool(ShieldedBool.unwrap(s.b));
+    }
+    function structAddrInline() public view returns (address) {
+        return address(ShieldedAddr.unwrap(s.a));
+    }
+    function structB32Inline() public view returns (bytes32) {
+        return bytes32(ShieldedB32.unwrap(s.b32));
+    }
+
+    // --- Mapping-of-struct fields: other UDVT types (inline) ---
+    function mapStructBoolInline() public view returns (bool) {
+        return bool(ShieldedBool.unwrap(sm[0].b));
+    }
+    function mapStructAddrInline() public view returns (address) {
+        return address(ShieldedAddr.unwrap(sm[0].a));
+    }
+    function mapStructB32Inline() public view returns (bytes32) {
+        return bytes32(ShieldedB32.unwrap(sm[0].b32));
+    }
+}
+// ----
+// store() ->
+// plainTwoStep() -> 42
+// plainInline() -> 42
+// mapTwoStep() -> 42
+// mapInline() -> 42
+// mapInlineAssigned() -> 42
+// arrTwoStep() -> 42
+// arrInline() -> 42
+// structTwoStep() -> 42
+// structInline() -> 42
+// mapStructTwoStep() -> 42
+// mapStructInline() -> 42
+// mapBoolInline() -> true
+// mapAddrInline() -> 0xbeef
+// mapB32Inline() -> 0xff
+// mapIntInline() -> -7
+// structBoolInline() -> true
+// structAddrInline() -> 0xbeef
+// structB32Inline() -> 0xff
+// mapStructBoolInline() -> true
+// mapStructAddrInline() -> 0xbeef
+// mapStructB32Inline() -> 0xff


### PR DESCRIPTION
## Summary

Fixes #248.

`bytes(sbytes_storage_ref)` could lose the fact that the alias still points at shielded storage. That made the compiler emit ordinary storage ops for paths that still touch private slots, which then failed at runtime with `InvalidPrivateStorageAccess`.

Affected cases included:
- inline reads like `return bytes(m[0]);`
- storage aliases like `bytes storage ref = bytes(data);`
- alias reads and writes such as `return ref`, `ref[i]`, `ref[i] = ...`, `ref.push(...)`, and `ref.pop()`
- internal helpers that take or return `bytes storage` aliases derived from shielded storage

## Fix

The compiler now preserves an internal shielded-storage marker on `bytes` / `string` storage references produced from shielded storage.

Both codegen pipelines use that marker to keep using shielded storage ops while the alias still points at shielded storage:
- storage-to-memory reads use `cload`
- alias writes use `cstore`
- indexed alias helpers preserve shielded storage ops as well

The marker is only for storage-op selection. It does not change the surface type of `bytes`: user-visible typing like `.length` stays ordinary, and deep copies into genuinely public storage stay on ordinary storage ops.

## Tests

Added and expanded coverage for:
- the original inline `bytes(sbytes_storage)` bug
- direct storage aliases created from `bytes(sbytes_storage_ref)`
- alias reads and writes through locals, internal parameters, and internal return values
- chained aliases, ternary/reassignment flows, modifiers, and `.length`
- short and long byte arrays
- plain storage, mappings, arrays, structs, mapping-of-struct, and nested mappings
