### PR TITLE
fix(typechecker): recurse through sub-expressions in inline-asm storage check

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1248,36 +1248,46 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 		}
 	};
 
+	// Walk an expression and every sub-expression so storage ops nested inside other calls
+	// (e.g. iszero(sload(...))) or in a switch value are checked, not just a top-level call.
+	std::function<void(yul::Expression const&)> walkExpression = [&](yul::Expression const& _expr) {
+		if (auto const* funCall = std::get_if<yul::FunctionCall>(&_expr))
+		{
+			checkStorageOp(funCall);
+			for (auto const& arg : funCall->arguments)
+				walkExpression(arg);
+		}
+	};
+
 	std::function<void(yul::Block const&)> collectStorageOps = [&](yul::Block const& _block) {
 		for (auto const& statement : _block.statements)
 		{
 			std::visit(util::GenericVisitor{
 				[&](yul::ExpressionStatement const& _exprStmt) {
-					if (auto const* funCall = std::get_if<yul::FunctionCall>(&_exprStmt.expression))
-						checkStorageOp(funCall);
+					walkExpression(_exprStmt.expression);
 				},
 				[&](yul::VariableDeclaration const& _varDecl) {
 					if (_varDecl.value)
-						if (auto const* funCall = std::get_if<yul::FunctionCall>(_varDecl.value.get()))
-							checkStorageOp(funCall);
+						walkExpression(*_varDecl.value);
 				},
 				[&](yul::Assignment const& _assignment) {
 					if (_assignment.value)
-						if (auto const* funCall = std::get_if<yul::FunctionCall>(_assignment.value.get()))
-							checkStorageOp(funCall);
+						walkExpression(*_assignment.value);
 				},
 				[&](yul::If const& _if) {
-					if (auto const* funCall = std::get_if<yul::FunctionCall>(_if.condition.get()))
-						checkStorageOp(funCall);
+					if (_if.condition)
+						walkExpression(*_if.condition);
 					collectStorageOps(_if.body);
 				},
 				[&](yul::Switch const& _switch) {
+					if (_switch.expression)
+						walkExpression(*_switch.expression);
 					for (auto const& _case : _switch.cases)
 						collectStorageOps(_case.body);
 				},
 				[&](yul::ForLoop const& _forLoop) {
-					if (auto const* funCall = std::get_if<yul::FunctionCall>(_forLoop.condition.get()))
-						checkStorageOp(funCall);
+					if (_forLoop.condition)
+						walkExpression(*_forLoop.condition);
 					collectStorageOps(_forLoop.pre);
 					collectStorageOps(_forLoop.body);
 					collectStorageOps(_forLoop.post);

--- a/test/libsolidity/syntaxTests/inlineAssembly/shielded_sload_in_switch_and_nested.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/shielded_sload_in_switch_and_nested.sol
@@ -1,0 +1,16 @@
+contract C {
+    suint256 private secret;
+    function viaSwitch() external view {
+        assembly { switch sload(secret.slot) case 0 {} }
+    }
+    function viaNestedInCondition() external view {
+        assembly { if iszero(sload(secret.slot)) {} }
+    }
+    function viaNestedInValue() external view returns (uint256 r) {
+        assembly { r := add(sload(secret.slot), 1) }
+    }
+}
+// ----
+// TypeError 10308: (109-127): Cannot use sload() on shielded storage variable. Use cload() instead.
+// TypeError 10308: (227-245): Cannot use sload() on shielded storage variable. Use cload() instead.
+// TypeError 10308: (354-372): Cannot use sload() on shielded storage variable. Use cload() instead.


### PR DESCRIPTION
Fixes #338.

## Summary

Follow-up B4 — the P31 fix (finding 3.22) extended the inline-asm shielded-storage check (10308 / sister 10314) to `if`/`for` conditions, but `collectStorageOps` only inspected a single top-level call per expression position. A shielded storage op nested inside another call (`iszero(sload(...))`, `add(sload(...), 1)`) or used as a `switch` value bypassed the check.

- Adds a recursive expression walker that runs `checkStorageOp` on each `FunctionCall` and descends into its arguments, applied at every expression position — statement expressions, var-decl/assignment values, `if`/`for` conditions, and the previously-ignored `switch` value.
- `checkStorageOp` already handles both the shielded (10308) and non-shielded (10314) sister checks, so both broaden in one change. Top-level conditions still fire (the walker visits the outermost call first).

## Test plan

- [x] New `syntaxTests/inlineAssembly/shielded_sload_in_switch_and_nested.sol`: 10308 now fires on a switch value, on `sload` nested in `iszero(...)`, and on `sload` nested in a var-decl value.
- [x] Existing P31 test `shielded_sload_in_if_for_condition.sol` unchanged and green (top-level conditions still caught).
- [x] Full `syntaxTests/*` suite green (4067 tests). Diagnostic-only change; no codegen impact.