### PR TITLE
test: add 77 shielded struct tests; fix via-IR ICE for shielded reference types

### DIFF
--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -3470,13 +3470,17 @@ void IRGeneratorForStatements::writeToLValue(IRLValue const& _lvalue, IRVariable
 					[&](std::string const& _offset) { offsetArgument = ", " + _offset; }
 				}, _storage.offset);
 
+				// For reference types (structs, arrays), shielded storage ops are
+				// handled per-member by the copy functions, not via the override flag.
+				// Only pass the shielded flag for value types.
+				bool useShieldedOps = _lvalue.type.isValueType() && _storage.usesShieldedStorage;
 				appendCode() <<
 					m_utils.updateStorageValueFunction(
 						_value.type(),
 						_lvalue.type,
 						VariableDeclaration::Location::Unspecified,
 						offsetStatic,
-						_storage.usesShieldedStorage
+						useShieldedOps
 					) <<
 					"(" <<
 					_storage.slot <<

--- a/test/libsolidity/semanticTests/storage/shielded_struct_accessor.sol
+++ b/test/libsolidity/semanticTests/storage/shielded_struct_accessor.sol
@@ -1,0 +1,16 @@
+contract test {
+    struct Data { suint256 a; suint8 b; mapping(uint => uint) c; sbool d; }
+    mapping(uint => Data) private data;
+    constructor() {
+        data[7].a = suint256(1);
+        data[7].b = suint8(2);
+        data[7].c[0] = 3;
+        data[7].d = sbool(true);
+    }
+    function getData(uint256 key) public returns (uint256, uint8, bool) {
+        Data storage d = data[key];
+        return (uint256(d.a), uint8(d.b), bool(d.d));
+    }
+}
+// ----
+// getData(uint256): 7 -> 1, 2, true

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_nested_structs.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_nested_structs.sol
@@ -1,0 +1,47 @@
+pragma abicoder v2;
+
+contract C {
+    struct S {
+        suint128 p1;
+        suint256[][2] a;
+        suint32 p2;
+    }
+
+    struct S1 {
+        suint128 u;
+        S s;
+    }
+
+    struct S2 {
+        S[2] array;
+    }
+
+    function f1(S1 calldata c) internal returns(S1 calldata) {
+        return c;
+    }
+
+    function f(S1 calldata c, uint32 p) external returns(uint32, uint128, uint256, uint256, uint32) {
+        S1 memory m = f1(c);
+        assert(uint256(m.s.a[0][0]) == uint256(c.s.a[0][0]));
+        assert(uint256(m.s.a[1][1]) == uint256(c.s.a[1][1]));
+        return (p, uint128(m.s.p1), uint256(m.s.a[0][0]), uint256(m.s.a[1][1]), uint32(m.s.p2));
+    }
+
+    function g(S2 calldata c) external returns(uint128, uint256, uint256, uint32) {
+        S2 memory m = c;
+        assert(uint256(m.array[0].a[0][0]) == uint256(c.array[0].a[0][0]));
+        assert(uint256(m.array[0].a[1][1]) == uint256(c.array[0].a[1][1]));
+        return (uint128(m.array[1].p1), uint256(m.array[1].a[0][0]), uint256(m.array[1].a[1][1]), uint32(m.array[1].p2));
+    }
+
+    function h(S1 calldata c, uint32 p) external returns(uint32, uint128, uint256, uint256, uint32) {
+        S memory m = c.s;
+        assert(uint256(m.a[0][0]) == uint256(c.s.a[0][0]));
+        assert(uint256(m.a[1][1]) == uint256(c.s.a[1][1]));
+        return (p, uint128(m.p1), uint256(m.a[0][0]), uint256(m.a[1][1]), uint32(m.p2));
+    }
+}
+// ----
+// f((suint128,(suint128,suint256[][2],suint32)),uint32): 0x40, 44, 11, 0x40, 22, 0x60, 33, 0x40, 0x40, 2, 1, 2 -> 44, 22, 1, 2, 33
+// g(((suint128,suint256[][2],suint32)[2])): 0x20, 0x20, 0x40, 0x40, 22, 0x60, 33, 0x40, 0x40, 2, 1, 2 -> 22, 1, 2, 33
+// h((suint128,(suint128,suint256[][2],suint32)),uint32): 0x40, 44, 11, 0x40, 22, 0x60, 33, 0x40, 0x40, 2, 1, 2 -> 44, 22, 1, 2, 33

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct.sol
@@ -1,0 +1,16 @@
+pragma abicoder               v2;
+
+
+contract C {
+    struct S {
+        suint256 a;
+        suint256 b;
+    }
+
+    function f(S calldata s) external pure returns (uint256 a, uint256 b) {
+        a = uint256(s.a);
+        b = uint256(s.b);
+    }
+}
+// ----
+// f((suint256,suint256)): 42, 23 -> 42, 23

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_and_ints.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_and_ints.sol
@@ -1,0 +1,19 @@
+pragma abicoder               v2;
+
+
+contract C {
+    struct S {
+        suint256 a;
+        suint256 b;
+    }
+
+    function f(suint256 a, S calldata s, suint256 b)
+        external
+        pure
+        returns (uint256, uint256, uint256, uint256)
+    {
+        return (uint256(a), uint256(s.a), uint256(s.b), uint256(b));
+    }
+}
+// ----
+// f(suint256,(suint256,suint256),suint256): 1, 2, 3, 4 -> 1, 2, 3, 4

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_array_member.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_array_member.sol
@@ -1,0 +1,23 @@
+pragma abicoder v2;
+
+
+contract C {
+    struct S {
+        suint256 a;
+        suint256[2] b;
+        suint256 c;
+    }
+
+    function f(S calldata s)
+        external
+        pure
+        returns (uint256 a, uint256 b0, uint256 b1, uint256 c)
+    {
+        a = uint256(s.a);
+        b0 = uint256(s.b[0]);
+        b1 = uint256(s.b[1]);
+        c = uint256(s.c);
+    }
+}
+// ----
+// f((suint256,suint256[2],suint256)): 42, 1, 2, 23 -> 42, 1, 2, 23

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_array_member_dynamic.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_array_member_dynamic.sol
@@ -1,0 +1,22 @@
+pragma abicoder v2;
+
+contract C {
+    struct S {
+        suint32 a;
+        suint256[] b;
+        suint64 c;
+    }
+
+    function f(S calldata s)
+        external
+        pure
+        returns (uint32 a, uint256 b0, uint256 b1, uint64 c)
+    {
+        a = uint32(s.a);
+        b0 = uint256(s.b[0]);
+        b1 = uint256(s.b[1]);
+        c = uint64(s.c);
+    }
+}
+// ----
+// f((suint32,suint256[],suint64)): 0x20, 42, 0x60, 23, 2, 1, 2 -> 42, 1, 2, 23

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_as_argument_of_lib_function.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_as_argument_of_lib_function.sol
@@ -1,0 +1,27 @@
+pragma abicoder v2;
+
+struct S {
+    suint128 p1;
+    suint256[][2] a;
+    suint32 p2;
+}
+struct S1 {
+    suint128 u;
+    S s;
+}
+
+library L {
+    function f(S1 memory m, uint32 p) external returns(uint32, uint128, uint256, uint256, uint32) {
+        return (p, uint128(m.s.p1), uint256(m.s.a[0][0]), uint256(m.s.a[1][1]), uint32(m.s.p2));
+    }
+}
+
+contract C {
+
+    function f(S1 calldata c, uint32 p) external returns(uint32, uint128, uint256, uint256, uint32) {
+        return L.f(c, p);
+    }
+}
+// ----
+// library: L
+// f((suint128,(suint128,suint256[][2],suint32)),uint32): 0x40, 44, 11, 0x40, 22, 0x60, 33, 0x40, 0x40, 2, 1, 2 -> 44, 22, 1, 2, 33

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_as_memory_argument.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_as_memory_argument.sol
@@ -1,0 +1,21 @@
+pragma abicoder v2;
+
+contract C {
+    struct S {
+        suint128 p1;
+        suint256[][2] a;
+        suint32 p2;
+    }
+
+    function g(uint32 p1, S memory s) internal returns(uint32, uint128, uint256, uint256, uint32) {
+        s.p1 = suint128(uint128(s.p1) + 1);
+        s.a[0][1] = suint256(uint256(s.a[0][1]) + 1);
+        return (p1, uint128(s.p1), uint256(s.a[0][0]), uint256(s.a[1][1]), uint32(s.p2));
+    }
+
+    function f(uint32 p1, S calldata c) external returns(uint32, uint128, uint256, uint256, uint32) {
+        return g(p1, c);
+    }
+}
+// ----
+// f(uint32,(suint128,suint256[][2],suint32)): 55, 0x40, 77, 0x60, 88, 0x40, 0x40, 2, 1, 2 -> 55, 78, 1, 2, 88

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_struct_member.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_struct_member.sol
@@ -1,0 +1,26 @@
+pragma abicoder v2;
+
+contract C {
+    struct S {
+        suint64 a;
+        suint64 b;
+    }
+    struct S1 {
+        suint256 a;
+        S s;
+        suint256 c;
+    }
+
+    function f(S1 calldata s1)
+        external
+        pure
+        returns (uint256 a, uint64 b0, uint64 b1, uint256 c)
+    {
+        a = uint256(s1.a);
+        b0 = uint64(s1.s.a);
+        b1 = uint64(s1.s.b);
+        c = uint256(s1.c);
+    }
+}
+// ----
+// f((suint256,(suint64,suint64),suint256)): 42, 1, 2, 23 -> 42, 1, 2, 23

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_struct_member_dynamic.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_struct_member_dynamic.sol
@@ -1,0 +1,26 @@
+pragma abicoder v2;
+
+contract C {
+    struct S {
+        suint64 a;
+        bytes b;
+    }
+    struct S1 {
+        suint256 a;
+        S s;
+        suint256 c;
+    }
+
+    function f(S1 calldata s1)
+        external
+        pure
+        returns (uint256 a, uint64 b0, bytes1 b1, uint256 c)
+    {
+        a = uint256(s1.a);
+        b0 = uint64(s1.s.a);
+        b1 = s1.s.b[0];
+        c = uint256(s1.c);
+    }
+}
+// ----
+// f((suint256,(suint64,bytes),suint256)): 0x20, 42, 0x60, 23, 1, 0x40, 2, "ab" -> 42, 1, "a", 23

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_to_memory.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_to_memory.sol
@@ -1,0 +1,16 @@
+pragma abicoder v2;
+
+contract C {
+    struct S {
+        suint256 a;
+        suint256 b;
+        sbytes2 c;
+    }
+
+    function f(S calldata s) external pure returns (uint256, uint256, bytes1) {
+        S memory m = s;
+        return (uint256(m.a), uint256(m.b), bytes2(m.c)[1]);
+    }
+}
+// ----
+// f((suint256,suint256,sbytes2)): 42, 23, "ab" -> 42, 23, "b"

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_to_memory_tuple_assignment.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_to_memory_tuple_assignment.sol
@@ -1,0 +1,20 @@
+pragma abicoder v2;
+
+contract C {
+    struct S {
+        suint128 p1;
+        suint256[][2] a;
+        suint32 p2;
+    }
+
+    function f(uint32 p1, S calldata c) external returns(uint32, uint128, uint256, uint256, uint32) {
+        S memory m;
+        uint32 p2;
+        (p2, m) = (p1, c);
+        m.p1 = suint128(uint128(m.p1) + 1);
+        m.a[0][1] = suint256(uint256(m.a[0][1]) + 1);
+        return (p2, uint128(m.p1), uint256(m.a[0][0]), uint256(m.a[1][1]), uint32(m.p2));
+    }
+}
+// ----
+// f(uint32,(suint128,suint256[][2],suint32)): 55, 0x40, 77, 0x60, 88, 0x40, 0x40, 2, 1, 2 -> 55, 78, 1, 2, 88

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_to_storage.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_to_storage.sol
@@ -1,0 +1,19 @@
+pragma abicoder v2;
+
+contract C {
+    struct S {
+        suint256 a;
+        suint64 b;
+        bytes2 c;
+    }
+
+    uint[153] r;
+    S s;
+
+    function f(uint32 a, S calldata c, uint256 b) external returns (uint256, uint64, bytes1) {
+        s = c;
+        return (uint256(s.a), uint64(s.b), s.c[1]);
+    }
+}
+// ----
+// f(uint32,(suint256,suint64,bytes2),uint256): 1, 42, 23, "ab", 1 -> 42, 23, "b"

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_with_array_to_memory.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_with_array_to_memory.sol
@@ -1,0 +1,20 @@
+pragma abicoder v2;
+
+contract C {
+    struct S {
+        suint256 a;
+        suint256[2] b;
+        suint256 c;
+    }
+
+    function f(S calldata c)
+        external
+        pure
+        returns (uint256, uint256, uint256, uint256)
+    {
+        S memory m = c;
+        return (uint256(m.a), uint256(m.b[0]), uint256(m.b[1]), uint256(m.c));
+    }
+}
+// ----
+// f((suint256,suint256[2],suint256)): 42, 1, 2, 23 -> 42, 1, 2, 23

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_with_bytes_to_memory.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_with_bytes_to_memory.sol
@@ -1,0 +1,20 @@
+pragma abicoder v2;
+
+contract C {
+    struct S {
+        suint256 a;
+        bytes b;
+        suint256 c;
+    }
+
+    function f(S calldata c)
+        external
+        pure
+        returns (uint256, bytes1, bytes1, uint256)
+    {
+        S memory m = c;
+        return (uint256(m.a), m.b[0], m.b[1], uint256(m.c));
+    }
+}
+// ----
+// f((suint256,bytes,suint256)): 0x20, 42, 0x60, 23, 2, "ab" -> 42, "a", "b", 23

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_with_nested_array_to_memory.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_with_nested_array_to_memory.sol
@@ -1,0 +1,21 @@
+pragma abicoder v2;
+
+contract C {
+    struct S {
+        suint128 p1;
+        suint256[][2] a;
+        suint32 p2;
+    }
+    function f(uint32 p1, S calldata c) external returns(uint32, uint128, uint256, uint256, uint32) {
+        S memory s = c;
+        assert(uint256(s.a[0][0]) == uint256(c.a[0][0]));
+        assert(uint256(s.a[1][1]) == uint256(c.a[1][1]));
+        s.p1 = suint128(uint128(s.p1) + 1);
+        assert(uint128(s.p1) != uint128(c.p1));
+        s.a[0][1] = suint256(uint256(s.a[0][1]) + 1);
+        assert(uint256(s.a[0][1]) != uint256(c.a[0][1]));
+        return (p1, uint128(s.p1), uint256(s.a[0][0]), uint256(s.a[1][1]), uint32(s.p2));
+    }
+}
+// ----
+// f(uint32,(suint128,suint256[][2],suint32)): 55, 0x40, 77, 0x60, 88, 0x40, 0x40, 2, 1, 2 -> 55, 78, 1, 2, 88

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_with_nested_array_to_storage.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_struct_with_nested_array_to_storage.sol
@@ -1,0 +1,18 @@
+pragma abicoder               v2;
+
+contract C {
+    struct S {
+        suint128 p1;
+        suint256[][2] a;
+        suint32 p2;
+    }
+    S s;
+    function f(uint32 p1, S calldata c) external returns(uint32, uint128, uint256, uint256, uint32) {
+        s = c;
+        assert(uint256(s.a[0][0]) == uint256(c.a[0][0]));
+        assert(uint256(s.a[1][1]) == uint256(c.a[1][1]));
+        return (p1, uint128(s.p1), uint256(s.a[0][0]), uint256(s.a[1][1]), uint32(s.p2));
+    }
+}
+// ----
+// f(uint32,(suint128,suint256[][2],suint32)): 55, 0x40, 77, 0x60, 88, 0x40, 0x40, 2, 1, 2 -> 55, 77, 1, 2, 88

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_structs.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_calldata_structs.sol
@@ -1,0 +1,26 @@
+pragma abicoder               v2;
+
+
+contract C {
+    struct S1 {
+        suint256 a;
+        suint256 b;
+    }
+    struct S2 {
+        suint256 a;
+    }
+
+    function f(S1 calldata s1, S2 calldata s2, S1 calldata s3)
+        external
+        pure
+        returns (uint256 a, uint256 b, uint256 c, uint256 d, uint256 e)
+    {
+        a = uint256(s1.a);
+        b = uint256(s1.b);
+        c = uint256(s2.a);
+        d = uint256(s3.a);
+        e = uint256(s3.b);
+    }
+}
+// ----
+// f((suint256,suint256),(suint256),(suint256,suint256)): 1, 2, 3, 4, 5 -> 1, 2, 3, 4, 5

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_dynamic_nested.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_dynamic_nested.sol
@@ -1,0 +1,11 @@
+pragma abicoder               v2;
+
+contract C {
+	struct S2 { suint256 b; }
+	struct S { suint256 a; S2[] children; }
+	function f(S calldata s) external pure returns (uint256, uint256, uint256, uint256) {
+		return (uint256(s.children.length), uint256(s.a), uint256(s.children[0].b), uint256(s.children[1].b));
+	}
+}
+// ----
+// f((suint256,(suint256)[])): 32, 17, 64, 2, 23, 42 -> 2, 17, 23, 42

