### PR TITLE
fix(typechecker): warn when shielded shift count leaks via public result

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1874,10 +1874,9 @@ bool TypeChecker::visit(Assignment const& _assignment)
 	{
 		// compound assignment
 		_assignment.rightHandSide().accept(*this);
-		Type const* resultType = t->binaryOperatorResult(
-			TokenTraits::AssignmentToBinaryOp(_assignment.assignmentOperator()),
-			type(_assignment.rightHandSide())
-		);
+		Token const binaryOp = TokenTraits::AssignmentToBinaryOp(_assignment.assignmentOperator());
+		Type const* rhsType = type(_assignment.rightHandSide());
+		Type const* resultType = t->binaryOperatorResult(binaryOp, rhsType);
 		if (!resultType || *resultType != *t)
 			m_errorReporter.typeError(
 				7366_error,
@@ -1889,6 +1888,17 @@ bool TypeChecker::visit(Assignment const& _assignment)
 				" and " +
 				type(_assignment.rightHandSide())->humanReadableName() +
 				"."
+			);
+		if (
+			resultType && *resultType == *t &&
+			TokenTraits::isShiftOp(binaryOp) &&
+			rhsType->category() == Type::Category::ShieldedInteger &&
+			t->category() != Type::Category::ShieldedInteger
+		)
+			m_errorReporter.warning(
+				10312_error,
+				_assignment.location(),
+				"Shielded integer shift count can leak through the public shift result."
 			);
 	}
 	return false;
@@ -2275,6 +2285,17 @@ void TypeChecker::endVisit(BinaryOperation const& _operation)
 			)
 		);
 	}
+
+	if (
+		TokenTraits::isShiftOp(_operation.getOperator()) &&
+		rightType->category() == Type::Category::ShieldedInteger &&
+		commonType->category() != Type::Category::ShieldedInteger
+	)
+		m_errorReporter.warning(
+			10312_error,
+			_operation.location(),
+			"Shielded integer shift count can leak through the public shift result."
+		);
 
 	if (_operation.getOperator() == Token::Exp || _operation.getOperator() == Token::SHL)
 	{

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_shift_leak.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_shift_leak.sol
@@ -10,6 +10,6 @@ contract C {
 }
 // ----
 // Warning 10312: (89-101): Shielded integer shift count can leak through the public shift result.
-// Warning 10312: (111-123): Shielded integer shift count can leak through the public shift result.
-// Warning 10312: (137-149): Shielded integer shift count can leak through the public shift result.
-// Warning 10312: (159-171): Shielded integer shift count can leak through the public shift result.
+// Warning 10312: (115-126): Shielded integer shift count can leak through the public shift result.
+// Warning 10312: (136-148): Shielded integer shift count can leak through the public shift result.
+// Warning 10312: (162-173): Shielded integer shift count can leak through the public shift result.

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_shift_leak.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_shift_leak.sol
@@ -1,0 +1,15 @@
+contract C {
+    suint8 private secret;
+    uint256 a;
+    function f() public {
+        a <<= secret;
+        a = a << secret;
+        a >>= secret;
+        a = a >> secret;
+    }
+}
+// ----
+// Warning 10312: (89-101): Shielded integer shift count can leak through the public shift result.
+// Warning 10312: (111-123): Shielded integer shift count can leak through the public shift result.
+// Warning 10312: (137-149): Shielded integer shift count can leak through the public shift result.
+// Warning 10312: (159-171): Shielded integer shift count can leak through the public shift result.


### PR DESCRIPTION
Fixes #313

## Summary

`a <<= secret;` (and `a = a << secret`, `a >>= secret`, `a = a >> secret`)
compiled without any leak warning when `a` was public and `secret` was a
shielded integer — the result is observable from `a`'s pre- and post-values,
so the shielded shift count can be recovered. The analogous exponentiation
case at `TypeChecker.cpp:2293-2301` already warns with `10304`.

Add warning `10312` when the operator is a shift (`isShiftOp`), the right
operand is `ShieldedInteger`, and the **result type** isn't shielded (so
`rational << shielded -> shielded` cases — where the shielding is
preserved — stay silent).

Fires in both `endVisit(BinaryOperation)` (for `a = a << secret`) and the
compound branch of `visit(Assignment)` (for `a <<= secret`); compound
assignments don't traverse the BinaryOperation visitor.

## Test plan

- [x] New `syntaxTests/shieldedTypes/shielded_shift_leak.sol` covers all four shapes (compound + non-compound, `<<` and `>>`).
- [x] Full syntax suite green (3988 successful, 75 skipped, totals match). Existing `shielded_*shift*` tests stay green unchanged — their results are shielded so the warning correctly doesn't fire.
- [x] Full semantic suite green (no-opt and via-IR).