### PR TITLE
fix(typechecker): reject aliasing shielded-marker mismatch in byte-array storage refs

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -154,6 +154,7 @@ void preserveShieldedStorageMarkersInInternalCall(
 	for (size_t i = 0; i < paramArgMap.size() && i < function->parameters().size(); ++i)
 		if (paramArgMap[i])
 			preserveShieldedStorageMarkerInDeclaration(*function->parameters()[i], *type(*paramArgMap[i]));
+	_functionType.refreshParameterTypesFromDeclaration();
 }
 
 }
@@ -1864,10 +1865,8 @@ bool TypeChecker::visit(Assignment const& _assignment)
 		// Sequenced assignments of tuples is not valid, make the result a "void" type.
 		_assignment.annotation().type = TypeProvider::emptyTuple();
 
-		expectType(_assignment.rightHandSide(), *tupleType);
+		_assignment.rightHandSide().accept(*this);
 
-		// Mirror the single-component branch below: propagate the shielded
-		// storage marker from each RHS component onto the matching LHS local.
 		auto const* lhsTuple = dynamic_cast<TupleExpression const*>(&_assignment.leftHandSide());
 		auto const* rhsTupleType = dynamic_cast<TupleType const*>(type(_assignment.rightHandSide()));
 		if (lhsTuple && rhsTupleType)
@@ -1883,18 +1882,45 @@ bool TypeChecker::visit(Assignment const& _assignment)
 					continue;
 				auto const* variable = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration);
 				if (variable && canPreserveShieldedStorageMarkerInAssignment(*variable))
+				{
 					preserveShieldedStorageMarkerInDeclaration(*variable, *rhsComponents[i]);
+					// Sync the cached Identifier annotation so the rebuilt tupleType picks it up.
+					identifier->annotation().type = variable->annotation().type;
+				}
+			}
+			// Rebuild tupleType from post-preserve component types, mirroring visit(TupleExpression).
+			auto const& components = lhsTuple->components();
+			if (components.size() == 1 && components[0])
+			{
+				if (auto const* innerTuple = dynamic_cast<TupleType const*>(type(*components[0])))
+					tupleType = innerTuple;
+			}
+			else
+			{
+				TypePointers updatedComponentTypes;
+				for (auto const& component: components)
+					updatedComponentTypes.push_back(component ? type(*component) : nullptr);
+				tupleType = TypeProvider::tuple(updatedComponentTypes);
 			}
 		}
+
+		checkImplicitConversion(_assignment.rightHandSide(), *tupleType);
 	}
 	else if (_assignment.assignmentOperator() == Token::Assign)
 	{
-		expectType(_assignment.rightHandSide(), *t);
-		checkMsgValueToShielded(_assignment.rightHandSide(), *t);
+		_assignment.rightHandSide().accept(*this);
 		if (auto const* identifier = dynamic_cast<Identifier const*>(&_assignment.leftHandSide()))
 			if (auto const* variable = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration))
 				if (canPreserveShieldedStorageMarkerInAssignment(*variable))
+				{
 					preserveShieldedStorageMarkerInDeclaration(*variable, *type(_assignment.rightHandSide()));
+					// Sync the cached Identifier and Assignment types to the variable's post-preserve type.
+					identifier->annotation().type = variable->annotation().type;
+					t = variable->annotation().type;
+					_assignment.annotation().type = t;
+				}
+		checkImplicitConversion(_assignment.rightHandSide(), *t);
+		checkMsgValueToShielded(_assignment.rightHandSide(), *t);
 	}
 	else
 	{
@@ -2576,9 +2602,9 @@ void TypeChecker::typeCheckFunctionCall(
 			"\"staticcall\" is not supported by the VM version."
 		);
 
-	// Perform standard function call type checking
-	typeCheckFunctionGeneralChecks(_functionCall, _functionType);
+	// preserve runs first so the convertibility check inside the general checks sees the marker.
 	preserveShieldedStorageMarkersInInternalCall(_functionCall, *_functionType);
+	typeCheckFunctionGeneralChecks(_functionCall, _functionType);
 }
 
 void TypeChecker::typeCheckFallbackFunction(FunctionDefinition const& _function)
