### PR TITLE
fix(scanner): demote shielded type keywords to identifier pre-Mercury

### DIFF
--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -1047,6 +1047,8 @@ std::tuple<Token, unsigned, unsigned> Scanner::scanIdentifierOrKeyword()
 	literal.complete();
 
 	auto const token = TokenTraits::fromIdentifierOrKeyword(m_tokens[NextNext].literal);
+	if (!m_shieldedTypesEnabled && TokenTraits::isShieldedTypeKeyword(std::get<0>(token)))
+		return std::make_tuple(Token::Identifier, 0, 0);
 	switch (m_kind)
 	{
 	case ScannerKind::SpecialComment:

--- a/liblangutil/Scanner.h
+++ b/liblangutil/Scanner.h
@@ -120,6 +120,16 @@ public:
 		rescan();
 	}
 
+	/// When false, shielded type keywords (suint/sint/sbytes/saddress/sbool and width
+	/// variants) are emitted as identifiers — for pre-Mercury source.
+	void setShieldedTypesEnabled(bool _enabled)
+	{
+		m_shieldedTypesEnabled = _enabled;
+
+		// Invalidate lookahead buffer.
+		rescan();
+	}
+
 	CharStream const& charStream() const noexcept { return m_source; }
 
 	/// @returns the next token and advances input
@@ -264,6 +274,7 @@ private:
 	std::shared_ptr<std::string const> m_sourceName;
 
 	ScannerKind m_kind = ScannerKind::Solidity;
+	bool m_shieldedTypesEnabled = true;
 
 	/// one character look-ahead, equals 0 at end of input
 	char m_char;

--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -344,6 +344,13 @@ namespace TokenTraits
 			tok == Token::TrueLiteral || tok == Token::FalseLiteral || tok == Token::HexStringLiteral || tok == Token::Hex;
 	}
 
+	constexpr bool isShieldedTypeKeyword(Token tok)
+	{
+		return tok == Token::SUInt || tok == Token::SInt || tok == Token::SBytes ||
+			tok == Token::SAddress || tok == Token::SBool ||
+			tok == Token::SUIntM || tok == Token::SIntM || tok == Token::SBytesM;
+	}
+
 	constexpr bool isBuiltinTypeClassName(Token _token)
 	{
 		return

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -32,6 +32,7 @@
 
 #include <liblangutil/ErrorReporter.h>
 #include <liblangutil/Exceptions.h>
+#include <liblangutil/Token.h>
 
 #include <libsolutil/StringUtils.h>
 #include <libsolutil/CommonData.h>
@@ -193,6 +194,18 @@ void ReferencesResolver::endVisit(IdentifierPath const& _path)
 	std::vector<Declaration const*> declarations = m_resolver.pathFromCurrentScopeWithAllDeclarations(_path.path());
 	if (declarations.empty())
 	{
+		if (!m_evmVersion.supportShieldedStorage() && _path.path().size() == 1)
+		{
+			Token const token = std::get<0>(TokenTraits::fromIdentifierOrKeyword(_path.path().front()));
+			if (TokenTraits::isShieldedTypeKeyword(token))
+				m_errorReporter.fatalDeclarationError(
+					10002_error,
+					_path.location(),
+					"Shielded type \"" + _path.path().front() + "\" requires the Mercury EVM version or later. "
+					"The current EVM version \"" + m_evmVersion.name() + "\" does not support shielded types. "
+					"Use \"--evm-version mercury\" to enable shielded type support."
+				);
+		}
 		m_errorReporter.fatalDeclarationError(7920_error, _path.location(), "Identifier not found or not unique.");
 		return;
 	}

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -93,6 +93,7 @@ ASTPointer<SourceUnit> Parser::parse(CharStream& _charStream)
 	{
 		m_recursionDepth = 0;
 		m_scanner = std::make_shared<Scanner>(_charStream);
+		m_scanner->setShieldedTypesEnabled(m_evmVersion.supportShieldedStorage());
 		ASTNodeFactory nodeFactory(*this);
 		m_experimentalSolidityEnabledInCurrentSourceUnit = false;
 

--- a/test/libsolidity/syntaxTests/parsing/shielded_keywords_pre_mercury_identifier.sol
+++ b/test/libsolidity/syntaxTests/parsing/shielded_keywords_pre_mercury_identifier.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure returns (uint256) {
+        uint256 suint = 42;
+        return suint;
+    }
+}
+// ====
+// EVMVersion: =paris
+// ----

--- a/test/libsolidity/syntaxTests/types/shielded_type_used_pre_mercury.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_type_used_pre_mercury.sol
@@ -1,0 +1,7 @@
+contract C {
+    suint8 private secret = 42;
+}
+// ====
+// EVMVersion: =paris
+// ----
+// DeclarationError 10002: (17-23): Shielded type "suint8" requires the Mercury EVM version or later. The current EVM version "paris" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.


### PR DESCRIPTION
Fixes #302

## Summary

Shielded type tokens (`suint`/`sint`/`saddress`/`sbool`/`sbytes` and the
`suintM`/`sintM`/`sbytesM` width variants) were always-reserved keywords, so
pre-Mercury source that uses these names as identifiers failed to parse with
`ParserError 2314`.

Plumb the active EVM version's `supportShieldedStorage()` flag into Scanner.
When the flag is false, `scanIdentifierOrKeyword` demotes shielded type
keywords to `Token::Identifier` — mirroring the precedent for
`isExperimentalSolidityOnlyKeyword` demotion in the same function. Parser
sets the flag on its scanner right after construction.

The demotion would have regressed the error message for users who actually
try to use a shielded type pre-Mercury — they'd get "Identifier not found"
instead of the clear 10001 message. Recover the clear message in
`ReferencesResolver`: when an unresolved single-segment `IdentifierPath`
matches a shielded type keyword name and the EVM version doesn't support
shielded storage, emit `10002` with the same shape as `10001`.

## Test plan

- [x] New `syntaxTests/parsing/shielded_keywords_pre_mercury_identifier.sol` exposes the missing demotion (`uint256 suint = 42;` on paris).
- [x] New `syntaxTests/types/shielded_type_used_pre_mercury.sol` regression-tests that actual shielded type usage on pre-Mercury still gets a clear "use --evm-version mercury" message (now via 10002, same shape as 10001).
- [x] Full syntax suite green (3985 successful, 74 skipped — totals match).
- [x] Full semantic suite green (no-opt and via-IR).