### PR TITLE
fix(yul): UnusedStoreEliminator drops CSTORE before external call

### DIFF
--- a/libyul/optimiser/UnusedStoreEliminator.cpp
+++ b/libyul/optimiser/UnusedStoreEliminator.cpp
@@ -311,12 +311,16 @@ bool UnusedStoreEliminator::knownUnrelated(
 	if (_op1.location == Location::Storage)
 	{
 		// Different storage domains (public vs shielded) are generally unrelated.
-		// However, CLOAD can read BOTH domains, so it's related to any storage store.
+		// Two exceptions: CLOAD reads from BOTH domains, and a wildcard storage
+		// read (an external call's storage Read with no concrete slot) can
+		// observe any active store regardless of domain.
 		// Note: _op1 is always a store (from m_storeOperations), so we only check _op2.
 		if (_op1.isShieldedStorage != _op2.isShieldedStorage)
 		{
-			bool op2IsCload = (_op2.effect == Effect::Read && _op2.isShieldedStorage);
-			if (!op2IsCload)
+			bool op2ReadsBothDomains =
+				(_op2.effect == Effect::Read && _op2.isShieldedStorage) ||
+				!_op2.start;
+			if (!op2ReadsBothDomains)
 				return true;
 		}
 		if (_op1.start && _op2.start)

--- a/test/libsolidity/semanticTests/optimizer/unused_store_eliminator_cstore_before_call.sol
+++ b/test/libsolidity/semanticTests/optimizer/unused_store_eliminator_cstore_before_call.sol
@@ -1,0 +1,30 @@
+contract C {
+    suint256 private secret;          // slot 0 (shielded domain)
+    uint256 public probedValue;       // slot 1 (public domain)
+
+    // Re-entered via the self-call inside trigger() between the two CSTOREs.
+    // We CLOAD slot 0 to capture whatever the shielded domain currently holds
+    // and stash it in a public slot we can read afterwards.
+    //
+    // Behaviour depending on whether trigger()'s first CSTORE was preserved:
+    //   - preserved:    cload(0) returns 100  -> probedValue() returns 100
+    //   - eliminated:   slot 0 is uninitialized, cload(0) returns 0
+    //                   -> probedValue() returns 0
+    fallback() external {
+        assembly {
+            sstore(1, cload(0))
+        }
+    }
+
+    function trigger() external {
+        address self = address(this);
+        assembly {
+            cstore(secret.slot, 100)
+            pop(call(gas(), self, 0, 0, 0, 0, 0))
+            cstore(secret.slot, 200)
+        }
+    }
+}
+// ----
+// trigger() ->
+// probedValue() -> 100


### PR DESCRIPTION
Fixes #261.

`UnusedStoreEliminator::knownUnrelated` short-circuited any pair where the two operations had different `isShieldedStorage` flags. That assumption breaks for the wildcard storage Read external calls produce — `CALL`, `STATICCALL`, `DELEGATECALL`, `CALLCODE`, `CREATE`, `CREATE2`, plus user-defined Yul functions whose body has `storage = Read`. A `CSTORE` placed before such a call was treated as unrelated to it, never marked as used, and silently covered by a later `CSTORE` to the same slot. During the call window the slot was no longer claimed for the shielded domain.

Reproduces in `--via-ir --optimize` only.

## Commits

- `test(yul): expose CSTORE-before-CALL elimination` — semantic test that re-enters via fallback during the call window, `cload`s slot 0, and stashes the value to a public slot. Buggy build returns 0; fixed build returns 100. Currently fails under `--via-ir --optimize`.
- `fix(yul): treat wildcard storage reads as cross-domain` — extends the cross-domain exception in `knownUnrelated` so a wildcard read (`!_op2.start`) is also treated as observing both domains, in addition to the existing CLOAD case.

## Test plan

- [x] New semantic test fails on `seismic` HEAD under `--via-ir --optimize`, passes in the other 3 configs
- [x] New semantic test passes in all 4 configs after the fix
- [x] Full semantic test suite (1912 files) passes under `--via-ir --optimize`
- [x] Full semantic test suite (1912 files) passes under `--optimize` (no via-IR)
- [x] `scripts/soltest.sh` passes (8340 cases)

## Notes

- Concrete-slot reads on a different domain (e.g., `SLOAD` to a known slot vs. `CSTORE` to a known slot) still short-circuit. That case is a separate bug tracked as P19 and will be fixed in a follow-up branch.