--- a/test/libsolidity/semanticTests/structs/calldata/shielded_dynamically_encoded.sol
+++ b/test/libsolidity/semanticTests/structs/calldata/shielded_dynamically_encoded.sol
@@ -1,0 +1,10 @@
+pragma abicoder               v2;
+
+contract C {
+	struct S { suint256[] a; }
+	function f(S calldata s) external pure returns (uint256 a, uint256 b, uint256 c) {
+	    return (uint256(s.a.length), uint256(s.a[0]), uint256(s.a[1]));
+	}
+}
+// ----
+// f((suint256[])): 32, 32, 2, 42, 23 -> 2, 42, 23

--- a/test/libsolidity/semanticTests/structs/shielded_copy_from_mapping.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_copy_from_mapping.sol
@@ -1,0 +1,46 @@
+contract c {
+    struct Nested {
+        suint256 x;
+        suint256 y;
+    }
+    struct Struct {
+        suint256 a;
+        Nested nested;
+        suint256 c;
+    }
+    mapping(uint256 => Struct) data;
+
+    function set(uint256 k) public returns (bool) {
+        data[k].a = suint256(1);
+        data[k].nested.x = suint256(3);
+        data[k].nested.y = suint256(4);
+        data[k].c = suint256(2);
+        return true;
+    }
+
+    function copy(uint256 from, uint256 to) public returns (bool) {
+        data[to] = data[from];
+        return true;
+    }
+
+    function retrieve(uint256 k)
+        public
+        returns (uint256 a, uint256 x, uint256 y, uint256 c)
+    {
+        a = uint256(data[k].a);
+        x = uint256(data[k].nested.x);
+        y = uint256(data[k].nested.y);
+        c = uint256(data[k].c);
+    }
+}
+// ----
+// set(uint256): 7 -> true
+// retrieve(uint256): 7 -> 1, 3, 4, 2
+// copy(uint256,uint256): 7, 8 -> true
+// retrieve(uint256): 7 -> 1, 3, 4, 2
+// retrieve(uint256): 8 -> 1, 3, 4, 2
+// copy(uint256,uint256): 0, 7 -> true
+// retrieve(uint256): 7 -> 0, 0, 0, 0
+// retrieve(uint256): 8 -> 1, 3, 4, 2
+// copy(uint256,uint256): 7, 8 -> true
+// retrieve(uint256): 8 -> 0, 0, 0, 0

--- a/test/libsolidity/semanticTests/structs/shielded_copy_from_storage.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_copy_from_storage.sol
@@ -1,0 +1,24 @@
+pragma abicoder v2;
+// Shielded version of copy_from_storage.sol
+struct S {
+    suint256 x;
+}
+
+contract C {
+    S sStorage;
+    constructor() {
+        sStorage.x = suint256(13);
+    }
+
+    // Cannot return S[] memory with shielded fields from public function,
+    // so return the extracted value instead.
+    function f() external returns (uint256) {
+        S[] memory sMemory = new S[](1);
+
+        sMemory[0] = sStorage;
+
+        return uint256(sMemory[0].x);
+    }
+}
+// ----
+// f() -> 13

--- a/test/libsolidity/semanticTests/structs/shielded_copy_struct_array_from_storage.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_copy_struct_array_from_storage.sol
@@ -1,0 +1,90 @@
+pragma abicoder v2;
+
+struct S { suint256 value; }
+
+contract Test {
+    S[][] a;
+    S[] b;
+
+    constructor() {
+        a.push();
+        a[0].push(S(suint256(1)));
+        a[0].push(S(suint256(2)));
+        a[0].push(S(suint256(3)));
+
+        b.push(S(suint256(4)));
+        b.push(S(suint256(5)));
+        b.push(S(suint256(6)));
+        b.push(S(suint256(7)));
+    }
+
+    function test1() external returns (bool) {
+        a.push();
+        a[1] = b;
+
+        assert(uint256(a.length) == 2);
+        assert(uint256(a[0].length) == 3);
+        assert(uint256(a[1].length) == 4);
+        assert(uint256(a[1][0].value) == 4);
+        assert(uint256(a[1][1].value) == 5);
+        assert(uint256(a[1][2].value) == 6);
+        assert(uint256(a[1][3].value) == 7);
+
+        return true;
+    }
+
+    function test2() external returns (bool) {
+        S[][] memory temp = new S[][](2);
+
+        temp = a;
+
+        assert(uint256(temp.length) == 2);
+        assert(uint256(temp[0].length) == 3);
+        assert(uint256(temp[1].length) == 4);
+        assert(uint256(temp[1][0].value) == 4);
+        assert(uint256(temp[1][1].value) == 5);
+        assert(uint256(temp[1][2].value) == 6);
+        assert(uint256(temp[1][3].value) == 7);
+
+        return true;
+    }
+
+    function test3() external returns (bool) {
+        S[][] memory temp = new S[][](2);
+
+        temp[0] = a[0];
+        temp[1] = a[1];
+
+        assert(uint256(temp.length) == 2);
+        assert(uint256(temp[0].length) == 3);
+        assert(uint256(temp[1].length) == 4);
+        assert(uint256(temp[1][0].value) == 4);
+        assert(uint256(temp[1][1].value) == 5);
+        assert(uint256(temp[1][2].value) == 6);
+        assert(uint256(temp[1][3].value) == 7);
+
+        return true;
+    }
+
+    function test4() external returns (bool) {
+        S[][] memory temp = new S[][](2);
+
+        temp[0] = a[0];
+        temp[1] = b;
+
+        assert(uint256(temp.length) == 2);
+        assert(uint256(temp[0].length) == 3);
+        assert(uint256(temp[1].length) == 4);
+        assert(uint256(temp[1][0].value) == 4);
+        assert(uint256(temp[1][1].value) == 5);
+        assert(uint256(temp[1][2].value) == 6);
+        assert(uint256(temp[1][3].value) == 7);
+
+        return true;
+    }
+}
+// ----
+// test1() -> true
+// test2() -> true
+// test3() -> true
+// test4() -> true

