### PR TITLE
fix(codegen): suffix partial_clear_storage_slot helper with type identifier

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -1882,7 +1882,7 @@ std::string YulUtilFunctions::storageArrayPushZeroFunction(ArrayType const& _typ
 
 std::string YulUtilFunctions::partialClearStorageSlotFunction(ArrayType const& _type)
 {
-	std::string functionName = "partial_clear_storage_slot";
+	std::string functionName = "partial_clear_storage_slot_" + _type.identifier();
 	bool isShielded = _type.containsShieldedType();
 	return m_functionCollector.createFunction(functionName, [&]() {
 		return Whiskers(R"(

--- a/test/libsolidity/semanticTests/storage/partial_clear_storage_slot_cache_collision.sol
+++ b/test/libsolidity/semanticTests/storage/partial_clear_storage_slot_cache_collision.sol
@@ -1,0 +1,20 @@
+contract C {
+	suint256[] a;
+	uint128[] b;
+
+	function exploit() external returns (uint128) {
+		delete a;
+		b.push(uint128(0xAA));
+		b.push(uint128(0xBB));
+		b.push(uint128(0xCC));
+		b.push(uint128(0xDD));
+		uint128[] memory s = new uint128[](1);
+		s[0] = 0x99;
+		b = s;
+		return b[0];
+	}
+}
+// ====
+// compileViaYul: true
+// ----
+// exploit() -> 0x99


### PR DESCRIPTION
Fixes #282

## Summary

`partialClearStorageSlotFunction` hardcoded the helper name as
`partial_clear_storage_slot` so every ArrayType collided in the function
collector. Whichever array registered first dictated `cstore`/`cload` vs
`sstore`/`sload` for every later caller.

Append `_type.identifier()`, matching `cleanUpStorageArrayEndFunction` and
`decreaseByteArraySizeFunction`.

## Test plan

- [x] New semantic test `storage/partial_clear_storage_slot_cache_collision.sol` exposes the bug (delete on `suint256[]` registers helper as `cstore`/`cload`, then resizing public `uint128[]` from 4 to 1 reverts with `InvalidPublicStorageAccess`).
- [x] Full semantic suite green across all four optimizer × via-IR configurations.