### PR TITLE
fix(codegen): per-element clear for reference-type array elements at any depth

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -1473,11 +1473,12 @@ std::string YulUtilFunctions::cleanUpStorageArrayEndFunction(ArrayType const& _t
 		)")
 		("convertToSize", arrayConvertLengthToSize(_type))
 		("dataPosition", arrayDataAreaFunction(_type))
-		// Struct bases need per-member clearing; the shieldedUint256 shortcut is value-type only.
+		// Reference-type elements (structs, nested arrays) need per-element clearing so each slot
+		// gets the right opcode at any depth; the flat shieldedUint256 shortcut is value-type only.
 		("clearStorageRange", clearStorageRangeFunction(
-			_type.baseType()->category() == Type::Category::Struct
-				? *_type.baseType()
-				: (_type.usesShieldedStorage() ? *TypeProvider::shieldedUint256() : *_type.baseType())
+			_type.baseType()->isValueType()
+				? (_type.usesShieldedStorage() ? *TypeProvider::shieldedUint256() : *_type.baseType())
+				: *_type.baseType()
 		))
 		("packed", _type.baseType()->storageBytes() <= 16)
 		("itemsPerSlot", std::to_string(32 / _type.baseType()->storageBytes()))

--- a/test/libsolidity/semanticTests/array/shielded_nested_struct_array_shrink_preserves_public_field.sol
+++ b/test/libsolidity/semanticTests/array/shielded_nested_struct_array_shrink_preserves_public_field.sol
@@ -1,0 +1,25 @@
+contract C {
+    struct S { suint256 priv; uint256 pub; }
+
+    S[2][] private arr;
+    S[2][] private empty;
+
+    function setup() external {
+        arr.push();
+        arr[0][0].priv = suint256(1);
+        arr[0][0].pub = 0xAA;
+        arr[0][1].priv = suint256(2);
+        arr[0][1].pub = 0xBB;
+    }
+    function shrink() external { arr = empty; }
+    function repush() external {
+        arr.push();
+        arr[0][0].pub = 0xCC;
+    }
+    function readPub() external view returns (uint256) { return arr[0][0].pub; }
+}
+// ----
+// setup() ->
+// shrink() ->
+// repush() ->
+// readPub() -> 0xCC


### PR DESCRIPTION
Fixes #334.

## Summary

Follow-up B1 — the P24 fix (#328) was incomplete. `cleanUpStorageArrayEndFunction` routed only `Struct` array elements through per-member clearing; a nested-array element (`S[N][]` -> element `S[N]`, category `Array`) fell back to the flat `shieldedUint256` clear and cstored the public field slots inside each struct. Critical (3.4), one nesting level deeper than the case P24 fixed.

- Gates the `shieldedUint256` shortcut on **value-type** elements instead of specifically `Struct`. Reference-type elements (structs and nested arrays) pass their real type to `clearStorageRangeFunction`, which dispatches through `clearStorageStructFunction` / `clearStorageArrayFunction` and recurses to the right opcode per slot at any depth. Value-type element arrays (`suint256[]`, `uint256[]`) keep the shortcut.
- Subsumes P24's struct case (structs are reference types).

## Test plan

- [x] New `semanticTests/array/shielded_nested_struct_array_shrink_preserves_public_field.sol` (`S[2][]`): pre-fix `setup; shrink; repush` reverts with `InvalidPublicStorageAccess`; post-fix all calls succeed and `readPub()` returns `0xCC`.
- [x] P24's `S[]` test still green (structs keep per-member clearing).
- [x] Full `semanticTests/*` green across all 4 configs (legacy ±opt, via-IR ±opt), 1921 tests each.