### PR TITLE
test(typechecker): fix sload_on_sbytes_slot expected offsets

### DIFF
--- a/test/libsolidity/syntaxTests/inlineAssembly/sload_on_sbytes_slot.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/sload_on_sbytes_slot.sol
@@ -6,4 +6,4 @@ contract T {
 }
 // ----
 // Warning 10305: (17-38): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
-// TypeError 10308: (109-128): Cannot use sload() on shielded storage variable. Use cload() instead.
+// TypeError 10308: (118-136): Cannot use sload() on shielded storage variable. Use cload() instead.


### PR DESCRIPTION
Follow-up to #309 (P10).

## Summary

Offset correction

```
Expected: TypeError 10308: (109-128): ...
Obtained: TypeError 10308: (118-136): ...
```