### PR TITLE
fix(smtchecker): model Seismic precompiles in endVisit(FunctionCall)

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -674,7 +674,15 @@ void SMTEncoder::endVisit(FunctionCall const& _funCall)
 	case FunctionType::Kind::ECRecover:
 	case FunctionType::Kind::SHA256:
 	case FunctionType::Kind::RIPEMD160:
+	case FunctionType::Kind::SeismicHKDF:
+	case FunctionType::Kind::SeismicECDH:
+	case FunctionType::Kind::SeismicAESGCMEncrypt:
+	case FunctionType::Kind::SeismicAESGCMDecrypt:
+	case FunctionType::Kind::SeismicSecp256k1Sign:
 		visitCryptoFunction(_funCall);
+		break;
+	case FunctionType::Kind::SeismicRNG:
+		// unsafe_rng_* is non-deterministic by design — leave the result unconstrained.
 		break;
 	case FunctionType::Kind::BlockHash:
 		defineExpr(_funCall, state().blockhash(expr(*_funCall.arguments().at(0))));
@@ -874,6 +882,62 @@ void SMTEncoder::visitCryptoFunction(FunctionCall const& _funCall)
 			{arg0, arg1, arg2, arg3}
 		);
 		result = smtutil::Expression::select(e, ecrecoverInput);
+	}
+	else if (kind == FunctionType::Kind::SeismicHKDF)
+		result = smtutil::Expression::select(
+			state().cryptoFunction("hkdf"),
+			expr(*_funCall.arguments().at(0), TypeProvider::bytesStorage())
+		);
+	else if (
+		kind == FunctionType::Kind::SeismicECDH ||
+		kind == FunctionType::Kind::SeismicAESGCMEncrypt ||
+		kind == FunctionType::Kind::SeismicAESGCMDecrypt ||
+		kind == FunctionType::Kind::SeismicSecp256k1Sign
+	)
+	{
+		std::string name;
+		std::vector<smtutil::Expression> args;
+		if (kind == FunctionType::Kind::SeismicECDH)
+		{
+			name = "ecdh";
+			args = {
+				expr(*_funCall.arguments().at(0), TypeProvider::fixedBytes(32)),
+				expr(*_funCall.arguments().at(1), TypeProvider::bytesStorage())
+			};
+		}
+		else if (kind == FunctionType::Kind::SeismicAESGCMEncrypt)
+		{
+			name = "aes_gcm_encrypt";
+			args = {
+				expr(*_funCall.arguments().at(0), TypeProvider::fixedBytes(32)),
+				expr(*_funCall.arguments().at(1), TypeProvider::uint(96)),
+				expr(*_funCall.arguments().at(2), TypeProvider::bytesStorage())
+			};
+		}
+		else if (kind == FunctionType::Kind::SeismicAESGCMDecrypt)
+		{
+			name = "aes_gcm_decrypt";
+			args = {
+				expr(*_funCall.arguments().at(0), TypeProvider::fixedBytes(32)),
+				expr(*_funCall.arguments().at(1), TypeProvider::uint(96)),
+				expr(*_funCall.arguments().at(2), TypeProvider::bytesStorage())
+			};
+		}
+		else
+		{
+			name = "secp256k1_sign";
+			args = {
+				expr(*_funCall.arguments().at(0), TypeProvider::fixedBytes(32)),
+				expr(*_funCall.arguments().at(1), TypeProvider::fixedBytes(32))
+			};
+		}
+		auto e = state().cryptoFunction(name);
+		auto inputSort = dynamic_cast<smtutil::ArraySort&>(*e.sort).domain;
+		auto input = smtutil::Expression::tuple_constructor(
+			smtutil::Expression(std::make_shared<smtutil::SortSort>(inputSort), ""),
+			args
+		);
+		result = smtutil::Expression::select(e, input);
 	}
 	else
 		solAssert(false, "");

--- a/libsolidity/formal/SymbolicState.h
+++ b/libsolidity/formal/SymbolicState.h
@@ -268,6 +268,56 @@ private:
 					}
 				),
 				smtSort(*TypeProvider::address())