--- a/test/libsolidity/semanticTests/structs/shielded_copy_struct_with_nested_array_from_calldata_to_memory.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_copy_struct_with_nested_array_from_calldata_to_memory.sol
@@ -1,0 +1,30 @@
+pragma abicoder v2;
+// Shielded version of copy_struct_with_nested_array_from_calldata_to_memory.sol
+
+contract C {
+    struct S {
+        suint8[1] x;
+        suint8[] y;
+    }
+
+    // Cannot return S memory with shielded fields, so return individual values.
+    function test(S calldata s) public returns (uint8 x0, uint256 yLen, uint8 y0, uint8 y1) {
+        S memory m = s;
+        x0 = uint8(m.x[0]);
+        yLen = uint256(m.y.length);
+        y0 = uint8(m.y[0]);
+        y1 = uint8(m.y[1]);
+    }
+
+    function test2(S calldata s) public returns (uint8 x0, uint256 yLen, uint8 y0, uint8 y1, uint8 y2) {
+        S memory m = s;
+        x0 = uint8(m.x[0]);
+        yLen = uint256(m.y.length);
+        y0 = uint8(m.y[0]);
+        y1 = uint8(m.y[1]);
+        y2 = uint8(m.y[2]);
+    }
+}
+// ----
+// test((suint8[1],suint8[])): 0x20, 3, 0x40, 2, 7, 11 -> 3, 2, 7, 11
+// test2((suint8[1],suint8[])): 0x20, 3, 0x40, 3, 17, 19, 23 -> 3, 3, 17, 19, 23

--- a/test/libsolidity/semanticTests/structs/shielded_copy_struct_with_nested_array_from_calldata_to_storage.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_copy_struct_with_nested_array_from_calldata_to_storage.sol
@@ -1,0 +1,22 @@
+pragma abicoder v2;
+// Shielded version of copy_struct_with_nested_array_from_calldata_to_storage.sol
+
+contract C {
+    struct S {
+        suint8[1] x;
+        suint8[] y;
+    }
+
+    S s;
+
+    function test(S calldata src) public {
+        s = src;
+
+        require(uint8(s.x[0]) == 3);
+        require(uint256(s.y.length) == 2);
+        require(uint8(s.y[0]) == 7);
+        require(uint8(s.y[1]) == 11);
+    }
+}
+// ----
+// test((suint8[1],suint8[])): 0x20, 3, 0x40, 2, 7, 11

--- a/test/libsolidity/semanticTests/structs/shielded_copy_struct_with_nested_array_from_memory_to_memory.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_copy_struct_with_nested_array_from_memory_to_memory.sol
@@ -1,0 +1,20 @@
+pragma abicoder v2;
+// Shielded version of copy_struct_with_nested_array_from_memory_to_memory.sol
+
+contract C {
+    struct S {
+        suint8[1] x;
+        suint8[] y;
+    }
+
+    // Cannot return S memory with shielded fields.
+    // Original returns default-initialized r, so x[0] = 0, y = empty.
+    function test(S memory s) public returns (uint8 x0, uint256 yLen) {
+        S memory r;
+        x0 = uint8(r.x[0]);
+        yLen = uint256(r.y.length);
+    }
+}
+// ----
+// test((suint8[1],suint8[])): 0x20, 3, 0x40, 2, 7, 11 -> 0, 0
+// test((suint8[1],suint8[])): 0x20, 3, 0x40, 3, 17, 19, 23 -> 0, 0

--- a/test/libsolidity/semanticTests/structs/shielded_copy_struct_with_nested_array_from_storage_to_storage.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_copy_struct_with_nested_array_from_storage_to_storage.sol
@@ -1,0 +1,28 @@
+// Shielded version of copy_struct_with_nested_array_from_storage_to_storage.sol
+
+contract C {
+    struct S {
+        suint8[1] x;
+        suint8[] y;
+    }
+
+    S src;
+    S dst;
+
+    constructor() {
+        src.x[0] = suint8(3);
+        src.y.push(suint8(7));
+        src.y.push(suint8(11));
+    }
+
+    function test() public {
+        dst = src;
+
+        require(uint8(dst.x[0]) == 3);
+        require(uint256(dst.y.length) == 2);
+        require(uint8(dst.y[0]) == 7);
+        require(uint8(dst.y[1]) == 11);
+    }
+}
+// ----
+// test()

--- a/test/libsolidity/semanticTests/structs/shielded_copy_substructures_from_mapping.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_copy_substructures_from_mapping.sol
@@ -1,0 +1,67 @@
+pragma abicoder v2;
+// Shielded version of copy_substructures_from_mapping.sol
+
+contract C {
+    struct S {
+        bytes b;
+        suint16[] a;
+        suint16 u;
+    }
+
+    struct SUnshielded {
+        bytes b;
+        uint16[] a;
+        uint16 u;
+    }
+
+    constructor() {
+        suint16[] memory a = new suint16[](2);
+        a[0] = suint16(13);
+        a[1] = suint16(14);
+
+        m[7] = S({b: "foo", a: a, u: suint16(7)});
+    }
+
+    mapping (uint => S) m;
+    S s;
+
+    function _toUnshielded(S storage src) internal view returns (SUnshielded memory r) {
+        r.b = src.b;
+        uint256 len = uint256(src.a.length);
+        r.a = new uint16[](len);
+        for (uint256 i = 0; i < len; i++) {
+            r.a[i] = uint16(src.a[i]);
+        }
+        r.u = uint16(src.u);
+    }
+
+    function to_state() public returns (SUnshielded memory) {
+        s.b = m[7].b;
+        s.a = m[7].a;
+        s.u = m[7].u;
+        return _toUnshielded(s);
+    }
+
+    function to_storage() public returns (SUnshielded memory) {
+        S storage sLocal = s;
+        sLocal.b = m[7].b;
+        sLocal.a = m[7].a;
+        sLocal.u = m[7].u;
+        return _toUnshielded(sLocal);
+    }
+
+    function to_memory() public returns (SUnshielded memory) {
+        S memory sLocal;
+        sLocal.b = m[7].b;
+        sLocal.a = m[7].a;
+        sLocal.u = m[7].u;
+        // Copy memory struct to storage so we can convert via _toUnshielded
+        s = sLocal;
+        return _toUnshielded(s);
+    }
+
+}
+// ----
+// to_state() -> 0x20, 0x60, 0xa0, 7, 3, 0x666F6F0000000000000000000000000000000000000000000000000000000000, 2, 13, 14
+// to_storage() -> 0x20, 0x60, 0xa0, 7, 3, 0x666F6F0000000000000000000000000000000000000000000000000000000000, 2, 13, 14
+// to_memory() -> 0x20, 0x60, 0xa0, 7, 3, 0x666F6F0000000000000000000000000000000000000000000000000000000000, 2, 13, 14

--- a/test/libsolidity/semanticTests/structs/shielded_copy_substructures_to_mapping.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_copy_substructures_to_mapping.sol
@@ -1,0 +1,73 @@
+pragma abicoder v2;
+// Shielded version of copy_substructures_to_mapping.sol
+
+contract C {
+    struct S {
+        bytes b;
+        suint16[] a;
+        suint16 u;
+    }
+
+    struct SUnshielded {
+        bytes b;
+        uint16[] a;
+        uint16 u;
+    }
+
+    S s;
+    constructor() {
+        suint16[] memory a = new suint16[](2);
+        a[0] = suint16(13);
+        a[1] = suint16(14);
+
+        s.b = "foo";
+        s.a = a;
+        s.u = suint16(21);
+    }
+
+    mapping (uint => S) m;
+
+    function _toUnshielded(S storage src) internal view returns (SUnshielded memory r) {
+        r.b = src.b;
+        uint256 len = uint256(src.a.length);
+        r.a = new uint16[](len);
+        for (uint256 i = 0; i < len; i++) {
+            r.a[i] = uint16(src.a[i]);
+        }
+        r.u = uint16(src.u);
+    }
+
+    function from_memory() public returns (SUnshielded memory) {
+        S memory sMemory = s;
+        m[0].b = sMemory.b;
+        m[0].a = sMemory.a;
+        m[0].u = sMemory.u;
+        return _toUnshielded(m[0]);
+    }
+
+    function from_state() public returns (SUnshielded memory) {
+        m[1].b = s.b;
+        m[1].a = s.a;
+        m[1].u = s.u;
+        return _toUnshielded(m[1]);
+    }
+
+    function from_storage() public returns (SUnshielded memory) {
+        S storage sLocal = s;
+        m[1].b = sLocal.b;
+        m[1].a = sLocal.a;
+        m[1].u = sLocal.u;
+        return _toUnshielded(m[1]);
+    }
+
+    function from_calldata(S calldata sCalldata) public returns (SUnshielded memory) {
+        m[2].b = sCalldata.b;
+        m[2].a = sCalldata.a;
+        m[2].u = sCalldata.u;
+        return _toUnshielded(m[2]);
+    }
+}
+// ----
+// from_memory() -> 0x20, 0x60, 0xa0, 0x15, 3, 0x666F6F0000000000000000000000000000000000000000000000000000000000, 2, 13, 14
+// from_state() -> 0x20, 0x60, 0xa0, 21, 3, 0x666F6F0000000000000000000000000000000000000000000000000000000000, 2, 13, 14
+// from_calldata((bytes,suint16[],suint16)): 0x20, 0x60, 0xa0, 21, 3, 0x666F6F0000000000000000000000000000000000000000000000000000000000, 2, 13, 14 -> 0x20, 0x60, 0xa0, 0x15, 3, 0x666F6F0000000000000000000000000000000000000000000000000000000000, 2, 13, 14

