### PR TITLE
fix(evmasm): preserve is_private marker on sstore-after-cstore

### DIFF
--- a/libevmasm/KnownState.cpp
+++ b/libevmasm/KnownState.cpp
@@ -369,7 +369,10 @@ KnownState::StoreOperation KnownState::storeInStorage(
 	AssemblyItem item(Instruction::SSTORE, std::move(_debugData));
 	Id id = m_expressionClasses->find(item, {_slot, _value}, true, m_sequenceNumber);
 	StoreOperation operation{StoreOperation::Storage, _slot, m_sequenceNumber, id};
-	m_storageContent[_slot] = {_value, false};
+	// If the slot is already claimed by the confidential domain, an SSTORE here
+	// reverts at runtime — don't clobber the is_private=true marker.
+	if (!m_storageContent.count(_slot) || !m_storageContent[_slot].is_private)
+		m_storageContent[_slot] = {_value, false};
 	// increment a second time so that we get unique sequence numbers for writes
 	m_sequenceNumber++;
 

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -2697,6 +2697,36 @@ BOOST_AUTO_TEST_CASE(cse_cstore_cload_same_slot_can_optimize)
 	});
 }
 
+BOOST_AUTO_TEST_CASE(cse_p27_sstore_does_not_clobber_private_marker)
+{
+	// cstore(0, 0x11) claims slot 0 private. sstore(0, 0x22) would revert at
+	// runtime — KnownState must not clobber the is_private=true marker, since
+	// a subsequent CLOAD's cached value depends on it. Pre-fix the model sees
+	// is_private=false after the SSTORE and a later CLOAD picks up 0x22 from
+	// the cache; with the fix it stays 0x11.
+	AssemblyItems input{
+		u256(0x11),
+		u256(0),
+		Instruction::CSTORE,
+		u256(0x22),
+		u256(0),
+		Instruction::SSTORE,
+		u256(0),
+		Instruction::CLOAD
+	};
+	// Post-fix: CLOAD eliminated, 0x11 (cstore value) left on stack via DUP.
+	checkCSE(input, {
+		u256(0x11),
+		u256(0),
+		Instruction::DUP2,
+		Instruction::DUP2,
+		Instruction::CSTORE,
+		u256(0x22),
+		Instruction::SWAP1,
+		Instruction::SSTORE
+	});
+}
+
 BOOST_AUTO_TEST_CASE(cse_cross_domain_cstore_sstore_cstore_preserves_all)
 {
 	// CSTORE privatizes slot 0, then SSTORE conflicts (should revert at runtime),


### PR DESCRIPTION
Fixes #317

## Summary

`KnownState::storeInStorage` unconditionally wrote `{_value, false}` into
`m_storageContent[_slot]`, clobbering any prior `is_private=true` marker.
The preservation loop just above (lines 362-366) correctly retains the
private entry, but the final assignment overwrote it.

A cross-domain SSTORE reverts at runtime, so this was latent today, but the
internal model becoming wrong breaks downstream CSE/EqualStore reasoning
that consults `is_private` — e.g. a later CLOAD picks up the SSTORE'd value
from the cache instead of the original cstore value.

Gate the assignment on the existing entry not already being `is_private=true`.

## Test plan

- [x] New `Optimiser/cse_p27_sstore_does_not_clobber_private_marker` asserts the exact post-fix CSE output for `cstore(0, 0x11); sstore(0, 0x22); cload(0)`. Pre-fix: 10 items, CLOAD eliminated using 0x22 (the wrong value). Post-fix: 8 items, CLOAD eliminated using 0x11 (the cstore value).
- [x] Verified the test commit fails pre-fix (stashed the fix, ran soltest, got `Mismatch at position 2: DUP2 != SWAP1`).
- [x] Full `Optimiser/*` suite green (116 cases).
- [x] Full semantic suite green (no-opt and via-IR).