### PR TITLE
fix(smtchecker): model saddress as Address

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -1212,6 +1212,13 @@ void SMTEncoder::visitTypeConversion(FunctionCall const& _funCall)
 		return;
 	}
 
+	// address <-> saddress: same, before the size-mismatch path truncates.
+	if (smt::isAddress(*argType) && smt::isAddress(*funCallType))
+	{
+		defineExpr(_funCall, symbArg);
+		return;
+	}
+
 	// TODO Simplify this whole thing for 0.8.0 where weird casts are disallowed.
 
 	unsigned argSize = argType->storageBytes();

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -367,12 +367,8 @@ bool isFixedBytes(frontend::Type const& _type)
 
 bool isAddress(frontend::Type const& _type)
 {
-	return _type.category() == frontend::Type::Category::Address;
-}
-
-bool isShieldedAddress(frontend::Type const& _type)
-{
-	return _type.category() == frontend::Type::Category::ShieldedAddress;
+	return _type.category() == frontend::Type::Category::Address
+		|| _type.category() == frontend::Type::Category::ShieldedAddress;
 }
 
 bool isContract(frontend::Type const& _type)

--- a/libsolidity/formal/SymbolicTypes.h
+++ b/libsolidity/formal/SymbolicTypes.h
@@ -48,7 +48,6 @@ bool isFixedPoint(frontend::Type const& _type);
 bool isRational(frontend::Type const& _type);
 bool isFixedBytes(frontend::Type const& _type);
 bool isAddress(frontend::Type const& _type);
-bool isShieldedAddress(frontend::Type const& _type);
 bool isContract(frontend::Type const& _type);
 bool isEnum(frontend::Type const& _type);
 bool isNumber(frontend::Type const& _type);

--- a/test/libsolidity/smtCheckerTests/types/shielded_address_equality_preserved.sol
+++ b/test/libsolidity/smtCheckerTests/types/shielded_address_equality_preserved.sol
@@ -1,0 +1,15 @@
+contract C {
+	saddress sa;
+	function check(address a) external {
+		sa = saddress(a);
+		address readBack = address(sa);
+		// Should be provable: the round-trip through shielded storage
+		// preserves the value. Pre-fix saddress routed to an abstract
+		// SymbolicIntVariable and the equality wasn't tracked.
+		assert(readBack == a);
+	}
+}
+// ====
+// SMTEngine: bmc
+// ----
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/shielded_address_variable.sol
+++ b/test/libsolidity/smtCheckerTests/types/shielded_address_variable.sol
@@ -1,0 +1,13 @@
+contract C {
+	// Exercises SymbolicAddressVariable's dispatch path. Pre-fix isAddress
+	// matched only Category::Address, so saddress fell through to the
+	// abstract fallback in newSymbolicVariable and emitted "does not yet
+	// support" / "does not yet implement type saddress" warnings.
+	saddress sa;
+	function f(saddress a) external {
+		sa = a;
+	}
+}
+// ====
+// SMTEngine: bmc
+// ----


### PR DESCRIPTION
## Summary

- Widens `smt::isAddress` to match `Category::ShieldedAddress`, mirroring P20's `isInteger`/`isFixedBytes` and P21's `isBool`. The dead `isShieldedAddress` helper is removed — no callers, and the other widened predicates don't have shielded-specific siblings.
- Adds the parallel of P21's bool/sbool short-circuit in `visitTypeConversion`: address↔saddress is a value-level identity (the shielded flag is a storage-domain property), so it must short-circuit before the size-mismatch branch truncates via `int2bv` (address is 20 storage bytes, saddress is 32). Without this, the predicate widening alone makes the round-trip lose equality and assertions like `address(saddress(a)) == a` aren't provable.

Fixes #325.

## Test plan

- [x] `shielded_address_variable`: declaring + assigning an saddress emits zero "does not yet support" warnings (pre-fix: five).
- [x] `shielded_address_equality_preserved`: BMC proves `address(saddress(a)) == a` (pre-fix: ICE at `SMTEncoder.cpp:1264` because the size-mismatch path solAsserts `isNumber(funCallType)`).
- [x] Full `smtCheckerTests/*` sweep: 16 failures, all in `for_loop_array_assignment_memory_storage` — same count and same test as on `zellic-audit-april-2026` baseline (verified during P27/P34). Not introduced here.