@@ -5017,6 +5043,11 @@ Declaration const& TypeChecker::dereference(IdentifierPath const& _path) const
 bool TypeChecker::expectType(Expression const& _expression, Type const& _expectedType)
 {
 	_expression.accept(*this);
+	return checkImplicitConversion(_expression, _expectedType);
+}
+
+bool TypeChecker::checkImplicitConversion(Expression const& _expression, Type const& _expectedType)
+{
 	BoolResult result = type(_expression)->isImplicitlyConvertibleTo(_expectedType);
 	if (!result)
 	{

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -200,6 +200,9 @@ private:
 	/// Runs type checks on @a _expression to infer its type and then checks that it is implicitly
 	/// convertible to @a _expectedType.
 	bool expectType(Expression const& _expression, Type const& _expectedType);
+	/// Convertibility check + error reporting half of expectType; assumes @a _expression
+	/// has already been visited.
+	bool checkImplicitConversion(Expression const& _expression, Type const& _expectedType);
 	/// Helper function for conditionals that checks for either bool or shielded_bools.
 	bool expectBoolOrShieldedBool(Expression const& _expression);
 	/// Runs type checks on @a _expression to infer its type and then checks that it is an LValue.

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -285,7 +285,7 @@ Type const* Type::commonType(Type const* _a, Type const* _b)
 {
 	if (!_a || !_b)
 		return nullptr;
-	else if (_a->mobileType() && _b->isImplicitlyConvertibleTo(*_a->mobileType()))
+	if (_a->mobileType() && _b->isImplicitlyConvertibleTo(*_a->mobileType()))
 		return _a->mobileType();
 	else if (_b->mobileType() && _a->isImplicitlyConvertibleTo(*_b->mobileType()))
 		return _b->mobileType();
@@ -1926,6 +1926,16 @@ BoolResult ArrayType::isImplicitlyConvertibleTo(Type const& _convertTo) const
 	auto& convertTo = dynamic_cast<ArrayType const&>(_convertTo);
 	if (convertTo.isByteArray() != isByteArray() || convertTo.isString() != isString())
 		return false;
+	// Reject aliasing a marked byte-array storage ref to an unmarked one (and vice versa); the
+	// two would emit different opcodes (cstore vs sstore). Copies (non-pointer target) are fine.
+	if (
+		location() == DataLocation::Storage &&
+		convertTo.location() == DataLocation::Storage &&
+		convertTo.isPointer() &&
+		isByteArrayOrString() && convertTo.isByteArrayOrString() &&
+		hasShieldedStorageMarker() != convertTo.hasShieldedStorageMarker()
+	)
+		return false;
 	// memory/calldata to storage can be converted, but only to a direct storage reference
 	if (convertTo.location() == DataLocation::Storage && location() != DataLocation::Storage && convertTo.isPointer())
 		return false;
@@ -3421,6 +3431,18 @@ TypePointers FunctionType::parameterTypes() const
 	if (!hasBoundFirstArgument())
 		return m_parameterTypes;
 	return TypePointers(m_parameterTypes.cbegin() + 1, m_parameterTypes.cend());
+}
+
+void FunctionType::refreshParameterTypesFromDeclaration() const
+{
+	auto const* function = dynamic_cast<FunctionDefinition const*>(m_declaration);
+	if (!function)
+		return;
+	auto const& params = function->parameters();
+	if (params.size() != m_parameterTypes.size())
+		return;
+	for (size_t i = 0; i < params.size(); ++i)
+		m_parameterTypes[i] = params[i]->annotation().type;
 }
 
 TypePointers const& FunctionType::parameterTypesIncludingSelf() const

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1696,12 +1696,17 @@ public:
 	/// @param _inLibrary if true, uses DelegateCall as location.
 	FunctionTypePointer asExternallyCallableFunction(bool _inLibrary) const;
 
+	/// Re-snapshot parameter types from the declaration's annotations (used after
+	/// preserveShieldedStorageMarker mutates them).
+	void refreshParameterTypesFromDeclaration() const;
+
 protected:
 	std::vector<std::tuple<std::string, Type const*>> makeStackItems() const override;
+
 private:
 	static TypePointers parseElementaryTypeVector(strings const& _types);
 
-	TypePointers m_parameterTypes;
+	mutable TypePointers m_parameterTypes;
 	TypePointers m_returnParameterTypes;
 	std::vector<std::string> m_parameterNames;
 	std::vector<std::string> m_returnParameterNames;

--- a/test/libsolidity/syntaxTests/types/shielded_ternary_marker_leak.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_ternary_marker_leak.sol
@@ -7,4 +7,4 @@ contract C {
 }
 // ----
 // Warning 10305: (17-38): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
-// TypeError 1080: (124-156): True expression's type bytes storage pointer does not match false expression's type bytes storage pointer.
+// TypeError 1080: (111-139): True expression's type bytes storage pointer does not match false expression's type bytes storage pointer.

--- a/test/libsolidity/syntaxTests/types/shielded_ternary_marker_leak.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_ternary_marker_leak.sol
@@ -1,0 +1,10 @@
+contract C {
+    sbytes private secret;
+    bytes private public_b;
+    function f(bool c) external {
+        (c ? bytes(secret) : public_b).push(0x42);
+    }
+}
+// ----
+// Warning 10305: (17-38): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// TypeError 1080: (124-156): True expression's type bytes storage pointer does not match false expression's type bytes storage pointer.


### PR DESCRIPTION
Fixes #292.

## Summary

Addresses both root causes the auditor flagged for P7 (3.8 in the draft report):

- **Marker check in `ArrayType::isImplicitlyConvertibleTo`** — reject implicit conversion when both sides are byte-array storage references with disagreeing `m_hasShieldedStorageMarker` AND the target is a pointer (alias). Element-by-element copies (non-pointer target) still compile, so `bytesStateVar = bytes(sbytesRef)` continues to work as a domain-crossing copy.
- **`preserveShieldedStorageMarker` runs before the convertibility check** at the assignment, tuple-assignment, and internal-call sites. Previously preserve ran after `expectType`, so the new marker check would reject legitimate `bytes storage tmp = bytes(sbytesRef)` patterns. After preserve, each affected LHS `Identifier`'s cached annotation type is synced to the post-preserve variable type; the single-component assignment also re-cache's its own annotation; the tuple-assignment branch rebuilds the LHS tuple type as a local from the per-component identifiers (the LHS `TupleExpression`'s own cached annotation is left untouched since the assignment uses `emptyTuple()` and downstream callers read either the local or `_assignment.annotation().type`).
- **`FunctionType::refreshParameterTypesFromDeclaration()`** — internal call parameters had a separate problem: `FunctionType` snapshots parameter types at construction, so updating a declaration's annotation after preserve didn't reach the convertibility check in `typeCheckFunctionGeneralChecks`. New helper re-snapshots `m_parameterTypes` from the live declaration; `preserveShieldedStorageMarkersInInternalCall` calls it after each preserve. `m_parameterTypes` is now `mutable`, matching the existing pattern for cache-style fields on `Type` subclasses.

`expectType` is factored into `accept` + `checkImplicitConversion` so the reordered sites can run preserve between the visit and the conversion check without double-visiting the RHS.

The auditor's stated recommendation was the predicate widening alone; the reorder + FunctionType refresh are the supporting work that lets it land without breaking the existing legitimate-alias semantic tests.

## Test plan

- [x] `syntaxTests/types/shielded_ternary_marker_leak.sol` — auditor's PoC rejected with `TypeError 1080`.
- [x] Full `syntaxTests/*` green (4054 tests).
- [x] Full via-IR semantic sweep green (1920 tests). Includes the four sbytes-marker round-trip tests that the original broader-fix attempt had broken: `shielded_inline_cast_sbytes_dynamic_internal_returns`/`_params`/`_edge_cases` and `sbytes_tuple_assignment_marker`.

## What's left in scope

The second auditor-flagged root cause (`preserveShieldedStorageMarker` is monotonic — only adds the marker, never clears) remains a latent fragility. With the reorder + marker check, every place that *should* have been hit by the bug is now blocked at compile time, so this PR closes the audit finding. The monotonic-preserve concern would only surface if a new unification or conversion path were added later that doesn't go through the sites updated here.