### PR TITLE
test(typechecker): expose sstore on sbytes.slot (test-only sibling of P10)

### DIFF
--- a/test/libsolidity/syntaxTests/inlineAssembly/sstore_on_sbytes_slot.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/sstore_on_sbytes_slot.sol
@@ -1,0 +1,9 @@
+contract T {
+    sbytes private secret;
+    function f() public {
+        assembly { sstore(secret.slot, 0) }
+    }
+}
+// ----
+// Warning 10305: (17-38): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// TypeError 10308: (85-107): Cannot use sstore() on shielded storage variable. Use cstore() instead.


### PR DESCRIPTION
Fixes #311

## Summary

Pre-planned test-only sibling to P10 (#308 / #309). P10's fix to
`TypeChecker.cpp:1053-1055` removed the hardcoded `isShieldedStorage=false`
for dynamic arrays, which catches both `sload(sbytes.slot)` and
`sstore(sbytes.slot, …)` symmetrically. P10 landed the sload-side
regression test; this PR adds the sstore-side coverage. No code change.

## Test plan

- [x] `isoltest -t "syntaxTests/inlineAssembly/sstore_on_sbytes_slot"` passes.
- [x] Full syntax suite green (3987 successful, 75 skipped, totals match).