--- a/test/libsolidity/semanticTests/structs/shielded_copy_to_mapping.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_copy_to_mapping.sol
@@ -1,0 +1,66 @@
+pragma abicoder v2;
+// Shielded version of copy_to_mapping.sol
+
+contract C {
+    struct S {
+        bytes b;
+        suint16[] a;
+        suint16 u;
+    }
+
+    struct SUnshielded {
+        bytes b;
+        uint16[] a;
+        uint16 u;
+    }
+
+    S s;
+    constructor() {
+        suint16[] memory a = new suint16[](2);
+        a[0] = suint16(13);
+        a[1] = suint16(14);
+
+        s.b = "foo";
+        s.a = a;
+        s.u = suint16(21);
+    }
+
+    mapping (uint => S) m;
+
+    function _toUnshielded(S storage src) internal view returns (SUnshielded memory r) {
+        r.b = src.b;
+        uint256 len = uint256(src.a.length);
+        r.a = new uint16[](len);
+        for (uint256 i = 0; i < len; i++) {
+            r.a[i] = uint16(src.a[i]);
+        }
+        r.u = uint16(src.u);
+    }
+
+    function from_state() public returns (SUnshielded memory) {
+        m[0] = s;
+        return _toUnshielded(m[0]);
+    }
+
+    function from_storage() public returns (SUnshielded memory) {
+        S storage sLocal = s;
+        m[1] = sLocal;
+        return _toUnshielded(m[1]);
+    }
+
+    function from_memory() public returns (SUnshielded memory) {
+        S memory sMemory = s;
+        m[2] = sMemory;
+        return _toUnshielded(m[2]);
+    }
+
+    function from_calldata(S calldata sCalldata) public returns (SUnshielded memory) {
+        m[3] = sCalldata;
+        return _toUnshielded(m[3]);
+    }
+}
+// ----
+// from_state() -> 0x20, 0x60, 0xa0, 21, 3, 0x666F6F0000000000000000000000000000000000000000000000000000000000, 2, 13, 14
+// from_storage() -> 0x20, 0x60, 0xa0, 21, 3, 0x666F6F0000000000000000000000000000000000000000000000000000000000, 2, 13, 14
+// from_memory() -> 0x20, 0x60, 0xa0, 21, 3, 0x666F6F0000000000000000000000000000000000000000000000000000000000, 2, 13, 14
+// from_calldata((bytes,suint16[],suint16)): 0x20, 0x60, 0xa0, 21, 3, 0x666F6F0000000000000000000000000000000000000000000000000000000000, 2, 13, 14 -> 0x20, 0x60, 0xa0, 21, 3, 0x666f6f0000000000000000000000000000000000000000000000000000000000, 2, 13, 14

--- a/test/libsolidity/semanticTests/structs/shielded_delete_struct.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_delete_struct.sol
@@ -1,0 +1,48 @@
+contract test {
+    struct topStruct {
+        nestedStruct nstr;
+        suint256 topValue;
+        mapping (uint => uint) topMapping;
+    }
+    suint256 toDelete;
+    topStruct str;
+    struct nestedStruct {
+        suint256 nestedValue;
+        mapping (uint => bool) nestedMapping;
+    }
+    constructor() {
+        toDelete = suint256(5);
+        str.topValue = suint256(1);
+        str.topMapping[0] = 1;
+        str.topMapping[1] = 2;
+
+        str.nstr.nestedValue = suint256(2);
+        str.nstr.nestedMapping[0] = true;
+        str.nstr.nestedMapping[1] = false;
+        delete str;
+        delete toDelete;
+    }
+    function getToDelete() public returns (uint256 res){
+        res = uint256(toDelete);
+    }
+    function getTopValue() public returns(uint256 topValue){
+        topValue = uint256(str.topValue);
+    }
+    function getNestedValue() public returns(uint256 nestedValue){
+        nestedValue = uint256(str.nstr.nestedValue);
+    }
+    function getTopMapping(uint index) public returns(uint ret) {
+        ret = str.topMapping[index];
+    }
+    function getNestedMapping(uint index) public returns(bool ret) {
+        return str.nstr.nestedMapping[index];
+    }
+}
+// ----
+// getToDelete() -> 0
+// getTopValue() -> 0
+// getNestedValue() -> 0 #mapping values should be the same#
+// getTopMapping(uint256): 0 -> 1
+// getTopMapping(uint256): 1 -> 2
+// getNestedMapping(uint256): 0 -> true
+// getNestedMapping(uint256): 1 -> false

--- a/test/libsolidity/semanticTests/structs/shielded_event.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_event.sol
@@ -1,0 +1,19 @@
+pragma abicoder v2;
+
+struct Item { suint256 x; }
+library L {
+    event Ev(uint256);
+    function o() public {
+        Item memory item = Item(suint256(1));
+        emit L.Ev(uint256(item.x));
+    }
+}
+contract C {
+    function f() public {
+        L.o();
+    }
+}
+// ----
+// library: L
+// f() ->
+// ~ emit Ev(uint256): 0x01

--- a/test/libsolidity/semanticTests/structs/shielded_global.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_global.sol
@@ -1,0 +1,10 @@
+pragma abicoder               v2;
+
+struct S { suint256 a; suint256 b; }
+contract C {
+    function f(S calldata s) external pure returns (uint256, uint256) {
+        return (uint256(s.a), uint256(s.b));
+    }
+}
+// ----
+// f((suint256,suint256)): 42, 23 -> 42, 23

--- a/test/libsolidity/semanticTests/structs/shielded_lone_struct_array_type.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_lone_struct_array_type.sol
@@ -1,0 +1,13 @@
+contract C {
+    struct s {
+        suint256 a;
+        suint256 b;
+    }
+
+    function f() public returns (uint256) {
+        s[7][]; // This is only the type, should not have any effect
+        return 3;
+    }
+}
+// ----
+// f() -> 3

--- a/test/libsolidity/semanticTests/structs/shielded_memory_struct_named_constructor.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_memory_struct_named_constructor.sol
@@ -1,0 +1,16 @@
+pragma abicoder               v2;
+
+contract C {
+    struct S {
+        suint256 a;
+        sbool x;
+    }
+
+    function s() public returns(uint256, bool)
+    {
+        S memory r = S({x: sbool(true), a: suint256(8)});
+        return (uint256(r.a), bool(r.x));
+    }
+}
+// ----
+// s() -> 8, true

--- a/test/libsolidity/semanticTests/structs/shielded_memory_structs_as_function_args.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_memory_structs_as_function_args.sol
@@ -1,0 +1,31 @@
+contract Test {
+    struct S {
+        suint8 x;
+        suint16 y;
+        suint256 z;
+    }
+
+    function test() public returns (uint256 x, uint256 y, uint256 z) {
+        S memory data = combine(suint8(1), suint16(2), suint256(3));
+        x = extract(data, 0);
+        y = extract(data, 1);
+        z = extract(data, 2);
+    }
+
+    function extract(S memory s, uint256 which) internal returns (uint256 x) {
+        if (which == 0) return uint8(s.x);
+        else if (which == 1) return uint16(s.y);
+        else return uint256(s.z);
+    }
+
+    function combine(suint8 x, suint16 y, suint256 z)
+        internal
+        returns (S memory s)
+    {
+        s.x = x;
+        s.y = y;
+        s.z = z;
+    }
+}
+// ----
+// test() -> 1, 2, 3

--- a/test/libsolidity/semanticTests/structs/shielded_memory_structs_nested.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_memory_structs_nested.sol
@@ -1,0 +1,41 @@
+contract Test {
+    struct S {
+        suint8 x;
+        suint16 y;
+        suint256 z;
+    }
+    struct X {
+        suint8 x;
+        S s;
+    }
+
+    function test()
+        public
+        returns (uint256 a, uint256 x, uint256 y, uint256 z)
+    {
+        X memory d = combine(suint8(1), suint8(2), suint16(3), suint256(4));
+        a = extract(d, 0);
+        x = extract(d, 1);
+        y = extract(d, 2);
+        z = extract(d, 3);
+    }
+
+    function extract(X memory s, uint256 which) internal returns (uint256 x) {
+        if (which == 0) return uint8(s.x);
+        else if (which == 1) return uint8(s.s.x);
+        else if (which == 2) return uint16(s.s.y);
+        else return uint256(s.s.z);
+    }
+
+    function combine(suint8 a, suint8 x, suint16 y, suint256 z)
+        internal
+        returns (X memory s)
+    {
+        s.x = a;
+        s.s.x = x;
+        s.s.y = y;
+        s.s.z = z;
+    }
+}
+// ----
+// test() -> 1, 2, 3, 4

--- a/test/libsolidity/semanticTests/structs/shielded_memory_structs_nested_load.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_memory_structs_nested_load.sol
@@ -1,0 +1,69 @@
+contract Test {
+    struct S {
+        suint8 x;
+        suint16 y;
+        suint256 z;
+    }
+    struct X {
+        suint8 x;
+        S s;
+        suint8[2] a;
+    }
+    X m_x;
+
+    function load()
+        public
+        returns (
+            uint256 a,
+            uint256 x,
+            uint256 y,
+            uint256 z,
+            uint256 a1,
+            uint256 a2
+        )
+    {
+        m_x.x = suint8(1);
+        m_x.s.x = suint8(2);
+        m_x.s.y = suint16(3);
+        m_x.s.z = suint256(4);
+        m_x.a[0] = suint8(5);
+        m_x.a[1] = suint8(6);
+        X memory d = m_x;
+        a = uint8(d.x);
+        x = uint8(d.s.x);
+        y = uint16(d.s.y);
+        z = uint256(d.s.z);
+        a1 = uint8(d.a[0]);
+        a2 = uint8(d.a[1]);
+    }
+
+    function store()
+        public
+        returns (
+            uint256 a,
+            uint256 x,
+            uint256 y,
+            uint256 z,
+            uint256 a1,
+            uint256 a2
+        )
+    {
+        X memory d;
+        d.x = suint8(1);
+        d.s.x = suint8(2);
+        d.s.y = suint16(3);
+        d.s.z = suint256(4);
+        d.a[0] = suint8(5);
+        d.a[1] = suint8(6);
+        m_x = d;
+        a = uint8(m_x.x);
+        x = uint8(m_x.s.x);
+        y = uint16(m_x.s.y);
+        z = uint256(m_x.s.z);
+        a1 = uint8(m_x.a[0]);
+        a2 = uint8(m_x.a[1]);
+    }
+}
+// ----
+// load() -> 0x01, 0x02, 0x03, 0x04, 0x05, 0x06
+// store() -> 0x01, 0x02, 0x03, 0x04, 0x05, 0x06

