### PR TITLE
fix(smtchecker): size shielded narrowing casts by real width, not storage slot

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -1221,8 +1221,16 @@ void SMTEncoder::visitTypeConversion(FunctionCall const& _funCall)
 
 	// TODO Simplify this whole thing for 0.8.0 where weird casts are disallowed.
 
-	unsigned argSize = argType->storageBytes();
-	unsigned castSize = funCallType->storageBytes();
+	// Shielded types report storageBytes() == 32; use their real value width so narrowing casts truncate.
+	auto valueSizeBytes = [](Type const* _type) -> unsigned {
+		if (auto const* shieldedInt = dynamic_cast<ShieldedIntegerType const*>(_type))
+			return shieldedInt->numBits() / 8;
+		if (auto const* shieldedBytes = dynamic_cast<ShieldedFixedBytesType const*>(_type))
+			return shieldedBytes->numBytes();
+		return _type->storageBytes();
+	};
+	unsigned argSize = valueSizeBytes(argType);
+	unsigned castSize = valueSizeBytes(funCallType);
 	bool castIsSigned = smt::isNumber(*funCallType) && smt::isSigned(funCallType);
 	bool argIsSigned = smt::isNumber(*argType) && smt::isSigned(argType);
 	std::optional<smtutil::Expression> symbMin;

--- a/test/libsolidity/smtCheckerTests/types/shielded_narrowing_cast_no_vacuous_proof.sol
+++ b/test/libsolidity/smtCheckerTests/types/shielded_narrowing_cast_no_vacuous_proof.sol
@@ -1,0 +1,17 @@
+contract C {
+	function vacuity(uint256 v) external pure {
+		suint8 s = suint8(v);
+		uint256 o = uint256(s);
+		o;
+		require(v >= 256);
+		// Reachable (suint8(v) wraps to v % 256), so this must be flagged.
+		// Pre-fix suint8 was sized by storageBytes() == 32, modeling the cast
+		// as a no-wrap same-size op; the path was pruned as contradictory and
+		// the assert vacuously "proved safe".
+		assert(1 == 2);
+	}
+}
+// ====
+// SMTEngine: chc
+// ----
+// Warning 6328: (393-407): CHC: Assertion violation happens here.


### PR DESCRIPTION
Fixes #330.

## Summary

Follow-up A1 — a soundness regression introduced by the shielded-type SMTChecker support (3.16/3.17). `visitTypeConversion` decided whether a cast truncates by comparing `storageBytes()`, which is **32 for every shielded type** regardless of real width. `suint8(v)` looked same-size as `uint256` and was modeled as a no-wrap identity, so for `v >= 256` the result contradicted the `suint8` `0..255` bound; the solver pruned the contradictory path and **vacuously proved reachable assertions safe** — worse than the pre-support behavior, which honestly said "unsupported type".

- Computes `argSize`/`castSize` from the real value width for shielded types (`numBits()/8` for `ShieldedIntegerType`, `numBytes()` for `ShieldedFixedBytesType`), falling back to `storageBytes()` for all other types. Shielded narrowing casts are then modeled as `v mod 2^n`, exactly like their non-shielded counterparts.
- These were the only two `storageBytes()` uses in the SMT layer, so the fix is fully localized. The downstream branches already assume these are value widths (the fixed-bytes truncation branch asserts `argSize - castSize == numBytes diff`), so feeding storage footprint was the inconsistency.

## Test plan

- [x] New `smtCheckerTests/types/shielded_narrowing_cast_no_vacuous_proof.sol`: CHC now reports the reachable `assert(1 == 2)` as a violation instead of vacuously "proved safe". Verified the non-shielded `uint8` analog already behaved correctly (control).
- [x] Existing shielded SMT tests (P20/P21/P32 family, 10 tests) still green.
- [x] Full `smtCheckerTests/*` sweep: 16 failures, **bit-identical** to the `zellic-audit-april-2026` baseline z3 4.8.x noise set (same names verified for P5/P32). No new failures introduced.