### PR TITLE
test(sbool): comprehensive shielded bool test suite

### DIFF
--- a/test/libsolidity/semanticTests/abiEncoderV2/shielded_bool_out_of_bounds.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/shielded_bool_out_of_bounds.sol
@@ -1,0 +1,10 @@
+pragma abicoder v2;
+
+contract C {
+	function f(sbool b) public pure returns (bool) { return bool(b); }
+}
+// ----
+// f(sbool): true -> true
+// f(sbool): false -> false
+// f(sbool): 0x000000 -> false
+// f(sbool): 0xffffff -> FAILURE

--- a/test/libsolidity/semanticTests/inlineAssembly/shielded_sbool_cload_cstore_roundtrip.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/shielded_sbool_cload_cstore_roundtrip.sol
@@ -1,0 +1,38 @@
+contract C {
+    sbool x;
+
+    function writeRaw(uint256 raw) public {
+        assembly {
+            cstore(x.slot, raw)
+        }
+    }
+
+    function writeTyped(sbool v) public {
+        x = v;
+    }
+
+    function readRaw() public view returns (uint256 raw) {
+        assembly {
+            raw := cload(x.slot)
+        }
+    }
+
+    function readTyped() public view returns (bool) {
+        return bool(x);
+    }
+}
+// ----
+// readRaw() -> 0
+// readTyped() -> false
+// writeRaw(uint256): 1 ->
+// readRaw() -> 1
+// readTyped() -> true
+// writeRaw(uint256): 0 ->
+// readRaw() -> 0
+// readTyped() -> false
+// writeRaw(uint256): 2 ->
+// readTyped() -> true
+// writeTyped(sbool): false ->
+// readRaw() -> 0
+// writeTyped(sbool): true ->
+// readRaw() -> 1

--- a/test/libsolidity/semanticTests/libraries/shielded_internal_library_function_attached_to_sbool.sol
+++ b/test/libsolidity/semanticTests/libraries/shielded_internal_library_function_attached_to_sbool.sol
@@ -1,0 +1,18 @@
+library L {
+    function xor(sbool a, sbool b) internal pure returns (sbool) {
+        return a != b;
+    }
+}
+
+contract C {
+    using L for sbool;
+
+    function foo(sbool a, sbool b) public returns (bool) {
+        return bool(a.xor(b));
+    }
+}
+// ----
+// foo(sbool,sbool): true, true -> false
+// foo(sbool,sbool): true, false -> true
+// foo(sbool,sbool): false, true -> true
+// foo(sbool,sbool): false, false -> false

--- a/test/libsolidity/semanticTests/types/shielded_sbool_cast_roundtrip.sol
+++ b/test/libsolidity/semanticTests/types/shielded_sbool_cast_roundtrip.sol
@@ -1,0 +1,24 @@
+contract C {
+    function boolToSboolToBool(bool a) public pure returns (bool) {
+        sbool x = sbool(a);
+        return bool(x);
+    }
+
+    function compareThenCast(uint256 a, uint256 b) public pure returns (bool) {
+        sbool x = sbool(a > b);
+        return bool(x);
+    }
+
+    function invertThroughSbool(bool a) public pure returns (bool) {
+        sbool x = sbool(a);
+        return bool(!x);
+    }
+}
+// ----
+// boolToSboolToBool(bool): true -> true
+// boolToSboolToBool(bool): false -> false
+// compareThenCast(uint256,uint256): 7, 3 -> true
+// compareThenCast(uint256,uint256): 3, 7 -> false
+// compareThenCast(uint256,uint256): 5, 5 -> false
+// invertThroughSbool(bool): true -> false
+// invertThroughSbool(bool): false -> true

--- a/test/libsolidity/semanticTests/types/shielded_sbool_default_value.sol
+++ b/test/libsolidity/semanticTests/types/shielded_sbool_default_value.sol
@@ -1,0 +1,13 @@
+contract C {
+    sbool x;
+    function getStorageDefault() public view returns (bool) {
+        return bool(x);
+    }
+    function getLocalDefault() public pure returns (bool) {
+        sbool local;
+        return bool(local);
+    }
+}
+// ----
+// getStorageDefault() -> false
+// getLocalDefault() -> false

