### PR TITLE
fix(yul): EqualStoreEliminator drops CSTORE after CLOAD

### DIFF
--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -97,6 +97,11 @@ void DataFlowAnalyzer::operator()(ExpressionStatement& _statement)
 					vars->second != value;
 			}));
 			m_state.environment.confidentialStorage[vars->first] = vars->second;
+			// CSTORE claims the slot for the shielded domain. Track this
+			// separately from the value cache so EqualStoreEliminator can
+			// distinguish "value already in slot" (which CLOAD also establishes)
+			// from "slot is provably shielded" (which only CSTORE establishes).
+			m_state.environment.confidentialStorageClaimed.insert(vars->first);
 			// cstore claims a slot, invalidating regular storage for the same key
 			// because in Seismic EVM a subsequent sload on that key would fail.
 			std::erase_if(m_state.environment.storage, mapTuple([&](auto&& key, auto&& /* value */) {
@@ -267,6 +272,11 @@ std::optional<YulName> DataFlowAnalyzer::confidentialStorageValue(YulName _key) 
 		return std::nullopt;
 }
 
+bool DataFlowAnalyzer::confidentialStorageIsClaimed(YulName _key) const
+{
+	return m_state.environment.confidentialStorageClaimed.contains(_key);
+}
+
 void DataFlowAnalyzer::handleAssignment(std::set<YulName> const& _variables, Expression* _value, bool _isDeclaration)
 {
 	if (!_isDeclaration)
@@ -301,6 +311,7 @@ void DataFlowAnalyzer::handleAssignment(std::set<YulName> const& _variables, Exp
 			std::erase_if(m_state.environment.storage, mapTuple([&name](auto&& /* key */, auto&& value) { return value == name; }));
 			// assignment to confidential storage slot denoted by "name"
 			m_state.environment.confidentialStorage.erase(name);
+			m_state.environment.confidentialStorageClaimed.erase(name);
 			// assignment to confidential storage slot contents denoted by "name"
 			std::erase_if(m_state.environment.confidentialStorage, mapTuple([&name](auto&& /* key */, auto&& value) { return value == name; }));
 			// assignment to slot denoted by "name"
@@ -371,6 +382,9 @@ void DataFlowAnalyzer::clearValues(std::set<YulName> const& _variablesToClear)
 	});
 	std::erase_if(m_state.environment.storage, eraseCondition);
 	std::erase_if(m_state.environment.confidentialStorage, eraseCondition);
+	std::erase_if(m_state.environment.confidentialStorageClaimed, [&_variablesToClear](auto&& key) {
+		return _variablesToClear.count(key);
+	});
 	std::erase_if(m_state.environment.memory, eraseCondition);
 	std::erase_if(m_state.environment.keccak, [&_variablesToClear](auto&& _item) {
 		return
@@ -410,6 +424,7 @@ void DataFlowAnalyzer::clearKnowledgeIfInvalidated(Block const& _block)
 	{
 		m_state.environment.storage.clear();
 		m_state.environment.confidentialStorage.clear();
+		m_state.environment.confidentialStorageClaimed.clear();
 	}
 	if (sideEffects.invalidatesMemory())
 	{
@@ -427,6 +442,7 @@ void DataFlowAnalyzer::clearKnowledgeIfInvalidated(Expression const& _expr)
 	{
 		m_state.environment.storage.clear();
 		m_state.environment.confidentialStorage.clear();
+		m_state.environment.confidentialStorageClaimed.clear();
 	}
 	if (sideEffects.invalidatesMemory())
 	{
@@ -505,6 +521,11 @@ void DataFlowAnalyzer::joinKnowledge(Environment const& _olderEnvironment)
 		return;
 	joinKnowledgeHelper(m_state.environment.storage, _olderEnvironment.storage);
 	joinKnowledgeHelper(m_state.environment.confidentialStorage, _olderEnvironment.confidentialStorage);
+	// A slot is claimed at the join point only if it was claimed in BOTH
+	// branches — drop entries that aren't in the older environment.
+	std::erase_if(m_state.environment.confidentialStorageClaimed, [&_olderEnvironment](auto&& key) {
+		return !_olderEnvironment.confidentialStorageClaimed.contains(key);
+	});
 	joinKnowledgeHelper(m_state.environment.memory, _olderEnvironment.memory);
 	std::erase_if(m_state.environment.keccak, mapTuple([&_olderEnvironment](auto&& key, auto&& currentValue) {
 		YulName const* oldValue = valueOrNullptr(_olderEnvironment.keccak, key);

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -34,6 +34,7 @@
 
 #include <map>
 #include <set>
+#include <unordered_set>
 
 namespace solidity::yul
 {
@@ -109,6 +110,11 @@ public:
 	std::optional<YulName> storageValue(YulName _key) const;
 	std::optional<YulName> memoryValue(YulName _key) const;
 	std::optional<YulName> confidentialStorageValue(YulName _key) const;
+	/// @returns true iff @p _key is provably claimed for the shielded domain
+	/// (i.e. a prior CSTORE on this slot is still live in the current state).
+	/// CLOAD does not establish a claim, so a hit on confidentialStorageValue
+	/// alone is not enough to prove the slot is shielded.
+	bool confidentialStorageIsClaimed(YulName _key) const;
 	std::optional<YulName> keccakValue(YulName _start, YulName _length) const;
 
 protected:
@@ -175,6 +181,12 @@ private:
 		std::unordered_map<YulName, YulName> storage;
 		std::unordered_map<YulName, YulName> memory;
 		std::unordered_map<YulName, YulName> confidentialStorage;
+		/// Slot identifiers known to have been claimed for the shielded
+		/// domain via a CSTORE. CLOAD reads both public and shielded
+		/// domains, so a confidentialStorage entry alone is not enough to
+		/// prove the slot is shielded — only entries also present here
+		/// allow safe elimination of a redundant CSTORE.
+		std::unordered_set<YulName> confidentialStorageClaimed;
 		/// If keccak[s, l] = y then y := keccak256(s, l) occurs in the code.
 		std::map<std::pair<YulName, YulName>, YulName> keccak;
 	};

--- a/libyul/optimiser/EqualStoreEliminator.cpp
+++ b/libyul/optimiser/EqualStoreEliminator.cpp
@@ -65,9 +65,15 @@ void EqualStoreEliminator::visit(Statement& _statement)
 		}
 		else if (auto vars = isSimpleStore(StoreLoadLocation::ConfidentialStorage, *expression))
 		{
+			// confidentialStorage is also populated by CLOAD, which reads both
+			// public and shielded slots. A value-cache hit alone is therefore
+			// not enough to drop the CSTORE: the CSTORE has a domain-claim
+			// side effect that CLOAD does not. Require an explicit prior
+			// CSTORE on this slot (tracked separately) before eliminating.
 			if (std::optional<YulName> currentValue = confidentialStorageValue(vars->first))
 				if (*currentValue == vars->second)
-					m_pendingRemovals.insert(&_statement);
+					if (confidentialStorageIsClaimed(vars->first))
+						m_pendingRemovals.insert(&_statement);
 		}
 	}
 

--- a/test/libsolidity/semanticTests/optimizer/equal_store_eliminator_cstore_after_cload.sol
+++ b/test/libsolidity/semanticTests/optimizer/equal_store_eliminator_cstore_after_cload.sol
@@ -1,0 +1,29 @@
+contract C {
+    // The "seal a slot as private" pattern: read the current value via CLOAD
+    // (which reads both domains), then write it back via CSTORE to claim the
+    // slot for the shielded domain.
+    //
+    // EqualStoreEliminator wrongly treats the CSTORE as redundant because the
+    // optimizer's confidentialStorage cache was populated by the preceding
+    // CLOAD with the same value. The cache only encodes "value v lives in
+    // slot k" — it doesn't encode the domain claim that CSTORE adds, so the
+    // CSTORE must not be eliminated solely on a cache hit from a CLOAD.
+    function seal(uint256 k) external {
+        assembly {
+            let v := cload(k)
+            cstore(k, v)
+        }
+    }
+
+    // Probes the slot via SLOAD. After seal() the slot should be claimed for
+    // the shielded domain, so SLOAD must revert. If the optimizer dropped the
+    // CSTORE, the slot is still unclaimed and SLOAD returns 0.
+    function probe(uint256 k) external returns (uint256 r) {
+        assembly {
+            r := sload(k)
+        }
+    }
+}
+// ----
+// seal(uint256): 0 ->
+// probe(uint256): 0 -> FAILURE


### PR DESCRIPTION
Fixes #265.

`EqualStoreEliminator` was eliminating `cstore(k, v)` whenever `confidentialStorage[k] == v` in the optimizer's value cache. That cache is populated by both CSTORE (slot provably shielded) and CLOAD (slot domain unknown — CLOAD reads both domains). On a CLOAD-populated hit the slot may still be public, in which case the CSTORE is the operation that claims it for the shielded domain. Eliminating it silently leaves the slot public; a subsequent SLOAD or `eth_getStorageAt` returns the value the developer believed was private.

Reproduces in `--via-ir --optimize` only.

## Approach

Track shielded-domain claims in a parallel `confidentialStorageClaimed` set on the data-flow environment, populated only by CSTORE. Mirror it through every existing `confidentialStorage` invalidation path:

- variable reassignment (`erase(name)`)
- value-side erasure (`erase_if value == name`) — N/A, claim has no value field
- `clearValues` (control-flow merge clearing)
- both `clearKnowledgeIfInvalidated` overloads (`clear()` on storage-invalidating side effects)
- `joinKnowledge` (intersection across branches at if/switch joins)

`EqualStoreEliminator` then drops a CSTORE only when the value matches AND the slot is provably claimed.

The cache continues to be populated by CLOAD as before, so `LoadResolver` still elides redundant CLOADs (range checks `x > min && x < max`, repeated reads of the same shielded var, arithmetic over the same var). The simpler "stop populating from CLOAD" approach was tried first and rejected — it adds real gas cost on common patterns.

## Commits

- `test(yul): expose CSTORE-after-CLOAD elimination` — semantic test sealing slot 0 then probing via SLOAD; correct: SLOAD reverts; buggy: SLOAD returns 0. Currently fails under `--via-ir --optimize`.
- `fix(yul): require explicit CSTORE before eliminating same-value CSTORE` — adds the claim set, accessor, and the EqualStoreEliminator check.

## Test plan

- [x] New semantic test fails on `seismic` HEAD under `--via-ir --optimize`, passes in the other 3 configs
- [x] New semantic test passes in all 4 configs after the fix
- [x] Full semantic test suite (1913 files) passes under `--via-ir --optimize`
- [x] Full semantic test suite (1913 files) passes under `--optimize` (no via-IR)
- [x] `scripts/soltest.sh` passes (8340 cases)
- [x] CLOAD count on a 5-pattern benchmark (`x+x`, `x>min && x<max`, two reads, loop-read, array element twice) unchanged vs. current `seismic` — confirming `LoadResolver` cload-elimination is preserved