--- a/test/libsolidity/semanticTests/structs/shielded_memory_structs_read_write.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_memory_structs_read_write.sol
@@ -1,0 +1,55 @@
+contract Test {
+    struct S {
+        suint8 x;
+        suint16 y;
+        suint256 z;
+        suint8[2] a;
+    }
+    S[5] data;
+
+    function testInit()
+        public
+        returns (uint8 x, uint16 y, uint256 z, uint8 a, bool flag)
+    {
+        S[2] memory d;
+        x = uint8(d[0].x);
+        y = uint16(d[0].y);
+        z = uint256(d[0].z);
+        a = uint8(d[0].a[1]);
+        flag = true;
+    }
+
+    function testCopyRead()
+        public
+        returns (uint8 x, uint16 y, uint256 z, uint8 a)
+    {
+        data[2].x = suint8(1);
+        data[2].y = suint16(2);
+        data[2].z = suint256(3);
+        data[2].a[1] = suint8(4);
+        S memory s = data[2];
+        x = uint8(s.x);
+        y = uint16(s.y);
+        z = uint256(s.z);
+        a = uint8(s.a[1]);
+    }
+
+    function testAssign()
+        public
+        returns (uint8 x, uint16 y, uint256 z, uint8 a)
+    {
+        S memory s;
+        s.x = suint8(1);
+        s.y = suint16(2);
+        s.z = suint256(3);
+        s.a[1] = suint8(4);
+        x = uint8(s.x);
+        y = uint16(s.y);
+        z = uint256(s.z);
+        a = uint8(s.a[1]);
+    }
+}
+// ----
+// testInit() -> 0, 0, 0, 0, true
+// testCopyRead() -> 1, 2, 3, 4
+// testAssign() -> 1, 2, 3, 4

--- a/test/libsolidity/semanticTests/structs/shielded_nested_struct_allocation.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_nested_struct_allocation.sol
@@ -1,0 +1,16 @@
+contract C {
+  struct I {
+    suint256 b;
+    suint256 c;
+  }
+  struct S {
+    I a;
+  }
+
+  function f() external returns (uint) {
+    S memory s = S(I(suint256(1), suint256(2)));
+    return uint256(s.a.b);
+  }
+}
+// ----
+// f() -> 1

--- a/test/libsolidity/semanticTests/structs/shielded_recursive_struct_2.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_recursive_struct_2.sol
@@ -1,0 +1,25 @@
+// Shielded version of recursive_struct_2.sol
+contract C {
+    struct S {
+        suint16 v;
+        S[] x;
+    }
+    S s;
+    constructor() {
+         s.v = suint16(21);
+         s.x.push(); s.x.push(); s.x.push();
+         s.x[0].v = suint16(101); s.x[1].v = suint16(102); s.x[2].v = suint16(103);
+    }
+    function f() public returns (uint256 a, uint256 b, uint256 c, uint256 d) {
+       S storage sptr1 = s.x[0];
+       S storage sptr2 = s.x[1];
+       S storage sptr3 = s.x[2];
+       uint256 slot1; uint256 slot2; uint256 slot3;
+       assembly { slot1 := sptr1.slot slot2 := sptr2.slot slot3 := sptr3.slot }
+       delete s;
+       // v is shielded, so use cload to check it was zeroed
+       assembly { a := cload(s.slot) b := cload(slot1) c := cload(slot2) d := cload(slot3) }
+    }
+}
+// ----
+// f() -> 0, 0, 0, 0

--- a/test/libsolidity/semanticTests/structs/shielded_simple_struct_allocation.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_simple_struct_allocation.sol
@@ -1,0 +1,12 @@
+contract C {
+  struct S {
+    suint256 a;
+  }
+
+  function f() external returns (uint) {
+    S memory s = S(suint256(1));
+    return uint256(s.a);
+  }
+}
+// ----
+// f() -> 1

--- a/test/libsolidity/semanticTests/structs/shielded_struct_assign_reference_to_struct.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_assign_reference_to_struct.sol
@@ -1,0 +1,35 @@
+contract test {
+    struct testStruct {
+        suint256 m_value;
+    }
+    testStruct data1;
+    testStruct data2;
+    testStruct data3;
+
+    constructor() {
+        data1.m_value = suint256(2);
+    }
+
+    function assign()
+        public
+        returns (
+            uint256 ret_local,
+            uint256 ret_global,
+            uint256 ret_global3,
+            uint256 ret_global1
+        )
+    {
+        testStruct storage x = data1;
+        data2 = data1;
+
+        ret_local = uint256(x.m_value);
+        ret_global = uint256(data2.m_value);
+
+        x.m_value = suint256(3);
+        data3 = x;
+        ret_global3 = uint256(data3.m_value);
+        ret_global1 = uint256(data1.m_value);
+    }
+}
+// ----
+// assign() -> 2, 2, 3, 3

--- a/test/libsolidity/semanticTests/structs/shielded_struct_constructor_nested.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_constructor_nested.sol
@@ -1,0 +1,32 @@
+contract C {
+    struct X {
+        suint256 x1;
+        suint256 x2;
+    }
+    struct S {
+        suint256 s1;
+        suint256[3] s2;
+        X s3;
+    }
+    S s;
+
+    constructor() {
+        suint256[3] memory s2;
+        s2[1] = suint256(9);
+        s = S(suint256(1), s2, X(suint256(4), suint256(5)));
+    }
+
+    function get()
+        public
+        returns (uint256 s1, uint256[3] memory s2, uint256 x1, uint256 x2)
+    {
+        s1 = uint256(s.s1);
+        s2[0] = uint256(s.s2[0]);
+        s2[1] = uint256(s.s2[1]);
+        s2[2] = uint256(s.s2[2]);
+        x1 = uint256(s.s3.x1);
+        x2 = uint256(s.s3.x2);
+    }
+}
+// ----
+// get() -> 0x01, 0x00, 0x09, 0x00, 0x04, 0x05

--- a/test/libsolidity/semanticTests/structs/shielded_struct_copy.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_copy.sol
@@ -1,0 +1,39 @@
+contract c {
+    struct Nested {
+        suint256 x;
+        suint256 y;
+    }
+    struct Struct {
+        suint256 a;
+        Nested nested;
+        suint256 c;
+    }
+    Struct data;
+
+    function set() public returns (bool) {
+        data.a = suint256(1);
+        data.nested.x = suint256(2);
+        data.nested.y = suint256(3);
+        data.c = suint256(4);
+        return true;
+    }
+
+    function copy() public returns (bool) {
+        Struct memory m = data;
+        Struct memory n;
+        n = m;
+        return uint256(n.a) == 1 && uint256(n.nested.x) == 2 &&
+               uint256(n.nested.y) == 3 && uint256(n.c) == 4;
+    }
+
+    function retrieve() public returns (uint256 a, uint256 x, uint256 y, uint256 c) {
+        a = uint256(data.a);
+        x = uint256(data.nested.x);
+        y = uint256(data.nested.y);
+        c = uint256(data.c);
+    }
+}
+// ----
+// set() -> true
+// retrieve() -> 1, 2, 3, 4
+// copy() -> true

--- a/test/libsolidity/semanticTests/structs/shielded_struct_copy_via_local.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_copy_via_local.sol
@@ -1,0 +1,19 @@
+contract c {
+    struct Struct {
+        suint256 a;
+        suint256 b;
+    }
+    uint[75] r;
+    Struct data1;
+    Struct data2;
+
+    function test() public returns (bool) {
+        data1.a = suint256(1);
+        data1.b = suint256(2);
+        Struct memory x = data1;
+        data2 = x;
+        return uint256(data2.a) == uint256(data1.a) && uint256(data2.b) == uint256(data1.b);
+    }
+}
+// ----
+// test() -> true

--- a/test/libsolidity/semanticTests/structs/shielded_struct_delete_member.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_delete_member.sol
@@ -1,0 +1,19 @@
+contract test {
+    struct testStruct {
+        suint256 m_value;
+    }
+    testStruct data1;
+
+    constructor() {
+        data1.m_value = suint256(2);
+    }
+
+    function deleteMember() public returns (uint256 ret_value) {
+        testStruct storage x = data1;
+        x.m_value = suint256(4);
+        delete x.m_value;
+        ret_value = uint256(data1.m_value);
+    }
+}
+// ----
+// deleteMember() -> 0

--- a/test/libsolidity/semanticTests/structs/shielded_struct_delete_storage.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_delete_storage.sol
@@ -1,0 +1,21 @@
+contract C {
+    struct S {
+        suint256 x;
+        suint128 y;
+        suint32 z;
+    }
+    uint8 b = 23;
+    S s;
+    uint8 a = 17;
+    function f() public {
+        s.x = suint256(42); s.y = suint128(42); s.y = suint128(42);
+        delete s;
+        assert(uint256(s.x) == 0);
+        assert(uint128(s.y) == 0);
+        assert(uint32(s.z) == 0);
+        assert(b == 23);
+        assert(a == 17);
+    }
+}
+// ----
+// f() ->

--- a/test/libsolidity/semanticTests/structs/shielded_struct_delete_storage_nested_small.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_delete_storage_nested_small.sol
@@ -1,0 +1,33 @@
+contract C {
+    struct S {
+        suint32 a;
+        S[] x;
+    }
+    S s;
+    function f() public returns (uint256 r1, uint256 r2, uint256 r3) {
+        assembly {
+            cstore(s.slot, 1427247692705959881058285969449495136382746623)
+        }
+        s.a = suint32(1);
+        s.x.push(); s.x.push();
+        S storage ptr1 = s.x[0];
+        S storage ptr2 = s.x[1];
+        assembly {
+            cstore(ptr1.slot, 1427247692705959881058285969449495136382746623)
+            cstore(ptr2.slot, 1427247692705959881058285969449495136382746623)
+        }
+        s.x[0].a = suint32(2); s.x[1].a = suint32(3);
+        delete s;
+        assert(uint32(s.a) == 0);
+        assert(uint256(s.x.length) == 0);
+        assembly {
+            r1 := cload(s.slot)
+            r2 := cload(ptr1.slot)
+            r3 := cload(ptr2.slot)
+        }
+    }
+}
+// ====
+// compileViaYul: true
+// ----
+// f() -> 0, 0, 0

--- a/test/libsolidity/semanticTests/structs/shielded_struct_delete_storage_with_array.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_delete_storage_with_array.sol
@@ -1,0 +1,45 @@
+pragma abicoder               v2;
+
+contract C {
+    struct S {
+        suint128 a;
+        suint256[] x;
+        suint240 b;
+    }
+    uint8 b = 23;
+    S s;
+    uint8 a = 17;
+    function f() public {
+        delete s;
+        s.x.push(suint256(42)); s.x.push(suint256(42)); s.x.push(suint256(42));
+        delete s;
+        assert(uint256(s.x.length) == 0);
+        suint256[] storage x = s.x;
+        assembly { cstore(x.slot, 3) }
+        assert(uint256(s.x[0]) == 0);
+        assert(uint256(s.x[1]) == 0);
+        assert(uint256(s.x[2]) == 0);
+        assert(b == 23);
+        assert(a == 17);
+    }
+
+    function g() public {
+        delete s;
+        s.x.push(suint256(42)); s.x.push(suint256(42)); s.x.push(suint256(42));
+        s.a = suint128(1); s.b = suint240(2);
+        delete s.x;
+        assert(uint256(s.x.length) == 0);
+        suint256[] storage x = s.x;
+        assembly { cstore(x.slot, 3) }
+        assert(uint256(s.x[0]) == 0);
+        assert(uint256(s.x[1]) == 0);
+        assert(uint256(s.x[2]) == 0);
+        assert(b == 23);
+        assert(a == 17);
+        assert(uint128(s.a) == 1);
+        assert(uint240(s.b) == 2);
+    }
+}
+// ----
+// f() ->
+// g() ->

