### PR TITLE
fix(typechecker): preserve shielded marker across tuple assignment

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1836,6 +1836,27 @@ bool TypeChecker::visit(Assignment const& _assignment)
 		_assignment.annotation().type = TypeProvider::emptyTuple();
 
 		expectType(_assignment.rightHandSide(), *tupleType);
+
+		// Mirror the single-component branch below: propagate the shielded
+		// storage marker from each RHS component onto the matching LHS local.
+		auto const* lhsTuple = dynamic_cast<TupleExpression const*>(&_assignment.leftHandSide());
+		auto const* rhsTupleType = dynamic_cast<TupleType const*>(type(_assignment.rightHandSide()));
+		if (lhsTuple && rhsTupleType)
+		{
+			auto const& lhsComponents = lhsTuple->components();
+			auto const& rhsComponents = rhsTupleType->components();
+			for (size_t i = 0; i < std::min(lhsComponents.size(), rhsComponents.size()); ++i)
+			{
+				if (!lhsComponents[i] || !rhsComponents[i])
+					continue;
+				auto const* identifier = dynamic_cast<Identifier const*>(lhsComponents[i].get());
+				if (!identifier)
+					continue;
+				auto const* variable = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration);
+				if (variable && canPreserveShieldedStorageMarkerInAssignment(*variable))
+					preserveShieldedStorageMarkerInDeclaration(*variable, *rhsComponents[i]);
+			}
+		}
 	}
 	else if (_assignment.assignmentOperator() == Token::Assign)
 	{

--- a/test/libsolidity/semanticTests/types/sbytes_tuple_assignment_marker.sol
+++ b/test/libsolidity/semanticTests/types/sbytes_tuple_assignment_marker.sol
@@ -1,0 +1,27 @@
+contract C {
+	sbytes private secret;
+
+	function init() external {
+		secret.push(sbytes1(0xAA));
+	}
+
+	function getSecret() internal returns (bytes storage r, uint) {
+		r = bytes(secret);
+		return (r, 1);
+	}
+
+	function g() external {
+		bytes storage ref;
+		uint x;
+		(ref, x) = getSecret();
+		ref.push(0x42);
+	}
+
+	function len() external view returns (uint256) {
+		return uint256(secret.length);
+	}
+}
+// ----
+// init() ->
+// g() ->
+// len() -> 2


### PR DESCRIPTION
Fixes #277.

The tuple-assignment branch in `TypeChecker::visit(Assignment&)` validated the RHS against the LHS tuple type but never called `preserveShieldedStorageMarkerInDeclaration` for any of the tuple components. A `bytes storage` local receiving an `sbytes` ref through `(ref, x) = getSecret()` therefore kept its plain `bytes storage` annotation; subsequent `ref.push` compiled to `sstore` on a shielded slot.

## Fix

Walk the LHS `TupleExpression` components and the RHS `TupleType` component types side-by-side; for each LHS that resolves to a preservable `VariableDeclaration`, call `preserveShieldedStorageMarkerInDeclaration`. Same pattern as the single-component branch directly below and the `VariableDeclarationStatement` tuple loop at line 1631-1639.

## Test plan

- [x] New test (`semanticTests/types/sbytes_tuple_assignment_marker.sol`) fails on base with `InvalidPrivateStorageAccess`; passes after the fix in all 4 optimizer × via-IR configs
- [x] Full semantic test suite (1917 files) passes under `--via-ir --optimize` and `--optimize`