### PR TITLE
fix(typechecker): visit shielded sload/cload in yul if/for condition

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1255,6 +1255,8 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 							checkStorageOp(funCall);
 				},
 				[&](yul::If const& _if) {
+					if (auto const* funCall = std::get_if<yul::FunctionCall>(_if.condition.get()))
+						checkStorageOp(funCall);
 					collectStorageOps(_if.body);
 				},
 				[&](yul::Switch const& _switch) {
@@ -1262,6 +1264,8 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 						collectStorageOps(_case.body);
 				},
 				[&](yul::ForLoop const& _forLoop) {
+					if (auto const* funCall = std::get_if<yul::FunctionCall>(_forLoop.condition.get()))
+						checkStorageOp(funCall);
 					collectStorageOps(_forLoop.pre);
 					collectStorageOps(_forLoop.body);
 					collectStorageOps(_forLoop.post);

--- a/test/libsolidity/syntaxTests/inlineAssembly/shielded_sload_in_if_for_condition.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/shielded_sload_in_if_for_condition.sol
@@ -1,0 +1,12 @@
+contract C {
+    suint256 private secret;
+    function f() external returns (uint256 result) {
+        assembly {
+            if sload(secret.slot) { result := 1 }
+            for { } sload(secret.slot) { } { break }
+        }
+    }
+}
+// ----
+// TypeError 10308: (123-141): Cannot use sload() on shielded storage variable. Use cload() instead.
+// TypeError 10308: (175-193): Cannot use sload() on shielded storage variable. Use cload() instead.

--- a/test/libsolidity/syntaxTests/inlineAssembly/shielded_sload_in_if_for_condition.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/shielded_sload_in_if_for_condition.sol
@@ -8,5 +8,5 @@ contract C {
     }
 }
 // ----
-// TypeError 10308: (123-141): Cannot use sload() on shielded storage variable. Use cload() instead.
-// TypeError 10308: (175-193): Cannot use sload() on shielded storage variable. Use cload() instead.
+// TypeError 10308: (129-147): Cannot use sload() on shielded storage variable. Use cload() instead.
+// TypeError 10308: (184-202): Cannot use sload() on shielded storage variable. Use cload() instead.


### PR DESCRIPTION
Fixes #297.

## What broke

`collectStorageOps` in `libsolidity/analysis/TypeChecker.cpp` recursed into the `Block` fields of yul control-flow constructs but never inspected `yul::If::condition` or `yul::ForLoop::condition` (which are `Expression` values, not `Block`s). A top-level `sload(shieldedVar.slot)` used directly as an `if` or `for` condition therefore bypassed TypeError 10308.

PoC:
```solidity
contract Bypass {
    suint256 private secret;
    function peek() external returns (uint256 result) {
        assembly {
            if sload(secret.slot) { result := 1 }     // 10308 missing
            for { } sload(secret.slot) { } { break }  // 10308 missing
            let x := sload(secret.slot)               // 10308 fires
        }
    }
}
```

## What changed

In the `yul::If` and `yul::ForLoop` visitors, dispatch `checkStorageOp` on the top-level `FunctionCall` of the condition, mirroring the existing statement-level pattern used for `ExpressionStatement`, `VariableDeclaration`, and `Assignment`.

## Test plan

- [x] New syntax test `test/libsolidity/syntaxTests/inlineAssembly/shielded_sload_in_if_for_condition.sol` covers both PoC cases and was committed first as a failing test.
- [x] `isoltest` full syntax suite passes.
- [x] `revme` semantic suite passes (no `--via-ir`).
- [x] `revme` semantic suite passes (with `--via-ir`).