### PR TITLE
fix(smtchecker): widen category checks to accept shielded types

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -1141,6 +1141,13 @@ void SMTEncoder::visitTypeConversion(FunctionCall const& _funCall)
 		return;
 	}
 
+	// bool <-> sbool: value-level identity (shielded flag is storage-domain only).
+	if (smt::isBool(*argType) && smt::isBool(*funCallType))
+	{
+		defineExpr(_funCall, symbArg);
+		return;
+	}
+
 	// TODO Simplify this whole thing for 0.8.0 where weird casts are disallowed.
 
 	unsigned argSize = argType->storageBytes();
@@ -1823,7 +1830,7 @@ void SMTEncoder::arithmeticOperation(BinaryOperation const& _op)
 {
 	auto type = _op.annotation().commonType;
 	solAssert(type, "");
-	solAssert(type->category() == Type::Category::Integer || type->category() == Type::Category::FixedPoint, "");
+	solAssert(smt::isInteger(*type) || smt::isFixedPoint(*type), "");
 	switch (_op.getOperator())
 	{
 	case Token::Add:
@@ -1868,10 +1875,7 @@ std::pair<smtutil::Expression, smtutil::Expression> SMTEncoder::arithmeticOperat
 	};
 	solAssert(validOperators.count(_op), "");
 	solAssert(_commonType, "");
-	solAssert(
-		_commonType->category() == Type::Category::Integer || _commonType->category() == Type::Category::FixedPoint,
-		""
-	);
+	solAssert(smt::isInteger(*_commonType) || smt::isFixedPoint(*_commonType), "");
 
 	IntegerType const* intType = nullptr;
 	if (auto type = dynamic_cast<IntegerType const*>(_commonType))
@@ -2041,7 +2045,7 @@ void SMTEncoder::booleanOperation(BinaryOperation const& _op)
 {
 	solAssert(_op.getOperator() == Token::And || _op.getOperator() == Token::Or, "");
 	solAssert(_op.annotation().commonType, "");
-	solAssert(_op.annotation().commonType->category() == Type::Category::Bool, "");
+	solAssert(smt::isBool(*_op.annotation().commonType), "");
 	// @TODO check that both of them are not constant
 	_op.leftExpression().accept(*this);
 	if (_op.getOperator() == Token::And)

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -398,7 +398,8 @@ bool isNumber(frontend::Type const& _type)
 
 bool isBool(frontend::Type const& _type)
 {
-	return _type.category() == frontend::Type::Category::Bool;
+	return _type.category() == frontend::Type::Category::Bool
+		|| _type.category() == frontend::Type::Category::ShieldedBool;
 }
 
 bool isFunction(frontend::Type const& _type)

--- a/libsolidity/formal/SymbolicVariables.cpp
+++ b/libsolidity/formal/SymbolicVariables.cpp
@@ -111,7 +111,7 @@ SymbolicBoolVariable::SymbolicBoolVariable(
 ):
 	SymbolicVariable(_type, _type, std::move(_uniqueName), _context)
 {
-	solAssert(m_type->category() == frontend::Type::Category::Bool, "");
+	solAssert(isBool(*m_type), "");
 }
 
 SymbolicIntVariable::SymbolicIntVariable(

--- a/test/libsolidity/smtCheckerTests/types/shielded_bool_conversions.sol
+++ b/test/libsolidity/smtCheckerTests/types/shielded_bool_conversions.sol
@@ -1,0 +1,17 @@
+contract C {
+	// Exercises visitTypeConversion's size-mismatch branches at lines 1193
+	// and 1233. bool storageBytes == 1, sbool == 32, so any bool<->sbool
+	// cast lands in a size-changing branch that solAsserts the target type
+	// is a number — neither bool nor sbool is.
+	function up(bool b) external pure returns (bool) {
+		// bool -> sbool -> bool round-trip; should preserve the value.
+		sbool s = sbool(b);
+		bool r = bool(s);
+		assert(r == b);
+		return r;
+	}
+}
+// ====
+// SMTEngine: bmc
+// ----
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/shielded_bool_logical.sol
+++ b/test/libsolidity/smtCheckerTests/types/shielded_bool_logical.sol
@@ -1,0 +1,16 @@
+contract C {
+	// Exercises booleanOperation, which previously solAsserted
+	// commonType->category() == Bool exactly. sbool && sbool is allowed by
+	// the type checker (inherited BoolType::binaryOperatorResult) but
+	// crashed the SMT checker.
+	function andOp(sbool a, sbool b) external pure returns (bool) {
+		return bool(a && b);
+	}
+
+	function orOp(sbool a, sbool b) external pure returns (bool) {
+		return bool(a || b);
+	}
+}
+// ====
+// SMTEngine: bmc
+// ----

--- a/test/libsolidity/smtCheckerTests/types/shielded_bool_variable.sol
+++ b/test/libsolidity/smtCheckerTests/types/shielded_bool_variable.sol
@@ -1,0 +1,13 @@
+contract C {
+	// Exercises SymbolicBoolVariable's constructor, which previously
+	// solAsserted m_type->category() == Bool exactly. Even just declaring
+	// an sbool variable triggers this once isBool is widened to accept
+	// ShieldedBool.
+	sbool flag;
+	function f(bool b) external {
+		flag = sbool(b);
+	}
+}
+// ====
+// SMTEngine: bmc
+// ----

--- a/test/libsolidity/smtCheckerTests/types/shielded_integer_arithmetic.sol
+++ b/test/libsolidity/smtCheckerTests/types/shielded_integer_arithmetic.sol
@@ -1,0 +1,20 @@
+contract C {
+	// Exercises SMTEncoder::arithmeticOperation, which previously
+	// solAsserted on commonType->category() == Integer || FixedPoint.
+	// ShieldedIntegerType returns Category::ShieldedInteger, causing
+	// an internal compiler error on any suint binary op.
+	function addInternal(suint256 a, suint256 b) internal pure returns (suint256) {
+		return a + b;
+	}
+
+	function f(suint256 a, suint256 b) external pure returns (uint256) {
+		// Cast to unshielded at the boundary; the inner add() exercises the
+		// shielded arithmetic path that previously crashed SMTChecker.
+		return uint256(addInternal(a, b));
+	}
+}
+// ====
+// SMTEngine: bmc
+// ----
+// Warning 10301: (357-362): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.
+// Warning 2661: (357-362): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.

--- a/test/libsolidity/smtCheckerTests/types/shielded_integer_inc_dec.sol
+++ b/test/libsolidity/smtCheckerTests/types/shielded_integer_inc_dec.sol
@@ -1,0 +1,29 @@
+contract C {
+	// Exercises arithmeticOperation's helper, which previously solAsserted
+	// commonType == Integer || FixedPoint exactly. suint pre/post-increment
+	// and decrement reach this site.
+	function incInternal(suint256 x) internal pure returns (suint256) {
+		x++;
+		return x;
+	}
+
+	function decInternal(suint256 x) internal pure returns (suint256) {
+		--x;
+		return x;
+	}
+
+	function f(suint256 x) external pure returns (uint256) {
+		return uint256(incInternal(x));
+	}
+
+	function g(suint256 x) external pure returns (uint256) {
+		return uint256(decInternal(x));
+	}
+}
+// ====
+// SMTEngine: bmc
+// ----
+// Warning 10302: (266-269): Shielded integer increment can leak information. A revert due to overflow reveals range information about the operand.
+// Warning 10302: (358-361): Shielded integer decrement can leak information. A revert due to overflow reveals range information about the operand.
+// Warning 2661: (266-269): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
+// Warning 4144: (358-361): BMC: Underflow (resulting value less than 0) happens here.


### PR DESCRIPTION
Fixes #269.

After P20 (#268), six SMTChecker sites still checked `Type::Category` exactly instead of going through the `smt::is*` predicates. Any contract using `suint` arithmetic, `suint++`/`--`, `sbool` boolean ops, `sbool` variables, or `bool↔sbool` conversions hit an InternalCompilerError. Strictly worse than P20's silent-drop baseline.

## Fix

1. Widen `isBool` in `SymbolicTypes.cpp` to accept `Category::ShieldedBool` (P20 deferred this because the downstream sites would crash; this PR fixes those first).
2. Convert exact-category checks to predicate calls:
   - `arithmeticOperation` (1826) + helper (1871) → `smt::isInteger || smt::isFixedPoint`
   - `booleanOperation` (2044) → `smt::isBool`
   - `SymbolicBoolVariable` ctor → `isBool(*m_type)`
   - `visitTypeConversion` (1193, 1233) → short-circuit `bool↔sbool` as a value-level identity before the size-mismatch branches.

`ShieldedIntegerType`/`ShieldedBoolType` inherit from their unshielded counterparts, so the existing `dynamic_cast`-based machinery accepts them once the predicates do.

The audit listed sites 1826/481/2044. Site 481 was fixed transitively by P20. The other three are addressed plus three additional sites of the same shape (SymbolicBoolVariable ctor + two visitTypeConversion solAsserts) found while implementing P20.

## Test plan

- [x] Five new tests covering each crash site fail on base with ICE; pass after
- [x] Full semantic suite (1914 files) passes under `--via-ir --optimize` and `--optimize`
- [x] All seven shielded SMTChecker tests pass under isoltest