+			)},
+			{"hkdf", std::make_shared<smtutil::ArraySort>(
+				smt::smtSort(*TypeProvider::bytesStorage()),
+				smtSort(*TypeProvider::fixedBytes(32))
+			)},
+			{"ecdh", std::make_shared<smtutil::ArraySort>(
+				std::make_shared<smtutil::TupleSort>(
+					"ecdh_input_type",
+					std::vector<std::string>{"priv", "pub"},
+					std::vector<smtutil::SortPointer>{
+						smt::smtSort(*TypeProvider::fixedBytes(32)),
+						smt::smtSort(*TypeProvider::bytesStorage())
+					}
+				),
+				smtSort(*TypeProvider::fixedBytes(32))
+			)},
+			{"aes_gcm_encrypt", std::make_shared<smtutil::ArraySort>(
+				std::make_shared<smtutil::TupleSort>(
+					"aes_gcm_encrypt_input_type",
+					std::vector<std::string>{"key", "nonce", "plaintext"},
+					std::vector<smtutil::SortPointer>{
+						smt::smtSort(*TypeProvider::fixedBytes(32)),
+						smt::smtSort(*TypeProvider::uint(96)),
+						smt::smtSort(*TypeProvider::bytesStorage())
+					}
+				),
+				smtSort(*TypeProvider::bytesStorage())
+			)},
+			{"aes_gcm_decrypt", std::make_shared<smtutil::ArraySort>(
+				std::make_shared<smtutil::TupleSort>(
+					"aes_gcm_decrypt_input_type",
+					std::vector<std::string>{"key", "nonce", "ciphertext"},
+					std::vector<smtutil::SortPointer>{
+						smt::smtSort(*TypeProvider::fixedBytes(32)),
+						smt::smtSort(*TypeProvider::uint(96)),
+						smt::smtSort(*TypeProvider::bytesStorage())
+					}
+				),
+				smtSort(*TypeProvider::bytesStorage())
+			)},
+			{"secp256k1_sign", std::make_shared<smtutil::ArraySort>(
+				std::make_shared<smtutil::TupleSort>(
+					"secp256k1_sign_input_type",
+					std::vector<std::string>{"priv", "hash"},
+					std::vector<smtutil::SortPointer>{
+						smt::smtSort(*TypeProvider::fixedBytes(32)),
+						smt::smtSort(*TypeProvider::fixedBytes(32))
+					}
+				),
+				smtSort(*TypeProvider::bytesStorage())
 			)}
 		},
 		m_context

--- a/test/libsolidity/smtCheckerTests/crypto/seismic_precompiles_same_input_same_output.sol
+++ b/test/libsolidity/smtCheckerTests/crypto/seismic_precompiles_same_input_same_output.sol
@@ -1,0 +1,32 @@
+contract C {
+	function h(bytes memory b0) public view {
+		bytes memory b1 = b0;
+		bytes32 k0 = hkdf(b0);
+		bytes32 k1 = hkdf(b1);
+		assert(k0 == k1);
+	}
+	function e(sbytes32 priv, bytes memory pub) public view {
+		bytes32 a0 = ecdh(priv, pub);
+		bytes32 a1 = ecdh(priv, pub);
+		assert(a0 == a1);
+	}
+	function ge(sbytes32 key, uint96 nonce, bytes memory plain) public view {
+		bytes memory c0 = aes_gcm_encrypt(key, nonce, plain);
+		bytes memory c1 = aes_gcm_encrypt(key, nonce, plain);
+		assert(c0.length == c1.length);
+	}
+	function gd(sbytes32 key, uint96 nonce, bytes memory cipher) public view {
+		bytes memory p0 = aes_gcm_decrypt(key, nonce, cipher);
+		bytes memory p1 = aes_gcm_decrypt(key, nonce, cipher);
+		assert(p0.length == p1.length);
+	}
+	function s(sbytes32 priv, bytes32 hashed) public view {
+		bytes memory s0 = secp256k1_sign(priv, hashed);
+		bytes memory s1 = secp256k1_sign(priv, hashed);
+		assert(s0.length == s1.length);
+	}
+}
+// ====
+// SMTEngine: bmc
+// ----
+// Info 6002: BMC: 5 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.


### PR DESCRIPTION
Fixes #271.

Six Seismic precompile `FunctionType::Kind` values had no case in `SMTEncoder::endVisit(FunctionCall)`. Calls fell through to default and got unconstrained symbolic values, so two `hkdf(seed)` calls with identical input returned different symbols and CHC reported a spurious counterexample.

## Fix

Register the five deterministic precompiles in `SymbolicState.h`'s `m_crypto` initializer, mirroring `keccak256`/`ecrecover`. Dispatch the matching `FunctionType::Kind` values to `visitCryptoFunction`, which builds an input tuple (where needed) and selects from the uninterpreted array. `SeismicRNG` gets an explicit empty case since `unsafe_rng_*` is non-deterministic by design.

## Test plan

- [x] New test (`smtCheckerTests/crypto/seismic_precompiles_same_input_same_output.sol`) fails on base; passes after the fix
- [x] Audit's literal `hkdf` PoC now reports `1 verification condition(s) proved safe` under both BMC and CHC
- [x] Full semantic test suite (1914 files) passes under `--via-ir --optimize`
- [x] All eight shielded SMTChecker tests (P20+P21+P22) pass under isoltest