### PR TITLE
fix(ci/release): avoid race condition in release asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,17 +185,11 @@ jobs:
           LATEST="${{ github.event.inputs.latest }}"
           LATEST_FLAG="--latest=${LATEST:-true}"
 
-          # Create release first
-          gh release create "$TAG_NAME" \
+          # Create release and upload assets in one step to avoid race condition
+          # (gh release upload can fail with "release not found" if called right after create)
+          shopt -s nullglob
+          gh release create "$TAG_NAME" *.tar.gz *.zip \
             --title "Release $TAG_NAME" \
             --notes "Automated release for commit $RESOLVED_SHA." \
             --target "$RESOLVED_SHA" \
             $LATEST_FLAG
-
-          # Then upload each asset separately
-          shopt -s nullglob
-          for file in *.tar.gz *.zip; do
-            echo "Uploading $file..."
-            gh release upload "$TAG_NAME" "$file" --clobber
-          done
-          shopt -u nullglob


### PR DESCRIPTION
## Summary
- Release workflow failed because `gh release upload` ran immediately after `gh release create` and got `release not found` due to GitHub API propagation delay ([failed run](https://github.com/SeismicSystems/seismic-solidity/actions/runs/24140996299/job/70448748683))
- Fix: pass assets directly as positional args to `gh release create`, making creation and upload atomic
- Added `nullglob` so unexpanded globs don't break the command if a pattern has no matches

## Test plan
- [ ] Re-run the release workflow and verify assets are uploaded successfully