### PR TITLE
fix(typechecker): warn on msg.value into shielded slot beyond simple assignment

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1529,6 +1529,16 @@ void TypeChecker::endVisit(Return const& _return)
 	else if (params->parameters().size() == 1)
 		preserveShieldedStorageMarkerInDeclaration(*params->parameters().front(), *type(*_return.expression()));
 
+	// Returning msg.value/msg.data through a shielded return parameter leaks it.
+	if (auto const* rhsTuple = dynamic_cast<TupleExpression const*>(_return.expression()))
+	{
+		for (size_t i = 0; i < std::min(rhsTuple->components().size(), params->parameters().size()); ++i)
+			if (rhsTuple->components()[i])
+				checkMsgValueToShielded(*rhsTuple->components()[i], *type(*params->parameters()[i]));
+	}
+	else if (params->parameters().size() == 1)
+		checkMsgValueToShielded(*_return.expression(), *type(*params->parameters().front()));
+
 	for (auto const& var: params->parameters())
 		returnTypes.push_back(type(*var));
 	if (auto tupleType = dynamic_cast<TupleType const*>(type(*_return.expression())))
@@ -1905,6 +1915,19 @@ bool TypeChecker::visit(Assignment const& _assignment)
 		}
 
 		checkImplicitConversion(_assignment.rightHandSide(), *tupleType);
+
+		// Per-component msg.value/msg.data leak check, for simple variable targets paired with a
+		// literal-tuple RHS. Mirrors the preserve loop above: only Identifier LHS components, so
+		// non-lvalue components like x.push() are skipped (they can't receive msg.value anyway).
+		if (auto const* lhsTuple = dynamic_cast<TupleExpression const*>(&_assignment.leftHandSide()))
+			if (auto const* rhsTuple = dynamic_cast<TupleExpression const*>(&_assignment.rightHandSide()))
+				for (size_t i = 0; i < std::min(lhsTuple->components().size(), rhsTuple->components().size()); ++i)
+				{
+					if (!lhsTuple->components()[i] || !rhsTuple->components()[i])
+						continue;
+					if (dynamic_cast<Identifier const*>(lhsTuple->components()[i].get()))
+						checkMsgValueToShielded(*rhsTuple->components()[i], *type(*lhsTuple->components()[i]));
+				}
 	}
 	else if (_assignment.assignmentOperator() == Token::Assign)
 	{
@@ -1926,6 +1949,7 @@ bool TypeChecker::visit(Assignment const& _assignment)
 	{
 		// compound assignment
 		_assignment.rightHandSide().accept(*this);
+		checkMsgValueToShielded(_assignment.rightHandSide(), *t);
 		Token const binaryOp = TokenTraits::AssignmentToBinaryOp(_assignment.assignmentOperator());
 		Type const* rhsType = type(_assignment.rightHandSide());
 		Type const* resultType = t->binaryOperatorResult(binaryOp, rhsType);
@@ -3177,6 +3201,8 @@ void TypeChecker::typeCheckFunctionGeneralChecks(
 	for (size_t i = 0; i < paramArgMap.size(); ++i)
 	{
 		solAssert(!!paramArgMap[i], "unmapped parameter");
+		// Passing msg.value/msg.data into a shielded parameter leaks it.
+		checkMsgValueToShielded(*paramArgMap[i], *parameterTypes[i]);
 		BoolResult result = type(*paramArgMap[i])->isImplicitlyConvertibleTo(*parameterTypes[i]);
 		if (!result)
 		{

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_msg_value_warning_all_paths.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_msg_value_warning_all_paths.sol
@@ -1,0 +1,23 @@
+contract C {
+    suint256 secret;
+    suint256 a;
+
+    function viaCompound() external payable {
+        secret += suint256(msg.value);
+    }
+    function viaTuple() external payable {
+        (secret, a) = (suint256(msg.value), a);
+    }
+    function viaReturn() internal returns (suint256) {
+        return suint256(msg.value);
+    }
+    function sink(suint256 x) internal {}
+    function viaArg() external payable {
+        sink(suint256(msg.value));
+    }
+}
+// ----
+// Warning 10306: (124-133): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.
+// Warning 10306: (217-226): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.
+// Warning 10306: (318-327): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.
+// Warning 10306: (441-450): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.


### PR DESCRIPTION
Fixes #336.

## Summary

Follow-up B3 — the msg.value/msg.data leak warning (10306/10307, finding 3.13) was emitted only from variable-declaration initializers and the simple-`=` assignment branch. Compound assignment, tuple assignment, return, and function/constructor arguments all committed `msg.value` into shielded slots silently.

Adds `checkMsgValueToShielded` at the four missed sites:
- compound-assignment branch (RHS vs LHS type);
- tuple-assignment branch — per literal-tuple component, guarded to `Identifier` LHS components only (mirrors the adjacent preserve loop, so non-lvalue components like `x.push()` are skipped and the nested/empty-tuple paths don't ICE);
- `endVisit(Return)` (per return component vs return-parameter type);
- the argument-compatibility loop in `typeCheckFunctionGeneralChecks` (function + struct-ctor args).

The helper self-scopes to shielded targets and recurses into conversion args.

## Test plan

- [x] New `syntaxTests/shieldedTypes/shielded_msg_value_warning_all_paths.sol`: 10306 now fires on compound, tuple, return, and argument paths (4 warnings).
- [x] Existing P30 tests (`shielded_msg_value_warning*`, `shielded_msg_data_warning`) unchanged and green.
- [x] Full `syntaxTests/*` suite green (4067 tests) — including the tuple/array push-assign tests that the initial unguarded version ICE'd on (`Tuple decomposition is not expected`); the `Identifier`-only guard resolves those.
- Warning-only change; no codegen impact, so the syntax suite is the complete gate.