### PR TITLE
fix(typechecker): warn on string-literal->shielded fixed bytes conversion

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -4774,7 +4774,10 @@ void TypeChecker::checkLiteralToShielded(
 	}
 	else if (
 		_expression.annotation().type &&
-		_expression.annotation().type->category() == Type::Category::RationalNumber &&
+		(
+			_expression.annotation().type->category() == Type::Category::RationalNumber ||
+			_expression.annotation().type->category() == Type::Category::StringLiteral
+		) &&
 		_targetType.category() == Type::Category::ShieldedFixedBytes
 	)
 	{

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_fixedbytes_string_literal.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_fixedbytes_string_literal.sol
@@ -1,0 +1,11 @@
+contract C {
+    constructor() {
+        sbytes4 x = sbytes4("abcd");
+        sbytes8 y = sbytes8("12345678");
+    }
+}
+// ----
+// Warning 10412: (53-68): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 10412: (90-109): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 2072: (41-50): Unused local variable.
+// Warning 2072: (78-87): Unused local variable.

--- a/test/libsolidity/syntaxTests/types/sbytes_string_literal_conversion.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_string_literal_conversion.sol
@@ -17,6 +17,15 @@ contract C {
     }
 }
 // ----
+// Warning 10412: (137-149): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 10412: (173-188): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 10412: (212-231): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 10412: (257-285): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 10412: (311-355): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 10412: (447-469): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 10412: (497-527): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 10412: (622-635): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 10412: (665-678): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
 // Warning 2072: (123-134): Unused local variable.
 // Warning 2072: (159-170): Unused local variable.
 // Warning 2072: (198-209): Unused local variable.


### PR DESCRIPTION
Fixes #284

## Summary

`checkLiteralToShielded` only matched `RationalNumber` literals against
`ShieldedFixedBytes` targets, so `sbytes4("abcd")` (and `sbytes4(hex"...")`)
fell through and emitted no deployment-leak warning, while `sbytes4(0x...)`
correctly fired 10410/10411/10412.

Extend the condition to also match `Type::Category::StringLiteral`.

## Test plan

- [x] New `syntaxTests/nameAndTypeResolution/warn_shielded_fixedbytes_string_literal.sol` exposes the missing warning.
- [x] Existing `syntaxTests/types/sbytes_string_literal_conversion.sol` updated — every conversion it exercises now emits the warning that should always have fired.
- [x] Full syntax suite green.
- [x] Full semantic suite green (no-opt and via-IR).