### PR TITLE
fix(smtchecker): widen isInteger/isFixedBytes for shielded types

### DIFF
--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -345,7 +345,8 @@ std::pair<bool, std::shared_ptr<SymbolicVariable>> newSymbolicVariable(
 
 bool isInteger(frontend::Type const& _type)
 {
-	return _type.category() == frontend::Type::Category::Integer;
+	return _type.category() == frontend::Type::Category::Integer
+		|| _type.category() == frontend::Type::Category::ShieldedInteger;
 }
 
 bool isFixedPoint(frontend::Type const& _type)
@@ -360,7 +361,8 @@ bool isRational(frontend::Type const& _type)
 
 bool isFixedBytes(frontend::Type const& _type)
 {
-	return _type.category() == frontend::Type::Category::FixedBytes;
+	return _type.category() == frontend::Type::Category::FixedBytes
+		|| _type.category() == frontend::Type::Category::ShieldedFixedBytes;
 }
 
 bool isAddress(frontend::Type const& _type)

--- a/test/libsolidity/smtCheckerTests/types/shielded_fixed_bytes_bound_preserved.sol
+++ b/test/libsolidity/smtCheckerTests/types/shielded_fixed_bytes_bound_preserved.sol
@@ -1,0 +1,15 @@
+contract C {
+	sbytes32 private secret;
+	function check(bytes32 b) external {
+		secret = sbytes32(b);
+		bytes32 readBack = bytes32(secret);
+		// The shielded round-trip must preserve `readBack == b`. Without the
+		// SymbolicTypes.cpp predicate widening, the sbytes32 hop is unmodelled
+		// and the assertion is reported as possibly violated.
+		assert(readBack == b);
+	}
+}
+// ====
+// SMTEngine: bmc
+// ----
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/shielded_integer_bound_preserved.sol
+++ b/test/libsolidity/smtCheckerTests/types/shielded_integer_bound_preserved.sol
@@ -1,0 +1,19 @@
+contract C {
+	suint256 private secret;
+	function check(uint256 v) external {
+		// Provably in [0, 255]: v % 256 cannot exceed 255.
+		uint256 safe = v % 256;
+		secret = suint256(safe);
+		uint256 readBack = uint256(secret);
+		// Should be provable: the bound on `safe` must propagate through
+		// the shielded round-trip. The bug: the suint256 hop is unmodelled
+		// by SMTChecker (predicates in SymbolicTypes.cpp drop ShieldedInteger),
+		// so the modulo bound is lost and the assertion is reported as
+		// possibly violated.
+		assert(readBack < 256);
+	}
+}
+// ====
+// SMTEngine: bmc
+// ----
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.


### PR DESCRIPTION
Fixes #267 (partial — see scope note below).

SMTChecker silently dropped every read/write of a shielded variable because `SymbolicTypes.cpp`'s category predicates only matched the unshielded forms. `isInteger`, `isFixedBytes`, and the aggregates `isNumber`/`isSupportedType` returned false on `suintN`/`sbytesN`, so the encoder's "we can model this" branch was never taken; it emitted a soft "Assertion checker does not yet implement..." warning and proceeded to produce verification results that did not constrain the shielded path. The audit's `BoundLost` example demonstrates the consequence: an arithmetic bound established on a uint is lost when the value passes through a `suint256` round-trip.

## Scope

This PR addresses **only** the `isInteger` and `isFixedBytes` widenings. `isBool` is intentionally deferred to P21 — see [issue #267 comment](https://github.com/SeismicSystems/seismic-solidity/issues/267#issuecomment-4372804996) for the full reasoning. Briefly: widening `isBool` in isolation lets `sbool` reach `SymbolicVariables.cpp:114` and `SMTEncoder.cpp:1193`, where the encoder's downstream `solAssert`s and conversion machinery still expect `Category::Bool` exactly — so a soft "unsupported" warning becomes a hard internal-compiler-error crash on `sbool(b)` conversions. P21 already tracks the deeper plumbing those sites need, so the `isBool` widening is best bundled there.

## Why the predicate widening is enough for integer/fixed-bytes

`ShieldedIntegerType` inherits from `IntegerType`; `ShieldedFixedBytesType` from `FixedBytesType`. The symbolic encoder's downstream paths (`minValue`, `maxValue`, `isSigned`, `smtSort`) all operate via `dynamic_cast<IntegerType const*>` / `dynamic_cast<FixedBytesType const*>`, so they already accept shielded values once the predicates do. No further plumbing is needed.

## Commits

- `test(smtchecker): expose lost arithmetic bound through shielded types` — adds two BMC tests (suint round-trip, sbytes32 round-trip). Both fail on `seismic` HEAD (the audit's symptom), pass after the fix.
- `fix(smtchecker): widen isInteger/isFixedBytes to accept shielded types` — the four-line widening.

## Test plan

- [x] New tests fail on `zellic-audit-april-2026` HEAD before the fix; pass after
- [x] Full semantic test suite (1914 files) passes under `--via-ir --optimize`
- [x] Full semantic test suite (1914 files) passes under `--optimize` (no via-IR)
- [x] `soltest` passes; the fix introduces no regressions.