### PR TITLE
fix(typechecker): scope asm 10314 to cstore and catch literal/copied public slots

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1170,6 +1170,19 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 {
 	auto const& externalRefs = _inlineAssembly.annotation().externalReferences;
 
+	// Storage slots occupied by a fully non-shielded state variable. Used to flag cstore on a
+	// public slot referenced by a bare literal (cstore(0, v)). Mixed/shielded vars are excluded
+	// so we never flag a slot where cstore could be legitimate.
+	std::set<u256> publicSlots;
+	if (m_currentContract)
+		for (auto const& [var, slot, byteOffset]: ContractType(*m_currentContract).linearizedStateVariables(DataLocation::Storage))
+			if (var->annotation().type && !var->annotation().type->isShielded() && !var->annotation().type->containsShieldedType())
+				publicSlots.insert(slot);
+
+	// yul locals that currently alias a non-shielded state variable's .slot (let s := pub.slot),
+	// so cstore(s, v) is flagged too. Reassigning the local to anything else clears the alias.
+	std::set<std::string> slotAliases;
+
 	// Track storage operations: slot key -> (isShielded, location, funcName)
 	struct StorageOp {
 		bool isShielded;
@@ -1190,6 +1203,27 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 			return "var:" + ident->name.str();
 		}
 		return std::nullopt;
+	};
+
+	// Whether a slot operand resolves to a non-shielded state variable's slot, through any of the
+	// statically-visible spellings: a direct .slot reference, a yul local aliasing one, or a bare
+	// literal slot number. Runtime-computed slots (keccak256, arithmetic) are not classifiable.
+	auto slotTargetsPublicStateVar = [&](yul::Expression const& _slot) -> bool {
+		if (auto const* lit = std::get_if<yul::Literal>(&_slot))
+			return lit->kind == yul::LiteralKind::Number && publicSlots.count(lit->value.value()) > 0;
+		if (auto const* ident = std::get_if<yul::Identifier>(&_slot))
+		{
+			auto it = externalRefs.find(ident);
+			if (it != externalRefs.end())
+			{
+				if (it->second.suffix == "slot" && !it->second.isShieldedStorage)
+					if (auto const* var = dynamic_cast<VariableDeclaration const*>(it->second.declaration))
+						return var->isStateVariable();
+				return false;
+			}
+			return slotAliases.count(ident->name.str()) > 0;
+		}
+		return false;
 	};
 
 	// Helper to check and record a storage operation
@@ -1219,26 +1253,14 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 					}
 				}
 			}
-			else if (isShieldedOp)
-			{
-				if (auto const* slotIdent = std::get_if<yul::Identifier>(&slotExpr))
-				{
-					auto it = externalRefs.find(slotIdent);
-					if (
-						it != externalRefs.end() &&
-						it->second.suffix == "slot" &&
-						!it->second.isShieldedStorage
-					)
-						if (auto const* var = dynamic_cast<VariableDeclaration const*>(it->second.declaration))
-							if (var->isStateVariable())
-								m_errorReporter.typeError(
-									10314_error,
-									nativeLocationOf(*funCall),
-									std::string("Cannot use ") + std::string(funcName) + "() on non-shielded storage variable. Use " +
-									(funcName == "cstore" ? "sstore" : "sload") + "() instead."
-								);
-				}
-			}
+			// cload only reads — it never claims a slot for the confidential domain, so it is safe
+			// on a public slot. Only cstore bricks a public slot, so 10314 is cstore-only.
+			else if (funcName == "cstore" && slotTargetsPublicStateVar(slotExpr))
+				m_errorReporter.typeError(
+					10314_error,
+					nativeLocationOf(*funCall),
+					"Cannot use cstore() on non-shielded storage variable. Use sstore() instead."
+				);
 
 			// Track for same-slot conflict detection
 			if (auto slotKey = getSlotKey(slotExpr))
