### PR TITLE
fix(ci/release): use ARM64 runner for Linux arm64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,12 @@ on:
 jobs:
   build-release:
     name: Build and Archive Binaries
-    runs-on: ${{ matrix.os == 'ubuntu-22.04' && 'ssolc-ubuntu-22.04' || matrix.os }}
+    runs-on: >-
+      ${{
+        matrix.os == 'ubuntu-22.04' && 'ssolc-ubuntu-22.04' ||
+        matrix.os == 'ubuntu-latest' && matrix.arch == 'arm64' && 'ubuntu-24.04-arm' ||
+        matrix.os
+      }}
     strategy:
       fail-fast: false
       matrix:
@@ -47,6 +52,10 @@ jobs:
             arch: arm64
           - os: macos-latest-large
             arch: arm64 # since macos-latest-large is x86_64
+          - os: ubuntu-22.04 # self-hosted runner is x86_64 only
+            arch: arm64
+          - os: windows-latest # no ARM64 runner available
+            arch: arm64
     steps:
       # Checkout source code
       - name: Checkout source code


### PR DESCRIPTION
## Summary
- `ssolc-linux-arm64.tar.gz` was a mislabeled x86_64 binary — `ubuntu-latest` is an x86_64 runner and no cross-compilation was configured
- Same issue for `windows-latest` + `arm64` and `ubuntu-22.04` + `arm64` (self-hosted x86_64 runner)
- Use GitHub's `ubuntu-24.04-arm` runner for real Linux ARM64 builds
- Exclude `ubuntu-22.04` arm64 (self-hosted runner is x86_64) and `windows-latest` arm64 (no ARM runner available)

Closes #254

## Test plan
- [ ] Trigger a workflow_dispatch release and verify `ssolc-linux-arm64.tar.gz` is built on the ARM runner
- [ ] Verify `file` or `readelf` on the produced binary confirms `aarch64` architecture
- [ ] Confirm the excluded matrix entries (ubuntu-22.04 arm64, windows arm64) no longer appear as jobs