### PR TITLE
fix(yul): invalidate confidentialStorage on sstore to same slot

### DIFF
--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -75,6 +75,10 @@ void DataFlowAnalyzer::operator()(ExpressionStatement& _statement)
 					vars->second != value;
 			}));
 			m_state.environment.storage[vars->first] = vars->second;
+			// Mirror the CSTORE branch: invalidate the parallel cache for the same slot.
+			std::erase_if(m_state.environment.confidentialStorage, mapTuple([&](auto&& key, auto&& /* value */) {
+				return !m_knowledgeBase.knownToBeDifferent(vars->first, key);
+			}));
 			return;
 		}
 		else if (auto vars = isSimpleStore(StoreLoadLocation::Memory, _statement))

--- a/test/libyul/yulOptimizerTests/loadResolver/sstore_invalidates_cload.yul
+++ b/test/libyul/yulOptimizerTests/loadResolver/sstore_invalidates_cload.yul
@@ -1,0 +1,23 @@
+{
+    let x := calldataload(0)
+    let y := calldataload(32)
+    cstore(x, y)
+    sstore(x, 99)
+    // cload must NOT be resolved to y: sstore between cstore and cload invalidates the cached value
+    let z := cload(x)
+    mstore(0, z)
+}
+// ====
+// EVMVersion: >=mercury
+// ----
+// step: loadResolver
+//
+// {
+//     {
+//         let _1 := 0
+//         let x := calldataload(_1)
+//         cstore(x, calldataload(32))
+//         sstore(x, 99)
+//         mstore(_1, cload(x))
+//     }
+// }


### PR DESCRIPTION
Fixes #304

## Summary

`DataFlowAnalyzer`'s CSTORE branch invalidates sibling `storage` entries for
the same slot; the SSTORE branch didn't do the mirror invalidation on
`confidentialStorage`. After `cstore(x, y); sstore(x, _);`, the cache still
said `confidentialStorage[x] == y`, so `loadResolver` could replace a later
`cload(x)` with `y` and `EqualStoreEliminator` could drop a re-affirming
`cstore(x, y)`.

Add the symmetric `std::erase_if` block to the SSTORE branch. Pairs with
#265 (P17), which added the parallel `confidentialStorageClaimed` set for the
read side of this invariant.

## Test plan

- [x] New `yulOptimizerTests/loadResolver/sstore_invalidates_cload.yul` exposes the missing invalidation (loadResolver pre-fix replaces `cload(x)` with `y` after `cstore(x, y); sstore(x, 99);`).
- [x] Full yul optimizer suite green.
- [x] Full syntax suite green.
- [x] Full semantic suite green across all four optimizer × via-IR configurations.