@@ -1269,10 +1291,23 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 				[&](yul::VariableDeclaration const& _varDecl) {
 					if (_varDecl.value)
 						walkExpression(*_varDecl.value);
+					// let s := pub.slot  -> s now aliases a public slot.
+					if (_varDecl.value && _varDecl.variables.size() == 1 && slotTargetsPublicStateVar(*_varDecl.value))
+						slotAliases.insert(_varDecl.variables.front().name.str());
 				},
 				[&](yul::Assignment const& _assignment) {
 					if (_assignment.value)
 						walkExpression(*_assignment.value);
+					// Reassignment updates the alias: track it if the new value is a public slot,
+					// otherwise the local no longer aliases one.
+					if (_assignment.variableNames.size() == 1)
+					{
+						std::string const name = _assignment.variableNames.front().name.str();
+						if (_assignment.value && slotTargetsPublicStateVar(*_assignment.value))
+							slotAliases.insert(name);
+						else
+							slotAliases.erase(name);
+					}
 				},
 				[&](yul::If const& _if) {
 					if (_if.condition)

--- a/test/libsolidity/syntaxTests/inlineAssembly/cstore_on_public_slot_spellings.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/cstore_on_public_slot_spellings.sol
@@ -1,0 +1,24 @@
+contract C {
+    uint256 pub;
+    suint256 secret;
+
+    // cload never claims a slot -> allowed on a public slot.
+    function cloadOk() external view returns (uint256 r) {
+        assembly { r := cload(pub.slot) }
+    }
+    // cstore via a bare literal slot number that lands on a public state var.
+    function cstoreLiteral() external {
+        assembly { cstore(0, 1) }
+    }
+    // cstore via a yul local copied from a public .slot.
+    function cstoreCopiedVar() external {
+        assembly { let s := pub.slot  cstore(s, 1) }
+    }
+    // cstore on a genuinely shielded slot stays allowed.
+    function cstoreShieldedOk() external {
+        assembly { cstore(secret.slot, 1) }
+    }
+}
+// ----
+// TypeError 10314: (359-371): Cannot use cstore() on non-shielded storage variable. Use sstore() instead.
+// TypeError 10314: (518-530): Cannot use cstore() on non-shielded storage variable. Use sstore() instead.

--- a/test/libsolidity/syntaxTests/inlineAssembly/cstore_on_public_state_var.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/cstore_on_public_state_var.sol
@@ -3,10 +3,10 @@ contract C {
     function privatize(uint256 v) external {
         assembly { cstore(x.slot, v) }
     }
-    function leak() external view returns (uint256 r) {
+    function readOk() external view returns (uint256 r) {
+        // cload is read-only and never claims the slot, so it is allowed on a public slot.
         assembly { r := cload(x.slot) }
     }
 }
 // ----
 // TypeError 10314: (99-116): Cannot use cstore() on non-shielded storage variable. Use sstore() instead.
-// TypeError 10314: (205-218): Cannot use cload() on non-shielded storage variable. Use sload() instead.


### PR DESCRIPTION
Fixes #340.

## Summary

Follow-up B2 — the P25 10314 footgun guard (finding 3.19) was wrong in both directions:

- **Too strict:** it fired for `cload`, which is read-only and never claims a slot — rejecting valid read-only assembly (`cload(pub.slot)`).
- **Too lax:** `cstore` only triggered it when the slot operand was *directly* `x.slot`, so `cstore(0, v)` (bare literal) and `let s := x.slot; cstore(s, v)` (copied yul local) bricked public slots silently.

Changes:
- Restrict 10314 to `cstore`.
- New `slotTargetsPublicStateVar` covering three statically-visible spellings: a direct non-shielded `.slot` reference; a yul local recorded as aliasing one (reassignment clears the alias); and a bare literal slot number landing on a fully non-shielded state variable's slot, built from `ContractType::linearizedStateVariables` (shielded/mixed vars excluded, so cstore stays allowed where it's correct).
- Runtime-computed slots (`cstore(keccak256(...), v)`) remain unclassifiable and out of scope.

10314 is a best-effort footgun guard, not a security boundary (the runtime EVM enforces domain claims regardless).

## Test plan

- [x] New `syntaxTests/inlineAssembly/cstore_on_public_slot_spellings.sol`: `cload(pub.slot)` allowed; `cstore(0,1)` and `cstore(s,1)` (copied var) both error 10314; `cstore(secret.slot,1)` (shielded) stays allowed.
- [x] P25 test `cstore_on_public_state_var.sol` updated — the `cload(x.slot)` 10314 expectation dropped (now allowed); the cstore case still errors.
- [x] Full `syntaxTests/*` suite green (4070).
- [x] Verified the at-risk semantic tests don't spuriously error: `cstore(0,...)` on shielded-array slots (`delete_shielded_storage_array`, `shielded_delete_saddress_storage_array`) and `cstore(add(0,0),...)` (not a bare literal) are unaffected. Scoped semantic sweeps green: array (274), inlineAssembly (88), optimizer (6).