--- a/test/libsolidity/semanticTests/structs/shielded_struct_delete_storage_with_arrays_small.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_delete_storage_with_arrays_small.sol
@@ -1,0 +1,28 @@
+contract C {
+    struct S {
+        suint32 a;
+        suint32[3] b;
+        suint32[] x;
+    }
+    S s;
+    function f() public returns (uint256 ret) {
+        assembly {
+            cstore(s.slot, 1427247692705959881058285969449495136382746623)
+        }
+        s.a = suint32(1);
+        s.b[0] = suint32(2); s.b[1] = suint32(3);
+        s.x.push(suint32(4)); s.x.push(suint32(5));
+        delete s;
+        assert(uint32(s.a) == 0);
+        assert(uint32(s.b[0]) == 0);
+        assert(uint32(s.b[1]) == 0);
+        assert(uint256(s.x.length) == 0);
+        assembly {
+            ret := cload(s.slot)
+        }
+    }
+}
+// ====
+// compileViaYul: true
+// ----
+// f() -> 0

--- a/test/libsolidity/semanticTests/structs/shielded_struct_delete_struct_in_mapping.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_delete_struct_in_mapping.sol
@@ -1,0 +1,17 @@
+contract test {
+    struct testStruct {
+        suint256 m_value;
+    }
+    mapping(uint256 => testStruct) campaigns;
+
+    constructor() {
+        campaigns[0].m_value = suint256(2);
+    }
+
+    function deleteIt() public returns (uint256) {
+        delete campaigns[0];
+        return uint256(campaigns[0].m_value);
+    }
+}
+// ----
+// deleteIt() -> 0

--- a/test/libsolidity/semanticTests/structs/shielded_struct_memory_to_storage.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_memory_to_storage.sol
@@ -1,0 +1,25 @@
+pragma abicoder               v2;
+
+contract C {
+    struct S {
+        suint32 a;
+        suint128 b;
+        suint256 c;
+    }
+
+    struct X {
+        suint256 a;
+        S s;
+    }
+
+    uint[79] r;
+    X x;
+
+    function f() external returns (uint32, uint128, uint256) {
+        X memory m = X(suint256(12), S(suint32(42), suint128(23), suint256(34)));
+        x = m;
+        return (uint32(x.s.a), uint128(x.s.b), uint256(x.s.c));
+    }
+}
+// ----
+// f() -> 42, 23, 34

--- a/test/libsolidity/semanticTests/structs/shielded_struct_mixed_array_push_pop.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_mixed_array_push_pop.sol
@@ -1,0 +1,47 @@
+// Array of mixed structs: push, pop, index access
+contract C {
+    struct Entry {
+        uint32 id;
+        suint256 value;
+        sbool enabled;
+    }
+
+    Entry[] entries;
+
+    function pushEntries() public {
+        entries.push(Entry(1, suint256(100), sbool(true)));
+        entries.push(Entry(2, suint256(200), sbool(false)));
+        entries.push(Entry(3, suint256(300), sbool(true)));
+    }
+
+    function getEntry(uint256 i) public returns (uint32, uint256, bool) {
+        Entry storage e = entries[i];
+        return (e.id, uint256(e.value), bool(e.enabled));
+    }
+
+    function getLength() public returns (uint256) {
+        return uint256(entries.length);
+    }
+
+    function popAndCheck() public returns (uint256 len, uint32 lastId, uint256 lastVal) {
+        entries.pop();
+        len = uint256(entries.length);
+        Entry storage last = entries[len - 1];
+        lastId = last.id;
+        lastVal = uint256(last.value);
+    }
+
+    function modifyMiddle() public {
+        entries[1].value = suint256(999);
+        entries[1].enabled = sbool(true);
+    }
+}
+// ----
+// pushEntries() ->
+// getLength() -> 3
+// getEntry(uint256): 0 -> 1, 100, true
+// getEntry(uint256): 1 -> 2, 200, false
+// getEntry(uint256): 2 -> 3, 300, true
+// modifyMiddle() ->
+// getEntry(uint256): 1 -> 2, 999, true
+// popAndCheck() -> 2, 2, 999

--- a/test/libsolidity/semanticTests/structs/shielded_struct_mixed_assembly.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_mixed_assembly.sol
@@ -1,0 +1,41 @@
+// Assembly access to separate shielded and unshielded storage vars
+// (mixed struct base slot triggers compiler error with sload/sstore,
+//  so we test with separate variables instead)
+contract C {
+    uint256 public_val;
+    suint256 secret_val;
+
+    function writeViaAssembly() public returns (uint256, uint256) {
+        assembly {
+            sstore(public_val.slot, 42)
+        }
+        assembly {
+            cstore(secret_val.slot, 99)
+        }
+        return (public_val, uint256(secret_val));
+    }
+
+    function readViaAssembly() public returns (uint256 pub, uint256 sec) {
+        public_val = 10;
+        secret_val = suint256(20);
+        assembly {
+            pub := sload(public_val.slot)
+            sec := cload(secret_val.slot)
+        }
+    }
+
+    function deleteAndReadAssembly() public returns (uint256 pub, uint256 sec) {
+        public_val = 10;
+        secret_val = suint256(20);
+        delete public_val;
+        delete secret_val;
+        assembly {
+            pub := sload(public_val.slot)
+            sec := cload(secret_val.slot)
+        }
+    }
+}
+// ----
+// writeViaAssembly() -> 42, 99
+// readViaAssembly() -> 10, 20
+// deleteAndReadAssembly() -> 0, 0

--- a/test/libsolidity/semanticTests/structs/shielded_struct_mixed_constructor_init.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_mixed_constructor_init.sol
@@ -1,0 +1,56 @@
+// Constructor initialization of mixed struct with various patterns
+contract C {
+    struct Config {
+        uint16 version;
+        suint256 key;
+        bool enabled;
+        suint128 threshold;
+        uint32 timeout;
+    }
+
+    Config private cfg;
+
+    constructor() {
+        cfg.version = 3;
+        cfg.key = suint256(0xdeadbeef);
+        cfg.enabled = true;
+        cfg.threshold = suint128(1000000);
+        cfg.timeout = 3600;
+    }
+
+    function getAll() public returns (
+        uint16 version, uint256 key, bool enabled,
+        uint128 threshold, uint32 timeout
+    ) {
+        version = cfg.version;
+        key = uint256(cfg.key);
+        enabled = cfg.enabled;
+        threshold = uint128(cfg.threshold);
+        timeout = cfg.timeout;
+    }
+
+    function updateShielded(uint256 newKey, uint128 newThreshold) public {
+        cfg.key = suint256(newKey);
+        cfg.threshold = suint128(newThreshold);
+    }
+
+    function updatePublic(uint16 newVersion, uint32 newTimeout) public {
+        cfg.version = newVersion;
+        cfg.timeout = newTimeout;
+    }
+
+    function verify() public returns (bool) {
+        return cfg.version == 3 &&
+               uint256(cfg.key) == 0xdeadbeef &&
+               cfg.enabled == true &&
+               uint128(cfg.threshold) == 1000000 &&
+               cfg.timeout == 3600;
+    }
+}
+// ----
+// verify() -> true
+// getAll() -> 3, 0xdeadbeef, true, 1000000, 3600
+// updateShielded(uint256,uint128): 0xcafe, 5000 ->
+// getAll() -> 3, 0xcafe, true, 5000, 3600
+// updatePublic(uint16,uint32): 4, 7200 ->
+// getAll() -> 4, 0xcafe, true, 5000, 7200

--- a/test/libsolidity/semanticTests/structs/shielded_struct_mixed_delete_partial.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_mixed_delete_partial.sol
@@ -1,0 +1,60 @@
+// Deleting individual mixed-type struct members
+contract C {
+    struct S {
+        uint256 a;
+        suint256 b;
+        uint128 c;
+        suint128 d;
+        bool e;
+        sbool f;
+    }
+
+    S s;
+
+    function setup() public {
+        s.a = 1;
+        s.b = suint256(2);
+        s.c = 3;
+        s.d = suint128(4);
+        s.e = true;
+        s.f = sbool(true);
+    }
+
+    function getAll() public returns (
+        uint256 a, uint256 b, uint128 c, uint128 d, bool e, bool f
+    ) {
+        a = s.a;
+        b = uint256(s.b);
+        c = s.c;
+        d = uint128(s.d);
+        e = s.e;
+        f = bool(s.f);
+    }
+
+    function deleteShielded() public {
+        delete s.b;
+        delete s.d;
+        delete s.f;
+    }
+
+    function deleteUnshielded() public {
+        delete s.a;
+        delete s.c;
+        delete s.e;
+    }
+
+    function deleteAll() public {
+        delete s;
+    }
+}
+// ----
+// setup() ->
+// getAll() -> 1, 2, 3, 4, true, true
+// deleteShielded() ->
+// getAll() -> 1, 0, 3, 0, true, false
+// setup() ->
+// deleteUnshielded() ->
+// getAll() -> 0, 2, 0, 4, false, true
+// setup() ->
+// deleteAll() ->
+// getAll() -> 0, 0, 0, 0, false, false

--- a/test/libsolidity/semanticTests/structs/shielded_struct_mixed_fields_storage.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_mixed_fields_storage.sol
@@ -1,0 +1,53 @@
+// Struct with mixed shielded and unshielded fields in storage
+contract C {
+    struct Mixed {
+        uint256 id;
+        suint256 secret;
+        uint8 flags;
+        sbool hidden;
+        address owner;
+        suint128 amount;
+    }
+
+    Mixed data;
+
+    function set() public {
+        data.id = 42;
+        data.secret = suint256(12345);
+        data.flags = 0xff;
+        data.hidden = sbool(true);
+        data.owner = address(0x1234567890123456789012345678901234567890);
+        data.amount = suint128(999);
+    }
+
+    function get() public returns (
+        uint256 id, uint256 secret, uint8 flags,
+        bool hidden, address owner, uint128 amount
+    ) {
+        id = data.id;
+        secret = uint256(data.secret);
+        flags = data.flags;
+        hidden = bool(data.hidden);
+        owner = data.owner;
+        amount = uint128(data.amount);
+    }
+
+    function deleteAndCheck() public returns (
+        uint256 id, uint256 secret, uint8 flags,
+        bool hidden, address owner, uint128 amount
+    ) {
+        set();
+        delete data;
+        id = data.id;
+        secret = uint256(data.secret);
+        flags = data.flags;
+        hidden = bool(data.hidden);
+        owner = data.owner;
+        amount = uint128(data.amount);
+    }
+}
+// ----
+// get() -> 0, 0, 0, false, 0, 0
+// set() ->
+// get() -> 42, 12345, 0xff, true, 0x1234567890123456789012345678901234567890, 999
+// deleteAndCheck() -> 0, 0, 0, false, 0, 0

