### PR TITLE
fix(typechecker): warn on shielded-to-public conversion in emit/revert

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1556,6 +1556,9 @@ void TypeChecker::endVisit(EmitStatement const& _emit)
 		dynamic_cast<FunctionType const&>(*type(_emit.eventCall().expression())).kind() != FunctionType::Kind::Event
 	)
 		m_errorReporter.typeError(9292_error, _emit.eventCall().expression().location(), "Expression has to be an event invocation.");
+	for (auto const& arg: _emit.eventCall().arguments())
+		if (arg)
+			checkShieldedLeakInPublicSink(*arg);
 }
 
 void TypeChecker::endVisit(RevertStatement const& _revert)
@@ -1567,6 +1570,9 @@ void TypeChecker::endVisit(RevertStatement const& _revert)
 		dynamic_cast<FunctionType const&>(*type(errorCall.expression())).kind() != FunctionType::Kind::Error
 	)
 		m_errorReporter.typeError(1885_error, errorCall.expression().location(), "Expression has to be an error.");
+	for (auto const& arg: errorCall.arguments())
+		if (arg)
+			checkShieldedLeakInPublicSink(*arg);
 }
 
 void TypeChecker::endVisit(ArrayTypeName const& _typeName)
@@ -3233,6 +3239,15 @@ void TypeChecker::typeCheckFunctionGeneralChecks(
 				"observable execution patterns such as gas costs, state changes, and execution traces."
 			);
 	}
+
+	// revert("msg") and require(cond, "msg") expose their message argument via revert returndata.
+	if (
+		_functionType->kind() == FunctionType::Kind::Revert ||
+		_functionType->kind() == FunctionType::Kind::Require
+	)
+		for (Expression const* arg: paramArgMap)
+			if (arg)
+				checkShieldedLeakInPublicSink(*arg);
 }
 
 bool TypeChecker::visit(FunctionCall const& _functionCall)
@@ -4896,6 +4911,40 @@ void TypeChecker::checkMsgValueToShielded(
 			if (arg)
 				checkMsgValueToShielded(*arg, _targetType);
 	}
+}
+
+void TypeChecker::checkShieldedLeakInPublicSink(Expression const& _expression)
+{
+	auto funcCall = dynamic_cast<FunctionCall const*>(&_expression);
+	if (!funcCall)
+		return;
+
+	// Structural shielding check that ignores the array storage marker, since
+	// bytes(sbytesRef) carries it through but the value is semantically public.
+	std::function<bool(Type const&)> structurallyShielded = [&](Type const& t) -> bool {
+		if (t.isShielded())
+			return true;
+		if (auto arr = dynamic_cast<ArrayType const*>(&t))
+			return structurallyShielded(*arr->baseType());
+		return t.containsShieldedType();
+	};
+
+	if (
+		*funcCall->annotation().kind == FunctionCallKind::TypeConversion &&
+		!funcCall->arguments().empty() &&
+		funcCall->arguments().front() &&
+		structurallyShielded(*type(*funcCall->arguments().front())) &&
+		!structurallyShielded(*type(_expression))
+	)
+		m_errorReporter.warning(
+			10313_error,
+			_expression.location(),
+			"Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata."
+		);
+
+	for (auto const& arg: funcCall->arguments())
+		if (arg)
+			checkShieldedLeakInPublicSink(*arg);
 }
 
 void TypeChecker::checkErrorAndEventParameters(CallableDeclaration const& _callable)

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -183,6 +183,10 @@ private:
 		Type const& _targetType
 	);
 
