### PR TITLE
fix(typechecker): allow explicit suint160 -> address conversion

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -837,6 +837,11 @@ BoolResult ShieldedIntegerType::isExplicitlyConvertibleTo(Type const& _convertTo
 			(addressType->stateMutability() != StateMutability::Payable) &&
 			!isSigned() &&
 			(numBits() == 160);
+	else if (auto addressType = dynamic_cast<AddressType const*>(&_convertTo))
+		return
+			(addressType->stateMutability() != StateMutability::Payable) &&
+			!isSigned() &&
+			(numBits() == 160);
 	else if (auto fixedBytesType = dynamic_cast<FixedBytesType const*>(&_convertTo))
 		return (!isSigned() && (numBits() == fixedBytesType->numBytes() * 8));
 	else if (dynamic_cast<EnumType const*>(&_convertTo))

--- a/test/libsolidity/semanticTests/types/shielded_uint160_to_address.sol
+++ b/test/libsolidity/semanticTests/types/shielded_uint160_to_address.sol
@@ -1,0 +1,14 @@
+contract C {
+    suint160 a;
+
+    function set(suint160 v) external { a = v; }
+
+    function get() external view returns (address) {
+        return address(a);
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// set(suint160): 0xAABBCCDDEEFF11223344556677889900AABBCCDD ->
+// get() -> 0xAABBCCDDEEFF11223344556677889900AABBCCDD

--- a/test/libsolidity/syntaxTests/types/address/shielded_uint_to_address.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_uint_to_address.sol
@@ -1,0 +1,6 @@
+contract C {
+    function f(suint160 x) public pure returns (address) {
+        return address(x);
+    }
+}
+// ----


### PR DESCRIPTION
Fixes #288

## Summary

`ShieldedIntegerType::isExplicitlyConvertibleTo` was missing the `AddressType`
branch — only `ShieldedAddressType` was covered. So `address(suintValue)`
was rejected even though `address->suint160`, `saddress->uint160`, and
`uint160->saddress` all worked, and the workaround
`address(uint160(suintValue))` compiled fine.

Add the branch mirroring `IntegerType::isExplicitlyConvertibleTo`: require
non-payable, unsigned, 160 bits.

## Test plan

- [x] Syntax test `syntaxTests/types/address/shielded_uint_to_address.sol` exposes the missing path.
- [x] Semantic test `semanticTests/types/shielded_uint160_to_address.sol` round-trips a 20-byte value through suint160 storage to bytes-equal address output.
- [x] Full syntax suite green.
- [x] Full semantic suite green (no-opt and via-IR).