### PR TITLE
fix(libevmasm): mark CSE cross-domain over aliasable slots

### DIFF
--- a/libevmasm/CommonSubexpressionEliminator.cpp
+++ b/libevmasm/CommonSubexpressionEliminator.cpp
@@ -149,18 +149,26 @@ AssemblyItems CSECodeGenerator::generateCode(
 
 	// generate the dependency graph starting from final storage and memory writes and target stack contents
 	//
-	// When the same slot has stores from both public (Storage) and shielded (ShieldedStorage) domains,
-	// we must preserve ALL stores — not just the last per (target, slot) — because cross-domain access
-	// to the same slot triggers a runtime revert. Dropping an earlier store can change the execution
-	// semantics from revert to success.
+	// Cross-domain stores on the same (or possibly-aliasing) slot revert at runtime, so any slot
+	// pair that knownToBeDifferent can't separate must preserve every store, not just the last.
 	std::set<Id> crossDomainSlots;
 	{
-		std::map<Id, std::set<StoreOperation::Target>> slotTargets;
+		std::set<Id> publicSlots;
+		std::set<Id> shieldedSlots;
 		for (auto const& p: m_storeOperations)
-			slotTargets[p.first.second].insert(p.first.first);
-		for (auto const& entry: slotTargets)
-			if (entry.second.count(StoreOperation::Storage) && entry.second.count(StoreOperation::ShieldedStorage))
-				crossDomainSlots.insert(entry.first);
+		{
+			if (p.first.first == StoreOperation::Storage)
+				publicSlots.insert(p.first.second);
+			else if (p.first.first == StoreOperation::ShieldedStorage)
+				shieldedSlots.insert(p.first.second);
+		}
+		for (Id pub: publicSlots)
+			for (Id shi: shieldedSlots)
+				if (pub == shi || !m_expressionClasses.knownToBeDifferent(pub, shi))
+				{
+					crossDomainSlots.insert(pub);
+					crossDomainSlots.insert(shi);
+				}
 	}
 	for (auto const& p: m_storeOperations)
 	{

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -2810,6 +2810,51 @@ BOOST_AUTO_TEST_CASE(cse_same_domain_duplicate_cstore_still_optimizes)
 	BOOST_CHECK_EQUAL(countInstruction(optimized, Instruction::CSTORE), 1u);
 }
 
+BOOST_AUTO_TEST_CASE(cse_cross_domain_aliased_slots_preserves_all)
+{
+	// calldataload(0) and calldataload(32) get distinct expression IDs but
+	// may alias at runtime — pre-fix the first CSTORE is dropped.
+	AssemblyItems input{
+		u256(0xaa),
+		u256(0),
+		Instruction::CALLDATALOAD,
+		Instruction::CSTORE,
+		u256(0xbb),
+		u256(32),
+		Instruction::CALLDATALOAD,
+		Instruction::SSTORE,
+		u256(0xcc),
+		u256(0),
+		Instruction::CALLDATALOAD,
+		Instruction::CSTORE
+	};
+	AssemblyItems optimized = CSE(input);
+
+	BOOST_CHECK_EQUAL(countInstruction(optimized, Instruction::CSTORE), 2u);
+	BOOST_CHECK_EQUAL(countInstruction(optimized, Instruction::SSTORE), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(cse_cross_domain_distinct_constants_still_optimize)
+{
+	// Negative control: static slots 0 and 1 are knownToBeDifferent, so the
+	// redundant first cstore on slot 0 should still be eliminated.
+	AssemblyItems input{
+		u256(0x11),
+		u256(0),
+		Instruction::CSTORE,
+		u256(0x22),
+		u256(1),
+		Instruction::SSTORE,
+		u256(0x33),
+		u256(0),
+		Instruction::CSTORE
+	};
+	AssemblyItems optimized = CSE(input);
+
+	BOOST_CHECK_EQUAL(countInstruction(optimized, Instruction::CSTORE), 1u);
+	BOOST_CHECK_EQUAL(countInstruction(optimized, Instruction::SSTORE), 1u);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } // end namespaces


### PR DESCRIPTION
## Summary

- CSE was keying cross-domain detection on expression-ID equality, so a cstore and sstore on slot expressions that may alias at runtime (e.g. `calldataload(0)` vs `calldataload(32)`) landed in separate slot-target buckets and the all-stores preservation path was skipped — the first cstore could then be eliminated.
- Replaces the slot-targets map with a public/shielded slot cross-product gated on `ExpressionClasses::knownToBeDifferent`. Any pair the optimizer cannot prove distinct is marked cross-domain, matching the aliasing notion `KnownState::storeInStorage`/`storeInShieldedStorage` already use.
- Pure single-domain blocks are untouched (one set is empty); static distinct constants stay optimizable.

Fixes #323.

## Test plan

- [x] New `cse_cross_domain_aliased_slots_preserves_all` — CALLDATALOAD-keyed cstore/sstore/cstore, asserts both CSTOREs and the SSTORE survive (fails pre-fix with 1 CSTORE, passes post-fix with 2).
- [x] New `cse_cross_domain_distinct_constants_still_optimize` — negative control over static slots 0 and 1, asserts the broadened detection does not over-fire (1 CSTORE, 1 SSTORE).
- [x] Full Optimiser suite (119 tests) green.
- [x] Full soltest suite: only `smtCheckerTests/loops/for_loop_array_assignment_memory_storage` fails — confirmed pre-existing z3 4.8.x noise on `origin/zellic-audit-april-2026` (same failure, same bytes), not introduced by this PR.