### PR TITLE
fix(typechecker): preserve shielded marker through payable(saddressValue)

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2355,6 +2355,15 @@ Type const* TypeChecker::typeCheckTypeConversionAndRetrieveReturnType(
 		if (auto type = dynamic_cast<ReferenceType const*>(resultType))
 			resultType = TypeProvider::withLocation(type, dataLoc, type->isPointer());
 		resultType = preserveShieldedStorageMarker(*argType, *resultType);
+		// payable(saddressValue) preserves the shielded marker; the parser cannot decide because it doesn't know identifier types.
+		if (auto const* fromAddr = dynamic_cast<AddressType const*>(argType))
+			if (auto const* toAddr = dynamic_cast<AddressType const*>(resultType))
+				if (
+					fromAddr->isShielded() &&
+					!toAddr->isShielded() &&
+					toAddr->stateMutability() == StateMutability::Payable
+				)
+					resultType = TypeProvider::payableShieldedAddress();
 		BoolResult result = argType->isExplicitlyConvertibleTo(*resultType);
 		SecondarySourceLocation ssl;
 		if (result)

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -2267,26 +2267,14 @@ ASTPointer<Expression> Parser::parseLeftHandSideExpression(
 	}
 	else if (m_scanner->currentToken() == Token::Payable)
 	{
-		//peek into inner payable() argument and check for Saddress
-        Token nextNextToken = m_scanner->peekNextNextToken();
-
+		// Always emit `address payable`; the type checker promotes to `saddress payable` when the argument is shielded.
 		expectToken(Token::Payable);
 		nodeFactory.markEndPosition();
-		if (nextNextToken == Token::SAddress){
-			auto expressionType = nodeFactory.createNode<ElementaryTypeName>(
-				ElementaryTypeNameToken(Token::SAddress, 0, 0),
-				std::make_optional(StateMutability::Payable)
-			);
-			expression = nodeFactory.createNode<ElementaryTypeNameExpression>(expressionType);
-		}
-		else
-		{
-			auto expressionType = nodeFactory.createNode<ElementaryTypeName>(
-				ElementaryTypeNameToken(Token::Address, 0, 0),
-				std::make_optional(StateMutability::Payable)
-			);
-			expression = nodeFactory.createNode<ElementaryTypeNameExpression>(expressionType);
-		}
+		auto expressionType = nodeFactory.createNode<ElementaryTypeName>(
+			ElementaryTypeNameToken(Token::Address, 0, 0),
+			std::make_optional(StateMutability::Payable)
+		);
+		expression = nodeFactory.createNode<ElementaryTypeNameExpression>(expressionType);
 		expectToken(Token::LParen, false);
 	}
 	else

--- a/test/libsolidity/syntaxTests/types/address/payable_saddress_identifier_preserves_marker.sol
+++ b/test/libsolidity/syntaxTests/types/address/payable_saddress_identifier_preserves_marker.sol
@@ -1,0 +1,9 @@
+contract C {
+    saddress private s;
+    function leak() external view returns (address payable) {
+        address payable p = payable(s);
+        return p;
+    }
+}
+// ----
+// TypeError 9574: (107-137): Type saddress payable is not implicitly convertible to expected type address payable.


### PR DESCRIPTION
Fixes #279.

The parser handled `payable(...)` with a peek-next-next-token heuristic that only recognized the literal `saddress` keyword (`payable(saddress(x))`). For `payable(s)` where `s` was an `saddress` identifier, the parser fell through to the public branch and the shielded marker was silently lost — the value could be returned or assigned as plain `address payable`.

## Fix

Move the marker decision into `typeCheckTypeConversionAndRetrieveReturnType`: when the conversion target is `address payable` and the source is shielded, return the shielded payable variant. The parser now always emits `address payable` as the cast target — both syntactic forms route through the same type-checker rule.

Done as a local check (not extending the shared `preserveShieldedStorageMarker` helper) because that helper is also called from variable-declaration / return-parameter paths that would silently rewrite user-declared `address` types.

## Test plan

- [x] New syntax test (`syntaxTests/types/address/payable_saddress_identifier_preserves_marker.sol`) fails on base; passes after the fix
- [x] `address(s)` (explicit downgrade) still compiles
- [x] `payable(saddress(address(1)))` (literal-syntax case the parser used to special-case) still compiles
- [x] Full semantic test suite (1917 files) passes under `--via-ir --optimize` and `--optimize`