### PR TITLE
fix(typechecker): skip require condition when scanning for 10313 leak

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3287,13 +3287,18 @@ void TypeChecker::typeCheckFunctionGeneralChecks(
 	}
 
 	// revert("msg") and require(cond, "msg") expose their message argument via revert returndata.
-	if (
-		_functionType->kind() == FunctionType::Kind::Revert ||
-		_functionType->kind() == FunctionType::Kind::Require
-	)
+	// require's first argument is the condition (control flow, not returndata) — skip it; a
+	// control-flow leak from a shielded condition is 10310/10311's concern, not 10313's.
+	if (_functionType->kind() == FunctionType::Kind::Revert)
+	{
 		for (Expression const* arg: paramArgMap)
 			if (arg)
 				checkShieldedLeakInPublicSink(*arg);
+	}
+	else if (_functionType->kind() == FunctionType::Kind::Require)
+		for (size_t i = 1; i < paramArgMap.size(); ++i)
+			if (paramArgMap[i])
+				checkShieldedLeakInPublicSink(*paramArgMap[i]);
 }
 
 bool TypeChecker::visit(FunctionCall const& _functionCall)

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_require_condition_no_leak_warning.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_require_condition_no_leak_warning.sol
@@ -1,0 +1,21 @@
+contract C {
+    sbool private flag;
+    sbytes private secret;
+
+    // require condition is control flow, not returndata -> no 10313.
+    function checkOnly() external view {
+        require(bool(flag));
+    }
+
+    // require/revert message IS returndata -> must still warn 10313.
+    function leakMessage(bool cond) external view {
+        require(cond, string(bytes(secret)));
+    }
+    function leakRevertString() external view {
+        revert(string(bytes(secret)));
+    }
+}
+// ----
+// Warning 10305: (41-62): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// Warning 10313: (363-376): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
+// Warning 10313: (456-469): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.


### PR DESCRIPTION
Fixes #332.

## Summary

Follow-up A2 — a false positive introduced by the emit/revert leak warning (finding 3.21). The scan over `require`/`revert` arguments included `require`'s first argument, which is the **condition** — control flow, never returndata — so `require(bool(flag))` wrongly warned 10313 ("leaks to public logs or returndata"). False positives on this common declassify-to-check pattern train developers to suppress 10313, hiding the genuine cases.

- Split the loop: `Kind::Revert` scans all args (the `revert("msg")` string form's arg 0 *is* the message); `Kind::Require` scans from arg 1 (the optional message), leaving the condition alone.
- A shielded condition's control-flow leak remains 10310/10311's concern, per the auditor's note.

## Test plan

- [x] New `syntaxTests/shieldedTypes/shielded_require_condition_no_leak_warning.sol`: `require(bool(flag))` no longer warns 10313; `require(cond, string(bytes(secret)))` and `revert(string(bytes(secret)))` still warn (message is returndata).
- [x] Existing P35 test `shielded_bytes_leak_via_emit_revert.sol` unchanged and green — its `require(cond, string(bytes(secret)))` message-leak case still fires.
- [x] Full `syntaxTests/*` suite green (4067 tests). 10313 is a warning and doesn't affect codegen, so the syntax suite is the complete gate; no semantic change.