### PR TITLE
fix(codegen): pass shielded flag from source array in bytesToFixedBytes

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -3931,7 +3931,7 @@ std::string YulUtilFunctions::bytesToFixedBytesConversionFunction(ArrayType cons
 			templ(
 				"extractValue",
 				_from.dataStoredIn(DataLocation::Storage) ?
-				readFromStorage(_to, 32 - _to.numBytes(), false, VariableDeclaration::Location::Unspecified) :
+				readFromStorage(_to, 32 - _to.numBytes(), false, VariableDeclaration::Location::Unspecified, _from.usesShieldedStorage()) :
 				readFromMemory(_to)
 			);
 		templ("shl", shiftLeftFunctionDynamic());

--- a/test/libsolidity/semanticTests/conversions/sbytes_to_fixed_bytes.sol
+++ b/test/libsolidity/semanticTests/conversions/sbytes_to_fixed_bytes.sol
@@ -1,0 +1,14 @@
+contract C {
+	sbytes private sb;
+
+	function init() external {
+		sb = "hi";
+	}
+
+	function get() external view returns (bytes8) {
+		return bytes8(bytes(sb));
+	}
+}
+// ----
+// init() ->
+// get() -> 0x6869000000000000000000000000000000000000000000000000000000000000


### PR DESCRIPTION
Fixes #275.

`bytesToFixedBytesConversionFunction` chose the storage read helper based on the public destination `FixedBytesType`, so `bytes8(bytes(sb))` emitted `SLOAD` on the shielded data slot and reverted at runtime.

## Fix

`readFromStorage` already takes a `_useShieldedStorageOps` flag for exactly this case. Pass `_from.usesShieldedStorage()` through to it. One-line change.

## Test plan

- [x] New test (`semanticTests/conversions/sbytes_to_fixed_bytes.sol`) fails on base with `InvalidPrivateStorageAccess`; passes after the fix in all 4 optimizer × via-IR configs
- [x] Full semantic test suite (1916 files) passes under `--via-ir --optimize` and `--optimize`