### PR TITLE
fix(codegen): guard shielded ops on isValueType in delete path

### DIFF
--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -738,11 +738,12 @@ bool IRGeneratorForStatements::visit(UnaryOperation const& _unaryOperation)
 		std::visit(
 			util::GenericVisitor{
 				[&](IRLValue::Storage const& _storage) {
+					bool useShieldedOps = m_currentLValue->type.isValueType() && _storage.usesShieldedStorage;
 					appendCode() <<
 						m_utils.storageSetToZeroFunction(
 							m_currentLValue->type,
 							VariableDeclaration::Location::Unspecified,
-							_storage.usesShieldedStorage
+							useShieldedOps
 						) <<
 						"(" <<
 						_storage.slot <<

--- a/test/libsolidity/semanticTests/array/delete/delete_shielded_dynamic_array_element.sol
+++ b/test/libsolidity/semanticTests/array/delete/delete_shielded_dynamic_array_element.sol
@@ -1,0 +1,17 @@
+contract C {
+    sbytes[] private messages;
+
+    function setup() external {
+        messages.push();
+        messages.push();
+    }
+
+    function deleteFirst() external {
+        delete messages[0];
+    }
+}
+// ====
+// compileViaYul: true
+// ----
+// setup() ->
+// deleteFirst() ->


### PR DESCRIPTION
Fixes #290

## Summary

`Token::Delete` in `IRGeneratorForStatements.cpp` passed
`_storage.usesShieldedStorage` to `storageSetToZeroFunction` unconditionally.
For non-value-type elements in shielded arrays (`sbytes[]`, `sbool[][]`,
shielded-member structs in arrays), the helper's assert fires and the
compiler hits an `InternalCompilerError`:

> Shielded storage ops override is only supported for value types.

The assignment path got the same guard at `IRGeneratorForStatements.cpp:3476`;
the delete path was missed. Mirror it.

## Test plan

- [x] New `semanticTests/array/delete/delete_shielded_dynamic_array_element.sol` exposes the ICE under via-IR (`compileViaYul: true`).
- [x] Full semantic suite green (no-opt and via-IR).