### PR TITLE
fix(typechecker): recurse msg.value check only through type conversions

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -5026,13 +5026,14 @@ void TypeChecker::checkMsgValueToShielded(
 		}
 	}
 
-	// Recurse into type conversion arguments: suint256(msg.value)
+	// Recurse only through type conversions (suint256(msg.value)). Arguments of a real call are
+	// the callee's parameters, checked at the call site — recursing into them here would double
+	// the warning and mis-attribute the callee's argument to this target.
 	if (auto funcCall = dynamic_cast<FunctionCall const*>(&_expression))
-	{
-		for (auto const& arg : funcCall->arguments())
-			if (arg)
-				checkMsgValueToShielded(*arg, _targetType);
-	}
+		if (funcCall->annotation().kind.set() && *funcCall->annotation().kind == FunctionCallKind::TypeConversion)
+			for (auto const& arg : funcCall->arguments())
+				if (arg)
+					checkMsgValueToShielded(*arg, _targetType);
 }
 
 void TypeChecker::checkShieldedLeakInPublicSink(Expression const& _expression)

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_msg_value_warning_nested_call.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_msg_value_warning_nested_call.sol
@@ -1,0 +1,22 @@
+contract C {
+    suint256 s;
+    suint256 a;
+
+    function f(suint256 x) internal pure returns (suint256) { return x; }
+
+    // msg.value nested in a real call into a shielded target must warn exactly once
+    // (the argument check owns it), not twice.
+    function nestedAssign() external payable {
+        s = f(suint256(msg.value));
+    }
+    function nestedReturn() internal returns (suint256) {
+        return f(suint256(msg.value));
+    }
+    function nestedTuple() external payable {
+        (s, a) = (f(suint256(msg.value)), a);
+    }
+}
+// ----
+// Warning 10306: (324-333): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.
+// Warning 10306: (427-436): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.
+// Warning 10306: (521-530): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.


### PR DESCRIPTION
Fixes #342.

## Summary

Post-merge manual review of the B-series follow-ups surfaced a duplicate-warning regression introduced by B3 (#337). `checkMsgValueToShielded` recursed into **every** nested `FunctionCall`'s arguments (to see through conversions like `suint256(msg.value)`). Once B3 added the argument-compatibility check, `msg.value` nested in a *real* call into a shielded target warned twice at the same location:

```solidity
s = f(suint256(msg.value));                 // 2x 10306 (same loc) -> now 1
return f(suint256(msg.value));              // 2x -> 1
(s, a) = (f(suint256(msg.value)), a);       // 2x -> 1
```

The duplicate also reflected a mis-attribution (the assignment path blaming its target for the callee's argument).

Severity low — the warning is warranted (no false positive/negative on whether to warn, no codegen/soundness impact, suppressible) — but it is diagnostic noise.

## Fix

Gate the helper's recursion on `FunctionCallKind::TypeConversion`. The helper now owns only conversions; the argument-compatibility loop owns real-call arguments. Each `msg.value`/`msg.data` warns exactly once, and the mis-attribution is gone.

## Test plan

- [x] New `syntaxTests/shieldedTypes/shielded_msg_value_warning_nested_call.sol`: nested-call assign/return/tuple now warn exactly once (were twice).
- [x] B3's `shielded_msg_value_warning_all_paths.sol` still green — compound/tuple/return/arg/simple each warn once.
- [x] Full `syntaxTests/*` suite green. Warning-only change; no codegen impact.