### PR TITLE
fix(yul): UnusedStoreEliminator drops CSTORE before same-slot cross-domain SLOAD

### DIFF
--- a/libyul/optimiser/UnusedStoreEliminator.cpp
+++ b/libyul/optimiser/UnusedStoreEliminator.cpp
@@ -311,16 +311,25 @@ bool UnusedStoreEliminator::knownUnrelated(
 	if (_op1.location == Location::Storage)
 	{
 		// Different storage domains (public vs shielded) are generally unrelated.
-		// Two exceptions: CLOAD reads from BOTH domains, and a wildcard storage
-		// read (an external call's storage Read with no concrete slot) can
-		// observe any active store regardless of domain.
+		// Three exceptions:
+		//   1. CLOAD reads from BOTH domains.
+		//   2. A wildcard storage read (an external call's storage Read with
+		//      no concrete slot) can observe any active store regardless of
+		//      domain.
+		//   3. A cross-domain access on the same slot is observable at runtime
+		//      (the load reverts because the slot is claimed for the other
+		//      domain), so the prior store must be kept live for the revert
+		//      to fire.
 		// Note: _op1 is always a store (from m_storeOperations), so we only check _op2.
 		if (_op1.isShieldedStorage != _op2.isShieldedStorage)
 		{
 			bool op2ReadsBothDomains =
 				(_op2.effect == Effect::Read && _op2.isShieldedStorage) ||
 				!_op2.start;
-			if (!op2ReadsBothDomains)
+			bool sameSlotCrossDomain =
+				_op1.start && _op2.start &&
+				!m_knowledgeBase.knownToBeDifferent(*_op1.start, *_op2.start);
+			if (!op2ReadsBothDomains && !sameSlotCrossDomain)
 				return true;
 		}
 		if (_op1.start && _op2.start)

--- a/test/libsolidity/semanticTests/optimizer/unused_store_eliminator_cstore_before_sload.sol
+++ b/test/libsolidity/semanticTests/optimizer/unused_store_eliminator_cstore_before_sload.sol
@@ -1,0 +1,18 @@
+contract C {
+    // The first CSTORE should claim slot 0 for the shielded domain. The
+    // following SLOAD on slot 0 must therefore revert (cross-domain access).
+    //
+    // If UnusedStoreEliminator wrongly treats the SLOAD as unrelated to the
+    // CSTORE because they live in different domains, it eliminates the first
+    // CSTORE, leaving the slot unclaimed when SLOAD runs. SLOAD then returns
+    // zero instead of reverting and trigger() succeeds — that is the bug.
+    function trigger(uint256 x, uint256 y) external returns (uint256 v) {
+        assembly {
+            cstore(add(0, 0), x)
+            v := sload(add(0, 0))
+            cstore(add(0, 0), y)
+        }
+    }
+}
+// ----
+// trigger(uint256,uint256): 100, 200 -> FAILURE


### PR DESCRIPTION
Fixes #263.

`UnusedStoreEliminator::knownUnrelated` short-circuits cross-domain pairs on the assumption that public and shielded slots cannot alias. That holds for two stores, but a cross-domain LOAD on the same slot is observable at runtime — it reverts because the slot is claimed for the other domain — so the prior store must be kept live for the revert to fire.

The pair `(CSTORE(N), SLOAD(N))` hits the buggy short-circuit. The SLOAD never marks the CSTORE as used, a later same-slot CSTORE covers it, and the first CSTORE is dropped. The slot is unclaimed when SLOAD runs, so SLOAD returns 0 instead of reverting.

Reproduces in `--via-ir --optimize` only.

Independent of #262 (P18). The two fixes compose cleanly — they sit in the same `if` block but address different short-circuit paths.

## Commits

- `test(yul): expose CSTORE-before-SLOAD same-slot elimination` — semantic test asserting `trigger(100, 200) -> FAILURE`. On the buggy build SLOAD returns 0 and trigger() succeeds, so the test fails.
- `fix(yul): keep CSTORE live before same-slot cross-domain SLOAD` — adds a same-slot check mirroring the existing `hasStorageDomainConflict` (used on the write path). Treats the pair as related when both operations have a known slot and `knowledgeBase.knownToBeDifferent` cannot prove they're different.

## Test plan

- [x] New semantic test fails on `seismic` HEAD under `--via-ir --optimize`, passes in the other 3 configs
- [x] New semantic test passes in all 4 configs after the fix
- [x] Full semantic test suite (1912 files) passes under `--via-ir --optimize`
- [x] Full semantic test suite (1912 files) passes under `--optimize` (no via-IR)
- [x] `scripts/soltest.sh` passes (8340 cases)

## Notes

- The wildcard external-call observer pattern is a separate bug, tracked as #261 and fixed in #262.