--- a/test/libsolidity/semanticTests/types/shielded_sbool_equality.sol
+++ b/test/libsolidity/semanticTests/types/shielded_sbool_equality.sol
@@ -1,0 +1,17 @@
+contract C {
+    function testEq(sbool a, sbool b) public pure returns (bool) {
+        return bool(a == b);
+    }
+    function testNeq(sbool a, sbool b) public pure returns (bool) {
+        return bool(a != b);
+    }
+}
+// ----
+// testEq(sbool,sbool): true, true -> true
+// testEq(sbool,sbool): true, false -> false
+// testEq(sbool,sbool): false, true -> false
+// testEq(sbool,sbool): false, false -> true
+// testNeq(sbool,sbool): true, false -> true
+// testNeq(sbool,sbool): false, true -> true
+// testNeq(sbool,sbool): true, true -> false
+// testNeq(sbool,sbool): false, false -> false

--- a/test/libsolidity/semanticTests/types/shielded_sbool_logical_ops.sol
+++ b/test/libsolidity/semanticTests/types/shielded_sbool_logical_ops.sol
@@ -1,0 +1,22 @@
+contract C {
+    function testAnd(sbool a, sbool b) public pure returns (bool) {
+        return bool(a && b);
+    }
+    function testOr(sbool a, sbool b) public pure returns (bool) {
+        return bool(a || b);
+    }
+    function testNot(sbool a) public pure returns (bool) {
+        return bool(!a);
+    }
+}
+// ----
+// testAnd(sbool,sbool): true, true -> true
+// testAnd(sbool,sbool): true, false -> false
+// testAnd(sbool,sbool): false, true -> false
+// testAnd(sbool,sbool): false, false -> false
+// testOr(sbool,sbool): true, true -> true
+// testOr(sbool,sbool): true, false -> true
+// testOr(sbool,sbool): false, true -> true
+// testOr(sbool,sbool): false, false -> false
+// testNot(sbool): true -> false
+// testNot(sbool): false -> true

--- a/test/libsolidity/semanticTests/types/shielded_sbool_memory_array.sol
+++ b/test/libsolidity/semanticTests/types/shielded_sbool_memory_array.sol
@@ -1,0 +1,18 @@
+contract C {
+    function defaults() public pure returns (bool, bool, bool) {
+        sbool[] memory arr = new sbool[](3);
+        return (bool(arr[0]), bool(arr[1]), bool(arr[2]));
+    }
+
+    function writeAndRead(sbool a, sbool b, sbool c) public pure returns (bool, bool, bool) {
+        sbool[] memory arr = new sbool[](3);
+        arr[0] = a;
+        arr[1] = b;
+        arr[2] = c;
+        return (bool(arr[0]), bool(arr[1]), bool(arr[2]));
+    }
+}
+// ----
+// defaults() -> false, false, false
+// writeAndRead(sbool,sbool,sbool): true, false, true -> true, false, true
+// writeAndRead(sbool,sbool,sbool): false, true, false -> false, true, false

--- a/test/libsolidity/semanticTests/types/shielded_sbool_noncanonical_runtime_ops.sol
+++ b/test/libsolidity/semanticTests/types/shielded_sbool_noncanonical_runtime_ops.sol
@@ -1,0 +1,43 @@
+contract C {
+    function fromRaw(uint256 raw) internal pure returns (sbool v) {
+        assembly {
+            v := raw
+        }
+    }
+
+    function testNot(uint256 raw) public pure returns (bool) {
+        sbool v = fromRaw(raw);
+        return bool(!v);
+    }
+
+    function testAnd(uint256 raw, sbool b) public pure returns (bool) {
+        sbool v = fromRaw(raw);
+        return bool(v && b);
+    }
+
+    function testOr(uint256 raw, sbool b) public pure returns (bool) {
+        sbool v = fromRaw(raw);
+        return bool(v || b);
+    }
+
+    function testEq(uint256 raw, sbool b) public pure returns (bool) {
+        sbool v = fromRaw(raw);
+        return bool(v == b);
+    }
+
+    function testNeq(uint256 raw, sbool b) public pure returns (bool) {
+        sbool v = fromRaw(raw);
+        return bool(v != b);
+    }
+}
+// ----
+// testNot(uint256): 0 -> true
+// testNot(uint256): 5 -> false
+// testAnd(uint256,sbool): 0, true -> false
+// testAnd(uint256,sbool): 5, true -> true
+// testOr(uint256,sbool): 0, false -> false
+// testOr(uint256,sbool): 5, false -> true
+// testEq(uint256,sbool): 0, false -> true
+// testEq(uint256,sbool): 5, false -> false
+// testNeq(uint256,sbool): 0, false -> false
+// testNeq(uint256,sbool): 5, false -> true

