### PR TITLE
fix(codegen): per-member clear for shielded struct array shrink

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -1473,8 +1473,11 @@ std::string YulUtilFunctions::cleanUpStorageArrayEndFunction(ArrayType const& _t
 		)")
 		("convertToSize", arrayConvertLengthToSize(_type))
 		("dataPosition", arrayDataAreaFunction(_type))
+		// Struct bases need per-member clearing; the shieldedUint256 shortcut is value-type only.
 		("clearStorageRange", clearStorageRangeFunction(
-			_type.usesShieldedStorage() ? *TypeProvider::shieldedUint256() : *_type.baseType()
+			_type.baseType()->category() == Type::Category::Struct
+				? *_type.baseType()
+				: (_type.usesShieldedStorage() ? *TypeProvider::shieldedUint256() : *_type.baseType())
 		))
 		("packed", _type.baseType()->storageBytes() <= 16)
 		("itemsPerSlot", std::to_string(32 / _type.baseType()->storageBytes()))

--- a/test/libsolidity/semanticTests/array/shielded_struct_array_shrink_preserves_public_field_domain.sol
+++ b/test/libsolidity/semanticTests/array/shielded_struct_array_shrink_preserves_public_field_domain.sol
@@ -1,0 +1,16 @@
+contract C {
+    struct S { suint256 priv; uint256 pub; }
+
+    S[] private arr;
+    S[] private empty;
+
+    function setup() external { arr.push(S(suint256(1), 0xAA)); }
+    function shrink() external { arr = empty; }
+    function repush() external { arr.push(S(suint256(2), 0xBB)); }
+    function readPub() external view returns (uint256) { return arr[0].pub; }
+}
+// ----
+// setup() ->
+// shrink() ->
+// repush() ->
+// readPub() -> 0xBB


### PR DESCRIPTION
## Summary

- `cleanUpStorageArrayEndFunction` in `YulUtilFunctions.cpp:1476` substituted `shieldedUint256` for the entire freed range whenever `usesShieldedStorage()` was true. For arrays of structs with mixed shielded + public fields, this cstored every freed slot — including public-field slots — claiming them for the confidential domain. Subsequent sstore writes to the same slots then reverted at runtime.
- Gates the substitution on the base type: for struct bases, pass the struct itself so `storageSetToZeroFunction` routes through `clearStorageStructFunction`'s per-member path, which already picks sstore vs cstore per field. Value-type bases (sbytes1/bytes1 in byte arrays) keep the `shieldedUint256` shortcut, since the `storageBytes() < 32 → uint256` fallback inside `clearStorageRangeFunction` would otherwise use sstore.

Fixes #327.

## Test plan

- [x] New `shielded_struct_array_shrink_preserves_public_field_domain.sol`: pushes `S { suint priv; uint pub }`, assigns `empty` to shrink, repushes, then reads back. Pre-fix `shrink()` reverts with `InvalidPublicStorageAccess`; post-fix all four calls succeed and `readPub()` returns `0xBB`.
- [x] Full `semanticTests/array/*` green under all three relevant configs: legacy, via-IR (no-opt), via-IR + optimizer.
- [x] Fix scoped to via-IR codegen; legacy pipeline (`ArrayUtils.cpp`) is independent and was already correct (per P33's retraction).