+	/// Walks an event/error call argument and warns when a shielded-to-public
+	/// type conversion exposes a confidential value to public logs or returndata.
+	void checkShieldedLeakInPublicSink(Expression const& _expression);
+
 	/// @returns the referenced declaration and throws on error.
 	Declaration const& dereference(Identifier const& _identifier) const;
 	/// @returns the referenced declaration and throws on error.

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_bytes_leak_via_emit_revert.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_bytes_leak_via_emit_revert.sol
@@ -1,0 +1,50 @@
+contract C {
+    sbytes private secret;
+    bytes private publicBytes;
+    event Log(bytes data);
+    event LogTwo(uint256 a, bytes data);
+    error E(bytes data);
+
+    // Positive cases — should warn (10313).
+    function leakEmit() external {
+        emit Log(bytes(secret));
+    }
+    function leakRevertCustom() external {
+        revert E(bytes(secret));
+    }
+    function leakRevertString() external {
+        revert(string(bytes(secret)));
+    }
+    function leakRequireString(bool cond) external pure {
+        require(cond, string(bytes(secret)));
+    }
+    function leakEmitNested() external {
+        emit Log(abi.encode(bytes(secret)));
+    }
+    function leakEmitSecondArg() external {
+        emit LogTwo(1, bytes(secret));
+    }
+
+    // Negative cases — should NOT warn.
+    function noWarnLiteral() external {
+        emit Log("hello");
+    }
+    function noWarnPublicConversion() external {
+        emit Log(abi.encodePacked(uint256(7)));
+    }
+    function noWarnPublicBytes() external {
+        emit Log(publicBytes);
+    }
+    function noWarnPlainRevert() external pure {
+        revert("plain message");
+    }
+}
+// ----
+// Warning 10305: (17-38): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// Warning 10313: (264-277): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
+// Warning 10313: (346-359): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
+// Warning 10313: (433-446): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
+// Warning 10313: (543-556): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
+// TypeError 10202: (635-648): Shielded types cannot be ABI encoded.
+// Warning 10313: (635-648): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
+// Warning 10313: (725-738): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.

--- a/test/libsolidity/syntaxTests/structs/shielded_struct_mixed_event_param_fail.sol
+++ b/test/libsolidity/syntaxTests/structs/shielded_struct_mixed_event_param_fail.sol
@@ -13,3 +13,4 @@ contract C {
 }
 // ----
 // Warning 10403: (264-276): Literals converted to shielded integers will leak during contract deployment.
+// Warning 10313: (308-325): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.


### PR DESCRIPTION
Fixes #315

## Summary

`emit Log(bytes(secret))`, `revert E(bytes(secret))`, `revert(string(bytes(secret)))`,
and `require(cond, string(bytes(secret)))` all compiled without any diagnostic.
The conversion itself is well-formed user-authored declassification, but the
value ends up in event logs or revert returndata and is publicly observable.

Add warning `10313` via a new helper `checkShieldedLeakInPublicSink` that walks
each argument tree and fires when a `FunctionCall` with `kind == TypeConversion`
goes from a structurally-shielded source to a non-shielded target.

Wired into three sinks:
- `endVisit(EmitStatement)` — `emit Log(...)`
- `endVisit(RevertStatement)` — `revert E(...)` (custom error form)
- `typeCheckFunctionCall` gated on `Kind::Revert` or `Kind::Require` — covers `revert("msg")` and `require(cond, "msg")` legacy forms.

The structural-shielding check ignores `ArrayType::m_hasShieldedStorageMarker`
because `bytes(sbytesRef)` propagates that marker even though the result is
semantically public — instead recurses into `ArrayType` base types and compares
intrinsic shielding.

## Known limitation (not addressed)

Indirection bypasses the warning: `bytes tmp = bytes(secret); emit Log(tmp);`
silently emits with no diagnostic. Catching this would require taint-tracking
shielded-derived locals through declarations and assignments — a separate ticket.

## Test plan

- [x] New `syntaxTests/shieldedTypes/shielded_bytes_leak_via_emit_revert.sol` covers six positive sinks (emit, custom-error revert, legacy-string revert, require-with-message, nested in `abi.encode`, non-first emit argument) and four negative cases (string literal, public conversion, public bytes identifier, plain `revert(\"msg\")`).
- [x] Existing `syntaxTests/structs/shielded_struct_mixed_event_param_fail.sol` updated — its `emit DataLogged(uint256(s.secret))` is exactly this leak pattern.
- [x] Verified the test commit fails pre-fix (stashed the fix, rebuilt, isoltest FAIL'd as expected).
- [x] Full syntax suite green (3989 successful, 75 skipped, totals match).
- [x] Full semantic suite green (no-opt and via-IR).