### PR TITLE
fix(typechecker): emit 10001 on memory/calldata shielded ref-type params

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -696,6 +696,14 @@ bool TypeChecker::visit(VariableDeclaration const& _variable)
 		// Local value-type variables (stack/memory)
 		shouldCheckShieldedTypes = true;
 	}
+	else if (
+		_variable.referenceLocation() == VariableDeclaration::Location::Memory ||
+		_variable.referenceLocation() == VariableDeclaration::Location::CallData
+	)
+	{
+		// Local reference-type parameters/locals (memory, calldata)
+		shouldCheckShieldedTypes = true;
+	}
 
 	if (shouldCheckShieldedTypes && varType->containsShieldedType())
 	{

--- a/test/libsolidity/syntaxTests/types/shielded_memory_param_evm_version.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_memory_param_evm_version.sol
@@ -1,0 +1,10 @@
+contract C {
+    function f(sbytes memory x) public pure { x; }
+    function g(sbytes calldata x) external pure { x; }
+}
+// ====
+// EVMVersion: =cancun
+// compileViaYul: true
+// ----
+// TypeError 10001: (28-43): Shielded types (suint, sbool, saddress, sbytes, etc.) require the Mercury EVM version or later. The current EVM version "cancun" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.
+// TypeError 10001: (79-96): Shielded types (suint, sbool, saddress, sbytes, etc.) require the Mercury EVM version or later. The current EVM version "cancun" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.


### PR DESCRIPTION
Fixes #286

## Summary

`shouldCheckShieldedTypes` had no branch for non-state non-storage
non-value-type locals, so `sbytes memory` and `sbytes calldata` function
parameters skipped the Mercury 10001 check on cancun.

Add the missing branch covering `Location::Memory` and `Location::CallData`.

## Test plan

- [x] New `syntaxTests/types/shielded_memory_param_evm_version.sol` exposes the missing 10001 for both memory and calldata reference parameters.
- [x] Full syntax suite green.
- [x] Full semantic suite green (no-opt and via-IR).