### PR TITLE
fix(typechecker): reject explicit shielded integer cast to enum

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -844,8 +844,6 @@ BoolResult ShieldedIntegerType::isExplicitlyConvertibleTo(Type const& _convertTo
 			(numBits() == 160);
 	else if (auto fixedBytesType = dynamic_cast<FixedBytesType const*>(&_convertTo))
 		return (!isSigned() && (numBits() == fixedBytesType->numBytes() * 8));
-	else if (dynamic_cast<EnumType const*>(&_convertTo))
-		return true;
 	else if (auto fixedPointType = dynamic_cast<FixedPointType const*>(&_convertTo))
 		return (isSigned() == fixedPointType->isSigned()) && (numBits() == fixedPointType->numBits());
 

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_129_int_to_enum_explicit_conversion_is_not_okay.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_129_int_to_enum_explicit_conversion_is_not_okay.sol
@@ -9,3 +9,4 @@ contract test {
 }
 // ----
 // Warning 10403: (108-116): Literals converted to shielded integers will leak during contract deployment.
+// TypeError 9640: (130-146): Explicit type conversion not allowed from "suint256" to "enum test.ActionChoices".

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_integer_to_enum_explicit_rejected.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_integer_to_enum_explicit_rejected.sol
@@ -6,4 +6,4 @@ contract C {
     }
 }
 // ----
-// TypeError 9640: (139-148): Explicit type conversion not allowed from "suint8" to "enum C.E".
+// TypeError 9640: (126-135): Explicit type conversion not allowed from "suint8" to "enum C.E".

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_integer_to_enum_explicit_rejected.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_integer_to_enum_explicit_rejected.sol
@@ -1,0 +1,9 @@
+contract C {
+    enum E { A, B, C }
+    suint8 private secret;
+    function leak() external view returns (E) {
+        return E(secret);
+    }
+}
+// ----
+// TypeError 9640: (139-148): Explicit type conversion not allowed from "suint8" to "enum C.E".


### PR DESCRIPTION
Fixes #296

## Summary

`ShieldedIntegerType::isExplicitlyConvertibleTo` accepted `EnumType`
unconditionally, so `E(secret)` compiled, dropped the shielded marker, and
yielded a public enum value with no leak warning. Drop the branch so the
conversion is rejected. Users that intentionally want the leak can opt in
via the explicit two-step `E(uint8(secret))`.

## Test plan

- [x] New `syntaxTests/nameAndTypeResolution/shielded_integer_to_enum_explicit_rejected.sol` exposes the missing rejection.
- [x] Existing `shielded_129_int_to_enum_explicit_conversion_is_okay.sol` renamed to `..._is_not_okay.sol` and updated to reflect the new rejection (matches the existing 130/131 naming for sibling enum-conversion tests).
- [x] Full syntax suite green.
- [x] Full semantic suite green (no-opt and via-IR).