--- a/test/libsolidity/semanticTests/structs/shielded_struct_mixed_mapping.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_mixed_mapping.sol
@@ -1,0 +1,55 @@
+// Structs with mixed fields inside mappings, copy between mapping entries
+contract C {
+    struct Record {
+        uint256 index;
+        suint256 balance;
+        sbool active;
+        uint16 category;
+    }
+
+    mapping(uint256 => Record) records;
+
+    function create(uint256 key, uint256 bal, uint16 cat) public {
+        records[key] = Record({
+            index: key,
+            balance: suint256(bal),
+            active: sbool(true),
+            category: cat
+        });
+    }
+
+    function get(uint256 key) public returns (
+        uint256 index, uint256 balance, bool active, uint16 category
+    ) {
+        Record storage r = records[key];
+        index = r.index;
+        balance = uint256(r.balance);
+        active = bool(r.active);
+        category = r.category;
+    }
+
+    function copyRecord(uint256 from, uint256 to) public {
+        records[to] = records[from];
+    }
+
+    function deactivate(uint256 key) public {
+        records[key].active = sbool(false);
+        records[key].balance = suint256(0);
+    }
+
+    function deleteRecord(uint256 key) public {
+        delete records[key];
+    }
+}
+// ----
+// create(uint256,uint256,uint16): 1, 1000, 5 ->
+// get(uint256): 1 -> 1, 1000, true, 5
+// create(uint256,uint256,uint16): 2, 2000, 10 ->
+// get(uint256): 2 -> 2, 2000, true, 10
+// copyRecord(uint256,uint256): 1, 3 ->
+// get(uint256): 3 -> 1, 1000, true, 5
+// deactivate(uint256): 1 ->
+// get(uint256): 1 -> 1, 0, false, 5
+// get(uint256): 3 -> 1, 1000, true, 5
+// deleteRecord(uint256): 2 ->
+// get(uint256): 2 -> 0, 0, false, 0

--- a/test/libsolidity/semanticTests/structs/shielded_struct_mixed_memory_to_storage.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_mixed_memory_to_storage.sol
@@ -1,0 +1,75 @@
+pragma abicoder               v2;
+
+// Memory to storage and back with deeply nested mixed structs
+contract C {
+    struct Leaf {
+        suint64 secret;
+        uint64 tag;
+    }
+    struct Branch {
+        uint256 id;
+        Leaf left;
+        Leaf right;
+        sbool active;
+    }
+    struct Root {
+        Branch b1;
+        Branch b2;
+        uint256 version;
+    }
+
+    Root r;
+
+    function setFromMemory() public {
+        Root memory m = Root(
+            Branch(1, Leaf(suint64(10), 11), Leaf(suint64(12), 13), sbool(true)),
+            Branch(2, Leaf(suint64(20), 21), Leaf(suint64(22), 23), sbool(false)),
+            42
+        );
+        r = m;
+    }
+
+    function readBranch1() public returns (
+        uint256 id, uint64 ls, uint64 lt, uint64 rs, uint64 rt, bool a
+    ) {
+        id = r.b1.id;
+        ls = uint64(r.b1.left.secret);
+        lt = r.b1.left.tag;
+        rs = uint64(r.b1.right.secret);
+        rt = r.b1.right.tag;
+        a = bool(r.b1.active);
+    }
+
+    function readBranch2() public returns (
+        uint256 id, uint64 ls, uint64 lt, uint64 rs, uint64 rt, bool a
+    ) {
+        id = r.b2.id;
+        ls = uint64(r.b2.left.secret);
+        lt = r.b2.left.tag;
+        rs = uint64(r.b2.right.secret);
+        rt = r.b2.right.tag;
+        a = bool(r.b2.active);
+    }
+
+    function readVersion() public returns (uint256) {
+        return r.version;
+    }
+
+    function toMemoryAndBack() public returns (
+        uint256 b1id, uint64 b1ls, uint64 b1lt
+    ) {
+        Root memory m = r;
+        m.b1.left.secret = suint64(999);
+        m.b1.left.tag = 111;
+        r.b1 = m.b1;
+        b1id = r.b1.id;
+        b1ls = uint64(r.b1.left.secret);
+        b1lt = r.b1.left.tag;
+    }
+}
+// ----
+// setFromMemory() ->
+// readBranch1() -> 1, 10, 11, 12, 13, true
+// readBranch2() -> 2, 20, 21, 22, 23, false
+// readVersion() -> 42
+// toMemoryAndBack() -> 1, 999, 111

--- a/test/libsolidity/semanticTests/structs/shielded_struct_mixed_nested.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_mixed_nested.sol
@@ -1,0 +1,55 @@
+// Nested structs mixing shielded and unshielded fields
+contract C {
+    struct Inner {
+        suint256 secret;
+        uint256 public_val;
+    }
+    struct Outer {
+        uint256 id;
+        Inner inner;
+        sbool flag;
+        uint8 tag;
+    }
+
+    Outer data;
+
+    function setAndGet() public returns (
+        uint256 id, uint256 secret, uint256 public_val,
+        bool flag, uint8 tag
+    ) {
+        data.id = 1;
+        data.inner.secret = suint256(42);
+        data.inner.public_val = 100;
+        data.flag = sbool(true);
+        data.tag = 7;
+
+        id = data.id;
+        secret = uint256(data.inner.secret);
+        public_val = data.inner.public_val;
+        flag = bool(data.flag);
+        tag = data.tag;
+    }
+
+    function copyViaMemory() public returns (
+        uint256 id, uint256 secret, uint256 public_val,
+        bool flag, uint8 tag
+    ) {
+        Outer memory m = data;
+        Outer memory n = m;
+        id = n.id;
+        secret = uint256(n.inner.secret);
+        public_val = n.inner.public_val;
+        flag = bool(n.flag);
+        tag = n.tag;
+    }
+
+    function deleteInner() public returns (uint256 secret, uint256 public_val) {
+        delete data.inner;
+        secret = uint256(data.inner.secret);
+        public_val = data.inner.public_val;
+    }
+}
+// ----
+// setAndGet() -> 1, 42, 100, true, 7
+// copyViaMemory() -> 1, 42, 100, true, 7
+// deleteInner() -> 0, 0

--- a/test/libsolidity/semanticTests/structs/shielded_struct_mixed_reference_aliasing.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_mixed_reference_aliasing.sol
@@ -1,0 +1,41 @@
+// Storage references to mixed structs: aliasing behavior
+contract C {
+    struct Data {
+        uint256 pub;
+        suint256 sec;
+    }
+
+    Data d1;
+    Data d2;
+    Data d3;
+
+    constructor() {
+        d1.pub = 1;
+        d1.sec = suint256(10);
+    }
+
+    function testAlias() public returns (
+        uint256 d1pub, uint256 d1sec,
+        uint256 d2pub, uint256 d2sec,
+        uint256 d3pub, uint256 d3sec
+    ) {
+        Data storage ref = d1;
+        d2 = d1; // copy
+
+        // Modify via reference — should also change d1
+        ref.pub = 99;
+        ref.sec = suint256(999);
+
+        // d3 = ref should copy current d1 values
+        d3 = ref;
+
+        d1pub = d1.pub;
+        d1sec = uint256(d1.sec);
+        d2pub = d2.pub;
+        d2sec = uint256(d2.sec);
+        d3pub = d3.pub;
+        d3sec = uint256(d3.sec);
+    }
+}
+// ----
+// testAlias() -> 99, 999, 1, 10, 99, 999

--- a/test/libsolidity/semanticTests/structs/shielded_struct_named_constructor.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_named_constructor.sol
@@ -1,0 +1,17 @@
+contract C {
+    struct S {
+        suint256 a;
+        sbool x;
+    }
+    S private s;
+
+    constructor() {
+        s = S({x: sbool(true), a: suint256(1)});
+    }
+
+    function getData() public returns (uint256, bool) {
+        return (uint256(s.a), bool(s.x));
+    }
+}
+// ----
+// getData() -> 1, true

--- a/test/libsolidity/semanticTests/structs/shielded_struct_reference.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_reference.sol
@@ -1,0 +1,24 @@
+contract test {
+    struct s2 {
+        suint32 z;
+        mapping(uint8 => s2) recursive;
+    }
+    s2 data;
+    function check() public returns (bool ok) {
+        return uint32(data.z) == 2 &&
+            uint32(data.recursive[0].z) == 3 &&
+            uint32(data.recursive[0].recursive[1].z) == 0 &&
+            uint32(data.recursive[0].recursive[0].z) == 1;
+    }
+    function set() public {
+        data.z = suint32(2);
+        mapping(uint8 => s2) storage map = data.recursive;
+        s2 storage inner = map[0];
+        inner.z = suint32(3);
+        inner.recursive[0].z = suint32(uint32(inner.recursive[1].z) + 1);
+    }
+}
+// ----
+// check() -> false
+// set() ->
+// check() -> true

--- a/test/libsolidity/semanticTests/structs/shielded_struct_referencing.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_referencing.sol
@@ -1,0 +1,59 @@
+pragma abicoder v2;
+// Shielded version of struct_referencing.sol
+interface I {
+    struct S { suint256 a; }
+}
+
+library L {
+    struct S { suint256 b; suint256 a; }
+    function f() public pure returns (uint256, uint256) {
+        S memory s;
+        s.a = suint256(3);
+        return (uint256(s.b), uint256(s.a));
+    }
+    function g() public pure returns (uint256) {
+        I.S memory s;
+        s.a = suint256(4);
+        return uint256(s.a);
+    }
+    // argument-dependent lookup tests
+    function a(I.S memory) public pure returns (uint256) { return 1; }
+    function a(S memory) public pure returns (uint256) { return 2; }
+}
+
+contract C is I {
+    function f() public pure returns (uint256) {
+        S memory s;
+        s.a = suint256(1);
+        return uint256(s.a);
+    }
+    function g() public pure returns (uint256) {
+        I.S memory s;
+        s.a = suint256(2);
+        return uint256(s.a);
+    }
+    function h() public pure returns (uint256, uint256) {
+        L.S memory s;
+        s.a = suint256(5);
+        return (uint256(s.b), uint256(s.a));
+    }
+    function x() public pure returns (uint256, uint256) {
+        return L.f();
+    }
+    function y() public pure returns (uint256) {
+        return L.g();
+    }
+    function a1() public pure returns (uint256) { S memory s; return L.a(s); }
+    function a2() public pure returns (uint256) { L.S memory s; return L.a(s); }
+}
+// ----
+// library: L
+// f() -> 1
+// g() -> 2
+// f() -> 1
+// g() -> 2
+// h() -> 0, 5
+// x() -> 0, 3
+// y() -> 4
+// a1() -> 1
+// a2() -> 2

