### PR TITLE
fix(typechecker): treat dynamic shielded array .slot as shielded

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1043,19 +1043,10 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 							return false;
 						}
 					}
-					// Track if the variable is shielded for storage operation validation
+					// Dynamic shielded arrays (e.g. sbytes) store their length via cstore/cload too,
+					// so .slot is shielded whenever the type contains a shielded type.
 					if (suffix == "slot")
-					{
-						// For dynamic arrays, .slot contains the length (not shielded)
-						// The actual shielded elements are stored at keccak256(slot) + index
-						// For other types, .slot contains the actual shielded data
-						// Note: if we ever change the semantics of the length slot and also make it shielded, then we'd need to change this.
-						if (auto const* arrayType = dynamic_cast<ArrayType const*>(var->type());
-						arrayType && arrayType->isDynamicallySized())
-						identifierInfo.isShieldedStorage = false;
-						else
-							identifierInfo.isShieldedStorage = var->type()->isShielded() || var->type()->containsShieldedType();
-					}
+						identifierInfo.isShieldedStorage = var->type()->isShielded() || var->type()->containsShieldedType();
 				}
 				else if (
 					auto const* arrayType = dynamic_cast<ArrayType const*>(var->type());

--- a/test/libsolidity/semanticTests/inlineAssembly/shielded_assembly_storage_access_local_var.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/shielded_assembly_storage_access_local_var.sol
@@ -5,7 +5,7 @@ contract C {
         suint256[] storage x = a;
         suint256 off;
         assembly {
-            sstore(x.slot, 7)
+            cstore(x.slot, 7)
             off := x.offset
         }
         assert(bool(off == suint(0)));

--- a/test/libsolidity/syntaxTests/inlineAssembly/sload_on_sbytes_slot.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/sload_on_sbytes_slot.sol
@@ -1,0 +1,9 @@
+contract T {
+    sbytes private secret;
+    function leak() public view returns (uint256 v) {
+        assembly { v := sload(secret.slot) }
+    }
+}
+// ----
+// Warning 10305: (17-38): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// TypeError 10308: (109-128): Cannot use sload() on shielded storage variable. Use cload() instead.


### PR DESCRIPTION
Fixes #308

## Summary

TypeChecker hardcoded `isShieldedStorage = false` for any dynamically-sized
array's `.slot` on the (incorrect) assumption that the length slot is not
shielded. Codegen actually uses `cstore`/`cload` for the length slot of
`sbytes` and any other dynamic array whose base contains a shielded type,
so a stray `sload(secret.slot)` reverts at runtime with no compile-time
hint.

Drop the dynamic-array special case; the else-branch's
`isShielded() || containsShieldedType()` already covers both static and
dynamic correctly.

Pre-planned with P23: a follow-up test-only PR will add the sstore-side
regression test once this lands.

## Test plan

- [x] New `syntaxTests/inlineAssembly/sload_on_sbytes_slot.sol` exposes the missing 10308.
- [x] Existing `semanticTests/inlineAssembly/shielded_assembly_storage_access_local_var.sol` updated — switched the inline-asm write from `sstore(suint256[].slot, …)` (now correctly rejected) to `cstore(…)`, the proper primitive for a shielded slot.
- [x] Full syntax suite green (3986 successful, 75 skipped, totals match).
- [x] Full semantic suite green (no-opt and via-IR).