### PR TITLE
fix(typechecker): emit msg.value leak warning on assignment

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1869,6 +1869,7 @@ bool TypeChecker::visit(Assignment const& _assignment)
 	else if (_assignment.assignmentOperator() == Token::Assign)
 	{
 		expectType(_assignment.rightHandSide(), *t);
+		checkMsgValueToShielded(_assignment.rightHandSide(), *t);
 		if (auto const* identifier = dynamic_cast<Identifier const*>(&_assignment.leftHandSide()))
 			if (auto const* variable = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration))
 				if (canPreserveShieldedStorageMarkerInAssignment(*variable))

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_msg_value_warning_assignment.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_msg_value_warning_assignment.sol
@@ -5,4 +5,4 @@ contract C {
     }
 }
 // ----
-// Warning 10306: (101-110): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.
+// Warning 10306: (108-117): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_msg_value_warning_assignment.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_msg_value_warning_assignment.sol
@@ -1,0 +1,8 @@
+contract C {
+    suint256 private secret;
+    function store() external payable {
+        secret = suint256(msg.value);
+    }
+}
+// ----
+// Warning 10306: (101-110): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.


### PR DESCRIPTION
Fixes #294

## Summary

`checkMsgValueToShielded` was only invoked from `visit(VariableDeclarationStatement)`,
so `secret = suint256(msg.value)` skipped the 10306 warning while
`suint256 x = suint256(msg.value)` correctly fired it.

Add the same call to `visit(Assignment)`, gated on the plain `Token::Assign`
branch so compound assignments don't double-fire.

## Test plan

- [x] New `syntaxTests/shieldedTypes/shielded_msg_value_warning_assignment.sol` exposes the missing warning.
- [x] Full syntax suite green.
- [x] Full semantic suite green (no-opt and via-IR).