### PR TITLE
fix(evmasm): preserve is_private marker on sload-after-cstore

### DIFF
--- a/libevmasm/KnownState.cpp
+++ b/libevmasm/KnownState.cpp
@@ -420,7 +420,9 @@ ExpressionClasses::Id KnownState::loadFromStorage(Id _slot, langutil::DebugData:
 
 	AssemblyItem item(Instruction::SLOAD, std::move(_debugData));
 	Id value = m_expressionClasses->find(item, {_slot}, true, m_sequenceNumber);
-	m_storageContent[_slot] = {value, false};
+	// Mirror the storeInStorage fix: don't clobber a slot already known private.
+	if (!m_storageContent.count(_slot) || !m_storageContent.at(_slot).is_private)
+		m_storageContent[_slot] = {value, false};
 	return value;
 }
 

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -2697,6 +2697,24 @@ BOOST_AUTO_TEST_CASE(cse_cstore_cload_same_slot_can_optimize)
 	});
 }
 
+BOOST_AUTO_TEST_CASE(known_state_p13_sload_preserves_private_marker)
+{
+	// SLOAD breaks CSE blocks (side-effecting), so drive KnownState directly:
+	// post-fix the second cstore early-outs against the preserved {value, true}.
+	KnownState state;
+	state.feedItem(AssemblyItem{u256(0x11)});
+	state.feedItem(AssemblyItem{u256(0)});
+	BOOST_REQUIRE(state.feedItem(AssemblyItem{Instruction::CSTORE}).isValid());
+
+	state.feedItem(AssemblyItem{u256(0)});
+	state.feedItem(AssemblyItem{Instruction::SLOAD});
+
+	state.feedItem(AssemblyItem{u256(0x11)});
+	state.feedItem(AssemblyItem{u256(0)});
+	KnownState::StoreOperation op = state.feedItem(AssemblyItem{Instruction::CSTORE});
+	BOOST_CHECK(!op.isValid());
+}
+
 BOOST_AUTO_TEST_CASE(cse_p27_sstore_does_not_clobber_private_marker)
 {
 	// cstore(0, 0x11) claims slot 0 private. sstore(0, 0x22) would revert at


### PR DESCRIPTION
Fixes #319

## Summary

`KnownState::loadFromStorage` early-returns the cached value only when the
slot is public (`!is_private`). For a slot previously cstored
(`is_private=true`), the early return doesn't fire and execution falls
through to a fresh SLOAD — and then unconditionally overwrites
`m_storageContent[_slot] = {value, false}`, clearing the private marker.

A cross-domain SLOAD on a privately-claimed slot reverts at runtime, so this
is latent today, but the internal model becoming wrong breaks downstream
reasoning that consults `is_private`. Pairs with the `storeInStorage` fix
(P27, #317): mirror the same gating on the read side.

## Test plan

- [x] New `Optimiser/known_state_p13_sload_preserves_private_marker` drives `KnownState` directly (SLOAD breaks CSE analysis blocks, so the bug isn't observable via the block-level CSE wrappers). Asserts the second `cstore` early-outs because `is_private=true` survives the sload.
- [x] Verified the test fails pre-fix (stashed the fix, rebuilt soltest, the early-out assertion fails as expected).
- [x] Full `Optimiser/*` suite green (117 cases).
- [x] Full semantic suite green (no-opt and via-IR).