### PR TITLE
fix(ci/release): revert to separate create + upload with retry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,11 +194,27 @@ jobs:
           LATEST="${{ github.event.inputs.latest }}"
           LATEST_FLAG="--latest=${LATEST:-true}"
 
-          # Create release and upload assets in one step to avoid race condition
-          # (gh release upload can fail with "release not found" if called right after create)
-          shopt -s nullglob
-          gh release create "$TAG_NAME" *.tar.gz *.zip \
+          # Create the release first (without files — passing files inline
+          # triggers a 403 "Resource not accessible by integration" error).
+          gh release create "$TAG_NAME" \
             --title "Release $TAG_NAME" \
             --notes "Automated release for commit $RESOLVED_SHA." \
             --target "$RESOLVED_SHA" \
             $LATEST_FLAG
+
+          # Upload assets separately, retrying to avoid the race condition
+          # where the release isn't immediately visible after creation.
+          shopt -s nullglob
+          for file in *.tar.gz *.zip; do
+            for attempt in 1 2 3 4 5; do
+              echo "Uploading $file (attempt $attempt)..."
+              if gh release upload "$TAG_NAME" "$file" --clobber; then
+                break
+              fi
+              if [ "$attempt" -eq 5 ]; then
+                echo "Failed to upload $file after 5 attempts"
+                exit 1
+              fi
+              sleep 3
+            done
+          done


### PR DESCRIPTION
## Summary
- Passing files directly to `gh release create` causes a 403 `Resource not accessible by integration` error, even with `contents: write` permissions
- Reverts to the separate `gh release create` (no files) then `gh release upload` approach from before #253
- Adds a retry loop (5 attempts, 3s delay) to handle the race condition that #253 was trying to fix

## Context
The release workflow has been failing since #253 was merged. The root cause is that `gh release create TAG *.tar.gz *.zip` hits a different code path that the GITHUB_TOKEN doesn't have access to, while `gh release create TAG` (without files) works fine.

## Test plan
- [ ] Merge and verify the release workflow succeeds on the next push to `seismic`