### PR TITLE
fix(codegen): full-slot sbytesN standalone storage; keep packed for sbytes elements

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -1761,7 +1761,8 @@ std::string YulUtilFunctions::storageByteArrayPopFunction(ArrayType const& _type
 			("setToZero", storageSetToZeroFunction(
 				*_type.baseType(),
 				VariableDeclaration::Location::Unspecified,
-				isShieldedStorageAlias(_type)
+				isShieldedStorageAlias(_type),
+				_type.isByteArrayOrString() && _type.usesShieldedStorage()
 			))
 			.render();
 	});
@@ -1837,7 +1838,8 @@ std::string YulUtilFunctions::storageArrayPushFunction(ArrayType const& _type, T
 				*_type.baseType(),
 				VariableDeclaration::Location::Unspecified,
 				std::optional<unsigned>(),
-				isShieldedStorageAlias(_type)
+				isShieldedStorageAlias(_type),
+				_type.isByteArrayOrString() && _type.usesShieldedStorage()
 			))
 			("maxArrayLength", (u256(1) << 64).str())
 			("shl", shiftLeftFunctionDynamic())
@@ -2349,10 +2351,10 @@ std::string YulUtilFunctions::copyValueArrayToStorageFunction(ArrayType const& _
 		else
 		{
 			templ("dstStride", std::to_string(_toType.storageStride()));
-			templ("extractFromSlot", extractFromStorageValueDynamic(*_fromType.baseType()));
+			templ("extractFromSlot", extractFromStorageValueDynamic(*_fromType.baseType(), _fromType.storageStride() < 32));
 			templ("updateByteSlice", updateByteSliceFunctionDynamic(_toType.storageStride()));
 			templ("convert", conversionFunction(*_fromType.baseType(), *_toType.baseType()));
-			templ("prepareStore", prepareStoreFunction(*_toType.baseType()));
+			templ("prepareStore", prepareStoreFunction(*_toType.baseType(), _toType.storageStride() < 32));
 		}
 		if (fromStorage)
 			templ("updateSrcPtr", Whiskers(R"(
@@ -2885,11 +2887,12 @@ std::string YulUtilFunctions::readFromStorageDynamic(
 	Type const& _type,
 	bool _splitFunctionTypes,
 	VariableDeclaration::Location _location,
-	bool _useShieldedStorageOps
+	bool _useShieldedStorageOps,
+	bool _packedShieldedFixedBytes
 )
 {
 	if (_type.isValueType())
-		return readFromStorageValueType(_type, {}, _splitFunctionTypes, _location, _useShieldedStorageOps);
+		return readFromStorageValueType(_type, {}, _splitFunctionTypes, _location, _useShieldedStorageOps, _packedShieldedFixedBytes);
 
 	solAssert(_location != VariableDeclaration::Location::Transient);
 	solAssert(!_useShieldedStorageOps, "Shielded storage ops override is only supported for value types.");
@@ -2917,7 +2920,8 @@ std::string YulUtilFunctions::readFromStorageValueType(
 	std::optional<size_t> _offset,
 	bool _splitFunctionTypes,
 	VariableDeclaration::Location _location,
-	bool _useShieldedStorageOps
+	bool _useShieldedStorageOps,
+	bool _packedShieldedFixedBytes
 )
 {
 	solAssert(_type.isValueType(), "");
@@ -2942,7 +2946,8 @@ std::string YulUtilFunctions::readFromStorageValueType(
 		) +
 		"_" +
 		_type.identifier() +
-		storageOpsIdentifierSuffix(_useShieldedStorageOps);
+		storageOpsIdentifierSuffix(_useShieldedStorageOps) +
+		(_packedShieldedFixedBytes ? "_packed" : "");
 
 	return m_functionCollector.createFunction(functionName, [&] {
 		if ((_type.isShielded() || _useShieldedStorageOps) && !m_evmVersion.supportShieldedStorage())
@@ -2966,7 +2971,7 @@ std::string YulUtilFunctions::readFromStorageValueType(
 		if (_offset.has_value())
 			templ("extract", extractFromStorageValue(_type, *_offset));
 		else
-			templ("extract", extractFromStorageValueDynamic(_type));
+			templ("extract", extractFromStorageValueDynamic(_type, _packedShieldedFixedBytes));
 		auto const* funType = dynamic_cast<FunctionType const*>(&_type);
 		bool split = _splitFunctionTypes && funType && funType->kind() == FunctionType::Kind::External;
 		templ("split", split);
@@ -3044,7 +3049,8 @@ std::string YulUtilFunctions::updateStorageValueFunction(
 	Type const& _toType,
 	VariableDeclaration::Location _location,
 	std::optional<unsigned> const& _offset,
-	bool _useShieldedStorageOps
+	bool _useShieldedStorageOps,
+	bool _packedShieldedFixedBytes
 )
 {
 	solAssert(
@@ -3065,7 +3071,8 @@ std::string YulUtilFunctions::updateStorageValueFunction(
 		_fromType.identifier() +
 		"_to_" +
 		_toType.identifier() +
-		storageOpsIdentifierSuffix(_useShieldedStorageOps);
+		storageOpsIdentifierSuffix(_useShieldedStorageOps) +
+		(_packedShieldedFixedBytes ? "_packed" : "");
 
 	return m_functionCollector.createFunction(functionName, [&] {
 		if (_toType.isValueType())
@@ -3074,10 +3081,12 @@ std::string YulUtilFunctions::updateStorageValueFunction(
 			solAssert(_toType.storageBytes() <= 32, "Invalid storage bytes size.");
 			solAssert(_toType.storageBytes() > 0, "Invalid storage bytes size.");
 
-			// For ShieldedFixedBytesType in packed storage, use numBytes() instead of storageBytes()
+			// sbytesN packs into numBytes() only when used as a sbytes byte-array element
+			// (caller passes _packedShieldedFixedBytes=true); standalone storage uses the full slot.
 			unsigned byteSize = _toType.storageBytes();
-			if (ShieldedFixedBytesType const* shieldedBytesType = dynamic_cast<ShieldedFixedBytesType const*>(&_toType))
-				byteSize = shieldedBytesType->numBytes();
+			if (_packedShieldedFixedBytes)
+				if (ShieldedFixedBytesType const* shieldedBytesType = dynamic_cast<ShieldedFixedBytesType const*>(&_toType))
+					byteSize = shieldedBytesType->numBytes();
 
 			return Whiskers(R"(
 				function <functionName>(slot, <offset><fromValues>) {
@@ -3098,7 +3107,7 @@ std::string YulUtilFunctions::updateStorageValueFunction(
 			("toValues", suffixedVariableNameList("convertedValue_", 0, _toType.sizeOnStack()))
 			("storeOpcode", storageStoreOpcode(_toType, _location, _useShieldedStorageOps))
 			("loadOpcode", storageLoadOpcode(_toType, _location, _useShieldedStorageOps))
-			("prepare", prepareStoreFunction(_toType))
+			("prepare", prepareStoreFunction(_toType, _packedShieldedFixedBytes))
 			.render();
 		}
 
@@ -3233,11 +3242,12 @@ std::string YulUtilFunctions::writeToMemoryFunction(Type const& _type)
 	});
 }
 
-std::string YulUtilFunctions::extractFromStorageValueDynamic(Type const& _type)
+std::string YulUtilFunctions::extractFromStorageValueDynamic(Type const& _type, bool _packedShieldedFixedBytes)
 {
 	std::string functionName =
 		"extract_from_storage_value_dynamic" +
-		_type.identifier();
+		_type.identifier() +
+		(_packedShieldedFixedBytes ? "_packed" : "");
 	return m_functionCollector.createFunction(functionName, [&] {
 		return Whiskers(R"(
 			function <functionName>(slot_value, offset) -> value {
@@ -3246,7 +3256,7 @@ std::string YulUtilFunctions::extractFromStorageValueDynamic(Type const& _type)
 		)")
 		("functionName", functionName)
 		("shr", shiftRightFunctionDynamic())
-		("cleanupStorage", cleanupFromStorageFunction(_type))
+		("cleanupStorage", cleanupFromStorageFunction(_type, _packedShieldedFixedBytes))
 		.render();
 	});
 }
@@ -3267,11 +3277,13 @@ std::string YulUtilFunctions::extractFromStorageValue(Type const& _type, size_t 
 	});
 }
 
-std::string YulUtilFunctions::cleanupFromStorageFunction(Type const& _type)
+std::string YulUtilFunctions::cleanupFromStorageFunction(Type const& _type, bool _packedShieldedFixedBytes)
 {
 	solAssert(_type.isValueType(), "");
 
-	std::string functionName = std::string("cleanup_from_storage_") + _type.identifier();
+	std::string functionName =
+		std::string("cleanup_from_storage_") + _type.identifier() +
+		(_packedShieldedFixedBytes ? "_packed" : "");
 	return m_functionCollector.createFunction(functionName, [&] {
 		Whiskers templ(R"(
 			function <functionName>(value) -> cleaned {
@@ -3285,12 +3297,11 @@ std::string YulUtilFunctions::cleanupFromStorageFunction(Type const& _type)
 			encodingType = _type.encodingType();
 		unsigned storageBytes = encodingType->storageBytes();
 
-		// For ShieldedFixedBytesType in packed storage (e.g., sbytes dynamic arrays),
-		// use numBytes() instead of storageBytes() to get the actual byte count.
-		// storageBytes() returns 32 for all shielded types (due to cload/cstore),
-		// but when extracted from packed storage, they need to be treated by their actual size.
-		if (ShieldedFixedBytesType const* shieldedBytesType = dynamic_cast<ShieldedFixedBytesType const*>(encodingType))
-			storageBytes = shieldedBytesType->numBytes();
+		// sbytesN occupies a full slot when standalone but is packed (numBytes per element)
+		// when used as a sbytes byte-array element. Callers pass true for the packed case.
+		if (_packedShieldedFixedBytes)
+			if (ShieldedFixedBytesType const* shieldedBytesType = dynamic_cast<ShieldedFixedBytesType const*>(encodingType))
+				storageBytes = shieldedBytesType->numBytes();
 
 		if (IntegerType const* intType = dynamic_cast<IntegerType const*>(encodingType))
 			if (intType->isSigned() && storageBytes != 32)
@@ -3310,9 +3321,11 @@ std::string YulUtilFunctions::cleanupFromStorageFunction(Type const& _type)
 	});
 }
 
-std::string YulUtilFunctions::prepareStoreFunction(Type const& _type)
+std::string YulUtilFunctions::prepareStoreFunction(Type const& _type, bool _packedShieldedFixedBytes)
 {
-	std::string functionName = "prepare_store_" + _type.identifier();
+	std::string functionName =
+		"prepare_store_" + _type.identifier() +
+		(_packedShieldedFixedBytes ? "_packed" : "");
 	return m_functionCollector.createFunction(functionName, [&]() {
 		solAssert(_type.isValueType(), "");
 		auto const* funType = dynamic_cast<FunctionType const*>(&_type);
@@ -3339,11 +3352,12 @@ std::string YulUtilFunctions::prepareStoreFunction(Type const& _type)
 			templ("functionName", functionName);
 			if (_type.leftAligned())
 			{
-				// For ShieldedFixedBytesType, use numBytes() instead of storageBytes()
-				// to get the actual byte count for proper shift calculation.
+				// sbytesN packs into numBytes() only when used as a sbytes byte-array element
+				// (see cleanupFromStorageFunction); standalone storage uses the full slot.
 				unsigned shiftBytes = _type.storageBytes();
-				if (ShieldedFixedBytesType const* shieldedBytesType = dynamic_cast<ShieldedFixedBytesType const*>(&_type))
-					shiftBytes = shieldedBytesType->numBytes();
+				if (_packedShieldedFixedBytes)
+					if (ShieldedFixedBytesType const* shieldedBytesType = dynamic_cast<ShieldedFixedBytesType const*>(&_type))
+						shiftBytes = shieldedBytesType->numBytes();
 				templ("actualPrepare", shiftRightFunction(256 - 8 * shiftBytes) + "(value)");
 			}
 			else
@@ -4582,7 +4596,8 @@ std::string YulUtilFunctions::zeroValueFunction(Type const& _type, bool _splitFu
 std::string YulUtilFunctions::storageSetToZeroFunction(
 	Type const& _type,
 	VariableDeclaration::Location _location,
-	bool _useShieldedStorageOps
+	bool _useShieldedStorageOps,
+	bool _packedShieldedFixedBytes
 )
 {
 	// SEISMIC: Cherry-picked fix for TransientStorageClearingHelperCollision (SOL-2026-1)
@@ -4616,7 +4631,8 @@ std::string YulUtilFunctions::storageSetToZeroFunction(
 		(_location == VariableDeclaration::Location::Transient ? "transient_"s : "") +
 		"storage_set_to_zero_" +
 		_type.identifier() +
-		storageOpsIdentifierSuffix(_useShieldedStorageOps);
+		storageOpsIdentifierSuffix(_useShieldedStorageOps) +
+		(_packedShieldedFixedBytes ? "_packed" : "");
 
 	return m_functionCollector.createFunction(functionName, [&]() {
 		if (_type.isValueType())
@@ -4627,7 +4643,7 @@ std::string YulUtilFunctions::storageSetToZeroFunction(
 				}
 			)")
 			("functionName", functionName)
-			("store", updateStorageValueFunction(_type, _type, _location, std::optional<unsigned>(), _useShieldedStorageOps))
+			("store", updateStorageValueFunction(_type, _type, _location, std::optional<unsigned>(), _useShieldedStorageOps, _packedShieldedFixedBytes))
 			("values", suffixedVariableNameList("zero_", 0, _type.sizeOnStack()))
 			("zeroValue", zeroValueFunction(_type))
 			.render();

--- a/libsolidity/codegen/YulUtilFunctions.h
+++ b/libsolidity/codegen/YulUtilFunctions.h
@@ -362,11 +362,13 @@ public:
 		VariableDeclaration::Location _location,
 		bool _useShieldedStorageOps = false
 	);
+	/// See cleanupFromStorageFunction for @a _packedShieldedFixedBytes.
 	std::string readFromStorageDynamic(
 		Type const& _type,
 		bool _splitFunctionTypes,
 		VariableDeclaration::Location _location,
-		bool _useShieldedStorageOps = false
+		bool _useShieldedStorageOps = false,
+		bool _packedShieldedFixedBytes = false
 	);
 
 	/// @returns a function that reads a value type from memory. Performs cleanup.
@@ -383,7 +385,8 @@ public:
 	///
 	/// For external function types, input and output is in "compressed"/"unsplit" form.
 	std::string extractFromStorageValue(Type const& _type, size_t _offset);
-	std::string extractFromStorageValueDynamic(Type const& _type);
+	/// See cleanupFromStorageFunction for @a _packedShieldedFixedBytes.
+	std::string extractFromStorageValueDynamic(Type const& _type, bool _packedShieldedFixedBytes = false);
 
 	/// Returns the name of a function will write the given value to
 	/// the specified slot and offset. If offset is not given, it is expected as
@@ -391,12 +394,14 @@ public:
 	/// For reference types, offset is checked to be zero at runtime.
 	/// `_useShieldedStorageOps` has the same meaning as in readFromStorage().
 	/// signature: (slot, [offset,] value)
+	/// See cleanupFromStorageFunction for @a _packedShieldedFixedBytes.
 	std::string updateStorageValueFunction(
 		Type const& _fromType,
 		Type const& _toType,
 		VariableDeclaration::Location _location,
 		std::optional<unsigned> const& _offset = std::optional<unsigned>(),
-		bool _useShieldedStorageOps = false
+		bool _useShieldedStorageOps = false,
+		bool _packedShieldedFixedBytes = false
 	);
 
 	/// Returns the name of a function that will write the given value to
@@ -411,13 +416,17 @@ public:
 	/// The storage cleanup expects the value to be right-aligned with potentially
 	/// dirty higher order bytes.
 	/// For external functions, input and output is in "compressed"/"unsplit" form.
-	std::string cleanupFromStorageFunction(Type const& _type);
+	/// @param _packedShieldedFixedBytes if true and @a _type is a ShieldedFixedBytesType, treat the
+	/// value as packed into numBytes() (used for sbytes byte-array elements); otherwise use the
+	/// full 32-byte slot, matching the documented full-slot invariant for standalone shielded types.
+	std::string cleanupFromStorageFunction(Type const& _type, bool _packedShieldedFixedBytes = false);
 
 	/// @returns the name of a function that prepares a value of the given type
 	/// for being stored in storage. This usually includes cleanup and right-alignment
 	/// to fit the number of bytes in storage.
 	/// The resulting value might still have dirty higher order bits.
-	std::string prepareStoreFunction(Type const& _type);
+	/// See cleanupFromStorageFunction for @a _packedShieldedFixedBytes.
+	std::string prepareStoreFunction(Type const& _type, bool _packedShieldedFixedBytes = false);
 
 	/// @returns the name of a function that allocates memory.
 	/// Modifies the "free memory pointer"
@@ -517,10 +526,12 @@ public:
 	/// zero
 	/// signature: (slot, offset) ->
 	/// `_useShieldedStorageOps` has the same meaning as in readFromStorage().
+	/// See cleanupFromStorageFunction for @a _packedShieldedFixedBytes.
 	std::string storageSetToZeroFunction(
 		Type const& _type,
 		VariableDeclaration::Location _location,
-		bool _useShieldedStorageOps = false
+		bool _useShieldedStorageOps = false,
+		bool _packedShieldedFixedBytes = false
 	);
 
 	/// If revertStrings is debug, @returns the name of a function that
@@ -604,7 +615,8 @@ private:
 		std::optional<size_t> _offset,
 		bool _splitFunctionTypes,
 		VariableDeclaration::Location _location,
-		bool _useShieldedStorageOps = false
+		bool _useShieldedStorageOps = false,
+		bool _packedShieldedFixedBytes = false
 	);
 	/// @returns a function that reads a reference type from storage to memory (performing a deep copy).
 	std::string readFromStorageReferenceType(Type const& _type);

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -743,7 +743,8 @@ bool IRGeneratorForStatements::visit(UnaryOperation const& _unaryOperation)
 						m_utils.storageSetToZeroFunction(
 							m_currentLValue->type,
 							VariableDeclaration::Location::Unspecified,
-							useShieldedOps
+							useShieldedOps,
+							_storage.packedShieldedFixedBytes
 						) <<
 						"(" <<
 						_storage.slot <<
@@ -1489,6 +1490,7 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 					slotName,
 					arrayType->usesShieldedStorage(),
 					offsetName,
+					arrayType->isByteArrayOrString() && arrayType->baseType()->isShielded()
 				}
 			});
 		}
@@ -2681,7 +2683,12 @@ void IRGeneratorForStatements::endVisit(IndexAccess const& _indexAccess)
 
 				setLValue(_indexAccess, IRLValue{
 					*_indexAccess.annotation().type,
-					IRLValue::Storage{slot, arrayType.usesShieldedStorage(), offset}
+					IRLValue::Storage{
+						slot,
+						arrayType.usesShieldedStorage(),
+						offset,
+						arrayType.isByteArrayOrString() && arrayType.baseType()->isShielded()
+					}
 				});
 
 				break;
@@ -3481,7 +3488,8 @@ void IRGeneratorForStatements::writeToLValue(IRLValue const& _lvalue, IRVariable
 						_lvalue.type,
 						VariableDeclaration::Location::Unspecified,
 						offsetStatic,
-						useShieldedOps
+						useShieldedOps,
+						_storage.packedShieldedFixedBytes
 					) <<
 					"(" <<
 					_storage.slot <<
@@ -3592,7 +3600,8 @@ IRVariable IRGeneratorForStatements::readFromLValue(IRLValue const& _lvalue)
 						_lvalue.type,
 						true,
 						VariableDeclaration::Location::Unspecified,
-						_storage.usesShieldedStorage
+						_storage.usesShieldedStorage,
+						_storage.packedShieldedFixedBytes
 					) <<
 					"(" <<
 					_storage.slot <<

--- a/libsolidity/codegen/ir/IRLValue.h
+++ b/libsolidity/codegen/ir/IRLValue.h
@@ -50,6 +50,10 @@ struct IRLValue
 		///           functions
 		/// string: Used when the offset is determined at run time
 		std::variant<std::string, unsigned> const offset;
+		/// True iff this lvalue refers to a single packed byte inside a sbytes byte-array slot.
+		/// Distinguishes that case from full-slot value-type accesses, which also use a dynamic
+		/// offset (always 0 at runtime) but need full-slot codegen — see P5.
+		bool packedShieldedFixedBytes = false;
 		std::string offsetString() const
 		{
 			if (std::holds_alternative<unsigned>(offset))

--- a/test/libsolidity/semanticTests/storage/shielded_fixed_bytes_storage_layout.sol
+++ b/test/libsolidity/semanticTests/storage/shielded_fixed_bytes_storage_layout.sol
@@ -1,0 +1,21 @@
+contract C {
+	sbytes8 private x;
+
+	function asmStore(bytes32 v) external {
+		assembly { cstore(x.slot, v) }
+	}
+
+	function publicView() external view returns (bytes8) {
+		return bytes8(x);
+	}
+
+	function rawSlot() external view returns (bytes32 r) {
+		assembly { r := cload(x.slot) }
+	}
+}
+// ====
+// compileViaYul: true
+// ----
+// asmStore(bytes32): 0x0102030405060708000000000000000000000000000000000000000000000000 ->
+// publicView() -> 0x0102030405060708000000000000000000000000000000000000000000000000
+// rawSlot() -> 0x0102030405060708000000000000000000000000000000000000000000000000


### PR DESCRIPTION
Fixes #281.

## Summary

`ShieldedFixedBytesType` always reports `storageBytes() == 32` (Seismic's full-slot rule), but the via-IR storage helpers unconditionally substituted `numBytes()` for the slot width. The result: standalone `sbytes8` state vars, mapping values, and struct members all wrote and read through a packed `numBytes`-wide layout, corrupting cross-pipeline data and silently losing high-byte content (auditor's P5 PoC).

Zellic's recommended fix (3.7) was to drop the `numBytes()` overrides entirely. That doesn't work standalone, because `sbytes1` is the element type for both:

1. Standalone state vars (full slot) — the case the auditor sees.
2. The `sbytes` dynamic byte array's element type (packed 1 byte per element).

Dropping the override outright breaks the byte-array case (~5-7 sbytes byte-array tests).

This PR is the **threaded-flag** alternative the audit doc had as a pragmatic option. The override only fires when the caller explicitly says "this is a packed sbytes-byte-array element"; otherwise full slot.

## Changes

- New `bool _packedShieldedFixedBytes` parameter on every helper that reads/writes through the override (default `false`):
  - `cleanupFromStorageFunction`, `prepareStoreFunction`
  - `extractFromStorageValueDynamic`
  - `updateStorageValueFunction`, `storageSetToZeroFunction`
  - `readFromStorageDynamic`, `readFromStorageValueType`
- The override (`byteSize/shiftBytes/storageBytes = numBytes()`) is gated on the flag being `true`.
- Callers pass `true` at the byte-array-element sites:
  - `storageArrayPushFunction` and `storageByteArrayPopFunction`: gated on `_type.isByteArrayOrString() && _type.usesShieldedStorage()` (i.e. `sbytes`).
  - `copyValueArrayToStorageFunction`: gated on the source/dest `storageStride() < 32`.
- New `bool packedShieldedFixedBytes` field on `IRLValue::Storage` so reads/writes/deletes through an LValue propagate the flag. Set true at storage-array index access only for `sbytes` (`isByteArrayOrString && baseType isShielded`); `sbytesN[]` element accesses keep full slot.

Function names get a `_packed` suffix when the flag is set, so the two layouts don't collide in `m_functionCollector`.

## Test plan

- [x] New `semanticTests/storage/shielded_fixed_bytes_storage_layout.sol` — auditor's PoC. Pre-fix `publicView()` returns 0; post-fix returns the stored bytes.
- [x] Full `semanticTests/*` via-IR sweep green (1920 tests). Includes all sbytes byte-array tests that the literal "drop the overrides" approach would have broken: `sbytes_dynamic_pop_*`, `sbytes_dynamic_delete_element`, `shielded_sbytes_array_storage`, `shielded_inline_cast_sbytes_fixed`, `shielded_sbytes_mapping_storage`.

## What this PR does *not* do

The auditor's recommendation was the literal override removal, which we couldn't take cleanly. A deeper refactor (switching `sbytes`'s element type from `sbytes1` to `bytes1 + usesShieldedStorage` flag — see the existing `IRLValue.h:46-48` pattern) would let `sbytes1` have a single storage layout and the override could disappear entirely. That's a follow-up worth doing post-audit; this PR closes the finding by routing the existing override correctly.