### PR TITLE
fix: preserve CSE stores on cross-domain slot conflicts

### DIFF
--- a/libevmasm/CommonSubexpressionEliminator.cpp
+++ b/libevmasm/CommonSubexpressionEliminator.cpp
@@ -148,8 +148,28 @@ AssemblyItems CSECodeGenerator::generateCode(
 		m_classPositions[item.second].insert(item.first);
 
 	// generate the dependency graph starting from final storage and memory writes and target stack contents
+	//
+	// When the same slot has stores from both public (Storage) and shielded (ShieldedStorage) domains,
+	// we must preserve ALL stores — not just the last per (target, slot) — because cross-domain access
+	// to the same slot triggers a runtime revert. Dropping an earlier store can change the execution
+	// semantics from revert to success.
+	std::set<Id> crossDomainSlots;
+	{
+		std::map<Id, std::set<StoreOperation::Target>> slotTargets;
+		for (auto const& p: m_storeOperations)
+			slotTargets[p.first.second].insert(p.first.first);
+		for (auto const& entry: slotTargets)
+			if (entry.second.count(StoreOperation::Storage) && entry.second.count(StoreOperation::ShieldedStorage))
+				crossDomainSlots.insert(entry.first);
+	}
 	for (auto const& p: m_storeOperations)
-		addDependencies(p.second.back().expression);
+	{
+		if (crossDomainSlots.count(p.first.second))
+			for (auto const& store: p.second)
+				addDependencies(store.expression);
+		else
+			addDependencies(p.second.back().expression);
+	}
 	for (auto const& targetItem: m_targetStack)
 	{
 		m_finalClasses.insert(targetItem.second);

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -152,6 +152,15 @@ namespace
 		AssemblyItems output = CFG(_input);
 		BOOST_CHECK_EQUAL_COLLECTIONS(_expectation.begin(), _expectation.end(), output.begin(), output.end());
 	}
+
+	size_t countInstruction(AssemblyItems const& _items, Instruction _instruction)
+	{
+		size_t count = 0;
+		for (AssemblyItem const& item: _items)
+			if (item.type() == Operation && item.instruction() == _instruction)
+				++count;
+		return count;
+	}
 }
 
 BOOST_AUTO_TEST_SUITE(Optimiser)
@@ -2686,6 +2695,71 @@ BOOST_AUTO_TEST_CASE(cse_cstore_cload_same_slot_can_optimize)
 		Instruction::SWAP1,
 		Instruction::CSTORE
 	});
+}
+
+BOOST_AUTO_TEST_CASE(cse_cross_domain_cstore_sstore_cstore_preserves_all)
+{
+	// CSTORE privatizes slot 0, then SSTORE conflicts (should revert at runtime),
+	// then another CSTORE writes to same slot. Without the fix, CSE drops the
+	// first CSTORE, allowing the SSTORE to succeed and changing revert->success.
+	AssemblyItems input{
+		u256(0x11),
+		u256(0),
+		Instruction::CSTORE,
+		u256(0),
+		u256(0),
+		Instruction::SSTORE,
+		u256(0x33),
+		u256(0),
+		Instruction::CSTORE,
+		u256(0),
+		Instruction::CLOAD
+	};
+	AssemblyItems optimized = CSE(input);
+
+	// Both CSTOREs and the SSTORE must be preserved — the cross-domain conflict
+	// means eliminating any store changes the runtime semantics.
+	BOOST_CHECK_EQUAL(countInstruction(optimized, Instruction::CSTORE), 2u);
+	BOOST_CHECK_EQUAL(countInstruction(optimized, Instruction::SSTORE), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(cse_cross_domain_sstore_cstore_sstore_preserves_all)
+{
+	// Reverse direction: SSTORE, then CSTORE, then SSTORE on same slot.
+	// Without the fix, CSE drops the first SSTORE.
+	AssemblyItems input{
+		u256(0x11),
+		u256(0),
+		Instruction::SSTORE,
+		u256(0x22),
+		u256(0),
+		Instruction::CSTORE,
+		u256(0x33),
+		u256(0),
+		Instruction::SSTORE
+	};
+	AssemblyItems optimized = CSE(input);
+
+	BOOST_CHECK_EQUAL(countInstruction(optimized, Instruction::SSTORE), 2u);
+	BOOST_CHECK_EQUAL(countInstruction(optimized, Instruction::CSTORE), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(cse_same_domain_duplicate_cstore_still_optimizes)
+{
+	// Two CSTOREs to the same slot with no cross-domain conflict —
+	// normal CSE optimization should still eliminate the first one.
+	AssemblyItems input{
+		u256(0x11),
+		u256(0),
+		Instruction::CSTORE,
+		u256(0x33),
+		u256(0),
+		Instruction::CSTORE
+	};
+	AssemblyItems optimized = CSE(input);
+
+	// Only the last CSTORE should survive (normal same-domain optimization)
+	BOOST_CHECK_EQUAL(countInstruction(optimized, Instruction::CSTORE), 1u);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

- The legacy CSE optimizer's dependency seeding only preserves the last store per `(target, slot)` pair. When both `CSTORE` (shielded) and `SSTORE` (public) target the same slot, earlier stores are dropped from the dependency graph. This can eliminate a `CSTORE` that privatizes a slot, letting a subsequent `SSTORE` succeed instead of reverting — a miscompilation that changes program semantics from revert to success.
- The fix detects slots with stores from both `Storage` and `ShieldedStorage` domains and adds dependencies for *all* stores on those slots, not just the last one. Non-conflicting slots retain the original optimization.

## Test plan

- [x] Added 3 unit tests in `test/libevmasm/Optimiser.cpp`:
  - `cse_cross_domain_cstore_sstore_cstore_preserves_all` — verifies both CSTOREs and the SSTORE survive CSE when targeting the same slot
  - `cse_cross_domain_sstore_cstore_sstore_preserves_all` — reverse direction (SSTORE→CSTORE→SSTORE)
  - `cse_same_domain_duplicate_cstore_still_optimizes` — confirms normal same-domain elision is unaffected
- [x] Tests fail before fix, pass after
- [x] Full `soltest` suite passes (8320 test cases, 0 failures)