--- a/test/libsolidity/semanticTests/types/shielded_sbool_operator_precedence.sol
+++ b/test/libsolidity/semanticTests/types/shielded_sbool_operator_precedence.sol
@@ -1,0 +1,23 @@
+contract C {
+    function andBeforeOr(sbool a, sbool b, sbool c) public pure returns (bool) {
+        return bool(a || b && c);
+    }
+
+    function withParens(sbool a, sbool b, sbool c) public pure returns (bool) {
+        return bool((a || b) && c);
+    }
+
+    function notBeforeAnd(sbool a, sbool b) public pure returns (bool) {
+        return bool(!a && b);
+    }
+}
+// ----
+// andBeforeOr(sbool,sbool,sbool): true, false, false -> true
+// withParens(sbool,sbool,sbool): true, false, false -> false
+// andBeforeOr(sbool,sbool,sbool): false, true, false -> false
+// withParens(sbool,sbool,sbool): false, true, false -> false
+// andBeforeOr(sbool,sbool,sbool): false, true, true -> true
+// withParens(sbool,sbool,sbool): false, true, true -> true
+// notBeforeAnd(sbool,sbool): true, true -> false
+// notBeforeAnd(sbool,sbool): false, true -> true
+// notBeforeAnd(sbool,sbool): false, false -> false

--- a/test/libsolidity/semanticTests/types/shielded_sbool_packed_storage_isolation.sol
+++ b/test/libsolidity/semanticTests/types/shielded_sbool_packed_storage_isolation.sol
@@ -1,0 +1,27 @@
+contract C {
+    sbool a;
+    sbool b;
+    sbool c;
+
+    function setAll(sbool _a, sbool _b, sbool _c) public {
+        a = _a;
+        b = _b;
+        c = _c;
+    }
+
+    function flipB() public {
+        b = !b;
+    }
+
+    function getAll() public view returns (bool, bool, bool) {
+        return (bool(a), bool(b), bool(c));
+    }
+}
+// ----
+// getAll() -> false, false, false
+// setAll(sbool,sbool,sbool): true, false, true ->
+// getAll() -> true, false, true
+// flipB() ->
+// getAll() -> true, true, true
+// setAll(sbool,sbool,sbool): false, true, false ->
+// getAll() -> false, true, false

--- a/test/libsolidity/semanticTests/types/shielded_sbool_short_circuit.sol
+++ b/test/libsolidity/semanticTests/types/shielded_sbool_short_circuit.sol
@@ -1,0 +1,27 @@
+contract C {
+    uint256 calls;
+
+    function mark(sbool v) internal returns (sbool) {
+        calls++;
+        return v;
+    }
+
+    function testOr(sbool a, sbool b) public returns (bool result, uint256 callCount) {
+        calls = 0;
+        sbool r = a || mark(b);
+        return (bool(r), calls);
+    }
+
+    function testAnd(sbool a, sbool b) public returns (bool result, uint256 callCount) {
+        calls = 0;
+        sbool r = a && mark(b);
+        return (bool(r), calls);
+    }
+}
+// ----
+// testOr(sbool,sbool): true, false -> true, 0
+// testOr(sbool,sbool): false, false -> false, 1
+// testOr(sbool,sbool): false, true -> true, 1
+// testAnd(sbool,sbool): false, true -> false, 0
+// testAnd(sbool,sbool): true, true -> true, 1
+// testAnd(sbool,sbool): true, false -> false, 1

--- a/test/libsolidity/semanticTests/types/shielded_sbool_storage_mutation.sol
+++ b/test/libsolidity/semanticTests/types/shielded_sbool_storage_mutation.sol
@@ -1,0 +1,43 @@
+contract C {
+    sbool value;
+    mapping(uint256 => sbool) values;
+
+    function setValue(sbool v) public {
+        value = v;
+    }
+
+    function getValue() public view returns (bool) {
+        return bool(value);
+    }
+
+    function clearValue() public {
+        delete value;
+    }
+
+    function setAt(uint256 k, sbool v) public {
+        values[k] = v;
+    }
+
+    function getAt(uint256 k) public view returns (bool) {
+        return bool(values[k]);
+    }
+
+    function clearAt(uint256 k) public {
+        delete values[k];
+    }
+}
+// ----
+// getValue() -> false
+// setValue(sbool): true ->
+// getValue() -> true
+// setValue(sbool): false ->
+// getValue() -> false
+// clearValue() ->
+// getValue() -> false
+// getAt(uint256): 7 -> false
+// setAt(uint256,sbool): 7, true ->
+// getAt(uint256): 7 -> true
+// setAt(uint256,sbool): 7, false ->
+// getAt(uint256): 7 -> false
+// clearAt(uint256): 7 ->
+// getAt(uint256): 7 -> false

