### PR TITLE
fix(typechecker): type 0x...s hex literal as saddress, not address

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -4403,7 +4403,9 @@ void TypeChecker::endVisit(Literal const& _literal)
 	if (_literal.looksLikeAddress())
 	{
 		// Assign type here if it even looks like an address. This prevents double errors for invalid addresses
-		_literal.annotation().type = TypeProvider::address();
+		_literal.annotation().type = _literal.token() == Token::ShieldedNumber
+			? static_cast<Type const*>(TypeProvider::shieldedAddress())
+			: static_cast<Type const*>(TypeProvider::address());
 
 		std::string msg;
 		if (_literal.valueWithoutUnderscores().length() != 42) // "0x" + 40 hex digits

--- a/test/libsolidity/syntaxTests/types/shielded_address_literal_trailing_s.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_address_literal_trailing_s.sol
@@ -1,0 +1,8 @@
+contract C {
+    address private a = 0x1234567890AbcdEF1234567890aBcdef12345678s;
+    saddress private b = 0x1234567890AbcdEF1234567890aBcdef12345678s;
+}
+// ----
+// Warning 10416: (37-80): Shielded number literals will leak during contract deployment.
+// Warning 10416: (107-150): Shielded number literals will leak during contract deployment.
+// TypeError 7407: (37-80): Type saddress is not implicitly convertible to expected type address.

--- a/test/libsolidity/syntaxTests/types/shielded_address_literal_trailing_s.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_address_literal_trailing_s.sol
@@ -4,5 +4,5 @@ contract C {
 }
 // ----
 // Warning 10416: (37-80): Shielded number literals will leak during contract deployment.
-// Warning 10416: (107-150): Shielded number literals will leak during contract deployment.
 // TypeError 7407: (37-80): Type saddress is not implicitly convertible to expected type address.
+// Warning 10416: (107-150): Shielded number literals will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_address_length_hex.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_address_length_hex.sol
@@ -1,4 +1,3 @@
-// Bug: 40-hex-digit shielded literal should NOT trigger address-related warnings
 contract C {
     suint256 private x;
 
@@ -8,5 +7,5 @@ contract C {
     }
 }
 // ----
-// Warning 10416: (227-270): Shielded number literals will leak during contract deployment.
-// TypeError 7407: (227-270): Type address is not implicitly convertible to expected type suint256.
+// Warning 10416: (145-188): Shielded number literals will leak during contract deployment.
+// TypeError 7407: (145-188): Type saddress is not implicitly convertible to expected type suint256.


### PR DESCRIPTION
Fixes #300

## Summary

Scanner emits `Token::ShieldedNumber` for `0x...s` but `endVisit(Literal)`
locked any literal that `looksLikeAddress()` to `TypeProvider::address()`,
dropping the marker. Result:
- `address x = 0x...s;` silently compiled.
- `saddress x = 0x...s;` failed.

Branch on the token: `ShieldedNumber` → `shieldedAddress()`, `Number` → `address()`.

## Test plan

- [x] New `syntaxTests/types/shielded_address_literal_trailing_s.sol` exposes both halves.
- [x] Existing `syntaxTests/types/shielded_literal_address_length_hex.sol` updated — its header comment called out the bug as known-incorrect behavior; expectation now reflects the literal being typed as saddress.
- [x] Full syntax suite green.
- [x] Full semantic suite green (no-opt and via-IR).