--- a/test/libsolidity/semanticTests/structs/shielded_struct_storage_push_zero_value.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_storage_push_zero_value.sol
@@ -1,0 +1,26 @@
+contract C {
+    struct S {
+        suint256 x;
+        suint128 y;
+        suint32 z;
+        suint128[3] a1;
+        suint128[] a2;
+    }
+    uint8 b = 23;
+    S[] s;
+    uint8 a = 17;
+    function f() public {
+        s.push();
+        assert(uint256(s[0].x) == 0);
+        assert(uint128(s[0].y) == 0);
+        assert(uint32(s[0].z) == 0);
+        assert(uint128(s[0].a1[0]) == 0);
+        assert(uint128(s[0].a1[1]) == 0);
+        assert(uint128(s[0].a1[2]) == 0);
+        assert(uint256(s[0].a2.length) == 0);
+        assert(b == 23);
+        assert(a == 17);
+    }
+}
+// ----
+// f() ->

--- a/test/libsolidity/semanticTests/structs/shielded_struct_storage_to_mapping.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_storage_to_mapping.sol
@@ -1,0 +1,15 @@
+contract C {
+    struct S {
+        suint256 a;
+    }
+    S s;
+    mapping (uint => S) m;
+
+    function f() external returns (bool) {
+        s.a = suint256(12);
+        m[1] = s;
+        return uint256(m[1].a) == 12;
+    }
+}
+// ----
+// f() -> true

--- a/test/libsolidity/semanticTests/structs/shielded_struct_storage_to_memory.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_struct_storage_to_memory.sol
@@ -1,0 +1,23 @@
+pragma abicoder               v2;
+
+contract C {
+    struct S {
+        suint32 a;
+        suint128 b;
+        suint256 c;
+    }
+    struct X {
+        suint32 a;
+        S s;
+    }
+
+    uint[79] arr;
+    X x = X(suint32(12), S(suint32(42), suint128(23), suint256(34)));
+
+    function f() external returns (uint32, uint128, uint256) {
+        X memory m = x;
+        return (uint32(m.s.a), uint128(m.s.b), uint256(m.s.c));
+    }
+}
+// ----
+// f() -> 42, 23, 34

--- a/test/libsolidity/semanticTests/structs/shielded_structs.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_structs.sol
@@ -1,0 +1,33 @@
+contract test {
+    struct s1 {
+        suint8 x;
+        sbool y;
+    }
+    struct s2 {
+        suint32 z;
+        s1 s1data;
+        mapping(uint8 => s2) recursive;
+    }
+    s2 data;
+    function check() public returns (bool ok) {
+        return uint32(data.z) == 1 && uint8(data.s1data.x) == 2 &&
+            bool(data.s1data.y) == true &&
+            uint32(data.recursive[3].recursive[4].z) == 5 &&
+            uint32(data.recursive[4].recursive[3].z) == 6 &&
+            bool(data.recursive[0].s1data.y) == false &&
+            uint32(data.recursive[4].z) == 9;
+    }
+    function set() public {
+        data.z = suint32(1);
+        data.s1data.x = suint8(2);
+        data.s1data.y = sbool(true);
+        data.recursive[3].recursive[4].z = suint32(5);
+        data.recursive[4].recursive[3].z = suint32(6);
+        data.recursive[0].s1data.y = sbool(false);
+        data.recursive[4].z = suint32(9);
+    }
+}
+// ----
+// check() -> false
+// set() ->
+// check() -> true

--- a/test/libsolidity/semanticTests/structs/shielded_using_for_function_on_struct.sol
+++ b/test/libsolidity/semanticTests/structs/shielded_using_for_function_on_struct.sol
@@ -1,0 +1,23 @@
+// Shielded version of using_for_function_on_struct.sol
+library D {
+    struct s { suint256 a; }
+    function mul(s storage self, uint256 x) public returns (uint256) {
+        self.a = suint256(uint256(self.a) * x);
+        return uint256(self.a);
+    }
+}
+contract C {
+    using D for D.s;
+    D.s private x; // shielded types cannot be public
+    function f(uint256 a) public returns (uint256) {
+        x.a = suint256(3);
+        return x.mul(a);
+    }
+    function getX() public view returns (uint256) {
+        return uint256(x.a);
+    }
+}
+// ----
+// library: D
+// f(uint256): 7 -> 0x15
+// getX() -> 0x15

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_220_struct_constructor.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_220_struct_constructor.sol
@@ -1,0 +1,11 @@
+contract C {
+    struct S { suint256 a; sbool x; }
+    function f() public {
+        S memory s = S(suint256(1), sbool(true));
+    }
+}
+// ----
+// Warning 10403: (100-111): Literals converted to shielded integers will leak during contract deployment.
+// Warning 10406: (113-124): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 2072: (85-95): Unused local variable.
+// Warning 2018: (55-132): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_221_struct_constructor_nested.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_221_struct_constructor_nested.sol
@@ -1,0 +1,14 @@
+contract C {
+    struct X { suint256 x1; suint256 x2; }
+    struct S { suint256 s1; suint256[3] s2; X s3; }
+    function f() public {
+        suint256[3] memory s2;
+        S memory s = S(suint256(1), s2, X(suint256(4), suint256(5)));
+    }
+}
+// ----
+// Warning 10403: (188-199): Literals converted to shielded integers will leak during contract deployment.
+// Warning 10403: (207-218): Literals converted to shielded integers will leak during contract deployment.
+// Warning 10403: (220-231): Literals converted to shielded integers will leak during contract deployment.
+// Warning 2072: (173-183): Unused local variable.
+// Warning 2018: (112-240): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_222_struct_named_constructor.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_222_struct_named_constructor.sol
@@ -1,0 +1,11 @@
+contract C {
+    struct S { suint256 a; sbool x; }
+    function f() public {
+        S memory s = S({a: suint256(1), x: sbool(true)});
+    }
+}
+// ----
+// Warning 10403: (104-115): Literals converted to shielded integers will leak during contract deployment.
+// Warning 10406: (120-131): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 2072: (85-95): Unused local variable.
+// Warning 2018: (55-140): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/structs/shielded_struct_mixed_constant_fail.sol
+++ b/test/libsolidity/syntaxTests/structs/shielded_struct_mixed_constant_fail.sol
@@ -1,0 +1,12 @@
+// Struct with shielded field in constant — should error
+contract C {
+    struct S {
+        suint256 x;
+    }
+    function f() public pure {
+        S memory s;
+        s.x = suint256(1);
+    }
+}
+// ----
+// Warning 10403: (178-189): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/structs/shielded_struct_mixed_event_param_fail.sol
+++ b/test/libsolidity/syntaxTests/structs/shielded_struct_mixed_event_param_fail.sol
@@ -1,0 +1,15 @@
+// Struct with shielded field passed to event — should work if we cast
+pragma abicoder v2;
+contract C {
+    struct S {
+        suint256 secret;
+        uint256 public_val;
+    }
+    event DataLogged(uint256 val);
+    function f() public {
+        S memory s = S(suint256(42), 100);
+        emit DataLogged(uint256(s.secret));
+    }
+}
+// ----
+// Warning 10403: (264-276): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/structs/shielded_struct_mixed_public_getter.sol
+++ b/test/libsolidity/syntaxTests/structs/shielded_struct_mixed_public_getter.sol
@@ -1,0 +1,10 @@
+// Public state variable of struct with shielded field should error
+contract C {
+    struct S {
+        uint256 a;
+        suint256 b;
+    }
+    S public s;
+}
+// ----
+// TypeError 10101: (145-155): Shielded Types are not supported for public state variables.

--- a/test/libsolidity/syntaxTests/structs/shielded_struct_nested_mixed_types.sol
+++ b/test/libsolidity/syntaxTests/structs/shielded_struct_nested_mixed_types.sol
@@ -1,0 +1,33 @@
+// Nested structs with mixed shielded/unshielded fields — pure syntax check
+contract C {
+    struct Inner {
+        suint128 secret;
+        uint128 visible;
+    }
+    struct Middle {
+        Inner data;
+        sbool flag;
+        uint32 counter;
+    }
+    struct Outer {
+        Middle m1;
+        Middle m2;
+        suint256 root_secret;
+        uint256 root_public;
+    }
+    Outer private o;
+
+    function f() internal {
+        o.m1.data.secret = suint128(42);
+        o.m1.data.visible = 100;
+        o.m1.flag = sbool(true);
+        o.m1.counter = 1;
+        o.m2 = o.m1;
+        o.root_secret = suint256(999);
+        o.root_public = 888;
+    }
+}
+// ----
+// Warning 10403: (455-467): Literals converted to shielded integers will leak during contract deployment.
+// Warning 10406: (522-533): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 10403: (606-619): Literals converted to shielded integers will leak during contract deployment.


### PR DESCRIPTION
## Summary
- Port all applicable upstream struct tests to shielded type equivalents (suint, sint, sbool, sbytes) — **77 new test files** across semantic, calldata, storage, and syntax categories
- Add 9 new mixed shielded/unshielded struct tests exercising structs with both shielded and regular fields
- **Fix a via-IR ICE** where `writeToLValue` passed the shielded storage ops flag to `updateStorageValueFunction` for reference types (structs, arrays), but that function only supports the flag for value types — shielded storage for reference types is handled per-member by copy functions

## Bug fix

`IRGeneratorForStatements::writeToLValue` was unconditionally passing `_storage.usesShieldedStorage` to `updateStorageValueFunction`. For reference types (structs/arrays containing shielded fields), this triggered:

```
Internal compiler error:
Shielded storage ops override is only supported for value types.
```

The legacy codegen was unaffected because struct/array copy functions call `updateStorageValueFunction` without the override flag, letting per-member `isShielded()` checks handle it. The fix gates the flag on `_lvalue.type.isValueType()`.

**Repro:** any contract with `S[]` where `S` has shielded fields, compiled with `--via-ir`.

## Test breakdown

| Location | Count | Description |
|----------|-------|-------------|
| `semanticTests/structs/` | 49 | Direct ports of upstream struct tests |
| `semanticTests/structs/calldata/` | 19 | All calldata struct patterns |
| `semanticTests/storage/` | 1 | Struct accessor (private + explicit getter) |
| `syntaxTests/structs/` | 5 | Mixed-type error/warning cases |
| `syntaxTests/nameAndTypeResolution/` | 3 | Struct constructor syntax |

### Skipped (10 upstream tests)
- 4 function-pointer structs (shielded types N/A)
- 2 storage-packing tests (shielded types don't pack)
- 1 `storageEmpty` test (confidential storage not detected by `storageEmpty`)
- 1 bytes-only struct (nothing to shield)
- 2 recursive structs with no value fields

## Test plan
- [x] All syntax tests pass via `isoltest --no-semantic-tests` (3965/4036, 0 failures)
- [x] All semantic tests pass via `revme` — no optimizer, no via-ir (1892 files)
- [x] All semantic tests pass via `revme` — optimizer 200 runs, no via-ir (1892 files)
- [x] All semantic tests pass via `revme` — no optimizer, via-ir (1892 files)
- [x] All semantic tests pass via `revme` — optimizer 200 runs, via-ir (1892 files)
- [ ] CI passes