--- a/test/libsolidity/syntaxTests/inlineAssembly/shielded_cload_on_sbool_ok.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/shielded_cload_on_sbool_ok.sol
@@ -1,0 +1,9 @@
+contract C {
+    sbool x;
+    function f() external view returns (uint r) {
+        assembly {
+            r := cload(x.slot)
+        }
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/inlineAssembly/shielded_cstore_on_sbool_ok.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/shielded_cstore_on_sbool_ok.sol
@@ -1,0 +1,9 @@
+contract C {
+    sbool x;
+    function f() external {
+        assembly {
+            cstore(x.slot, 1)
+        }
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_342_missing_bool_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_342_missing_bool_conversion.sol
@@ -1,0 +1,7 @@
+contract test {
+    function b(uint a) public {
+        sbool(a == 1);
+    }
+}
+// ----
+// Warning 2018: (20-76): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_536_array_length_invalid_expression_negative_sbool.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_536_array_length_invalid_expression_negative_sbool.sol
@@ -1,0 +1,5 @@
+contract C {
+    uint[-sbool(true)] ids;
+}
+// ----
+// TypeError 5462: (22-34): Invalid array length, expected integer literal or constant expression.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_537_array_length_invalid_expression_int_divides_sbool.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_537_array_length_invalid_expression_int_divides_sbool.sol
@@ -1,0 +1,5 @@
+contract C {
+    uint[sbool(true)/1] ids;
+}
+// ----
+// TypeError 5462: (22-35): Invalid array length, expected integer literal or constant expression.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_538_array_length_invalid_expression_sbool_divides_int.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_538_array_length_invalid_expression_sbool_divides_int.sol
@@ -1,0 +1,5 @@
+contract C {
+    uint[1/sbool(true)] ids;
+}
+// ----
+// TypeError 5462: (22-35): Invalid array length, expected integer literal or constant expression.


### PR DESCRIPTION
## Summary

- Mirrors four upstream `bool` tests in `nameAndTypeResolution/` that had no `shielded_` counterparts
- Adds `cload`/`cstore` success tests for `sbool` (previously only the `sstore` error case existed)
- Fills runtime semantic coverage gaps: `&&`, `||`, `!`, `==`, `!=`, default values, ABI v2 validation, and library attachment have zero existing semantic coverage

## New files (11 total)

### Syntax tests
| File | Covers |
|------|--------|
| `nameAndTypeResolution/shielded_342_missing_bool_conversion` | `sbool(runtime_expr)` is valid; pure warning only |
| `nameAndTypeResolution/shielded_536_array_length_invalid_expression_negative_sbool` | `-sbool(true)` as array length → TypeError 5462 |
| `nameAndTypeResolution/shielded_537_array_length_invalid_expression_int_divides_sbool` | `sbool(true)/1` as array length → TypeError 5462 |
| `nameAndTypeResolution/shielded_538_array_length_invalid_expression_sbool_divides_int` | `1/sbool(true)` as array length → TypeError 5462 |
| `inlineAssembly/shielded_cload_on_sbool_ok` | `cload(sbool.slot)` compiles clean |
| `inlineAssembly/shielded_cstore_on_sbool_ok` | `cstore(sbool.slot, 1)` compiles clean |

### Semantic tests
| File | Covers |
|------|--------|
| `abiEncoderV2/shielded_bool_out_of_bounds` | ABI v2 strict: `0xffffff` → FAILURE for sbool |
| `libraries/shielded_internal_library_function_attached_to_sbool` | `using L for sbool`; internal library XOR via `!=` |
| `types/shielded_sbool_logical_ops` | Runtime &&, \|\|, ! truth tables |
| `types/shielded_sbool_default_value` | Uninitialised sbool (storage + local) → false |
| `types/shielded_sbool_equality` | Runtime == and != (result is sbool, cast to bool) |

## Test plan
- [x] All 6 syntax tests verified passing with `isoltest --no-semantic-tests`
- [ ] Semantic tests require `seismic-revm`/`revme` — will be validated by CI