### PR TITLE
B2 follow-up: fix ICE on 'layout at' contract with inline assembly

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1173,11 +1173,19 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 	// Storage slots occupied by a fully non-shielded state variable. Used to flag cstore on a
 	// public slot referenced by a bare literal (cstore(0, v)). Mixed/shielded vars are excluded
 	// so we never flag a slot where cstore could be legitimate.
+	//
+	// A `contract ... layout at N` base is evaluated after type checking, so computing the slot
+	// map here would dereference an unset SetOnce. Skip the literal-slot map for such a contract
+	// until its base is resolved; the .slot and copied-local checks below need no slot map.
 	std::set<u256> publicSlots;
 	if (m_currentContract)
-		for (auto const& [var, slot, byteOffset]: ContractType(*m_currentContract).linearizedStateVariables(DataLocation::Storage))
-			if (var->annotation().type && !var->annotation().type->isShielded() && !var->annotation().type->containsShieldedType())
-				publicSlots.insert(slot);
+	{
+		auto const* layoutSpecifier = m_currentContract->storageLayoutSpecifier();
+		if (!layoutSpecifier || layoutSpecifier->annotation().baseSlot.set())
+			for (auto const& [var, slot, byteOffset]: ContractType(*m_currentContract).linearizedStateVariables(DataLocation::Storage))
+				if (var->annotation().type && !var->annotation().type->isShielded() && !var->annotation().type->containsShieldedType())
+					publicSlots.insert(slot);
+	}
 
 	// yul locals that currently alias a non-shielded state variable's .slot (let s := pub.slot),
 	// so cstore(s, v) is flagged too. Reassigning the local to anything else clears the alias.

--- a/test/libsolidity/syntaxTests/inlineAssembly/storage_layout_specifier_with_inline_asm.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/storage_layout_specifier_with_inline_asm.sol
@@ -1,0 +1,12 @@
+// A `layout at N` contract with inline assembly must not crash the shielded-storage-op check
+// (its layout base is evaluated after type checking, so the slot map is not yet available).
+// The literal-slot cstore guard is skipped for such a contract; the direct .slot check still works.
+contract C layout at 42 {
+    uint256 public x;
+    suint256 secret;
+    function okSstore() public { assembly { sstore(x.slot, 16) } }
+    function okCstoreShielded() public { assembly { cstore(secret.slot, 1) } }
+    function badCstorePublic() public { assembly { cstore(x.slot, 1) } }
+}
+// ----
+// TypeError 10314: (554-571): Cannot use cstore() on non-shielded storage variable. Use sstore() instead.


### PR DESCRIPTION
Fixes #344

## Problem

B2 (#341) added bare-literal `cstore` detection to `validateShieldedStorageOps`, which builds a storage slot map via `linearizedStateVariables(DataLocation::Storage)` for every inline-assembly block. For a `contract C layout at N`, that path dereferences the layout-base `SetOnce<u256>` in `layoutBaseForInheritanceHierarchy` (`ASTUtils.cpp:134`). That value is only populated *after* type checking, while `validateShieldedStorageOps` runs *during* it — so any `layout at` contract using inline assembly crashed with `BadSetOnceAccess`, including plain non-shielded contracts.

## Fix

Build the literal-slot map only when the contract has no storage-layout specifier, or its base slot is already resolved. The bare-literal cstore detection is skipped for unresolved-layout contracts (best-effort); the direct `.slot` and copied-local checks need no slot map and keep working.

## Tests

- New syntax test `storage_layout_specifier_with_inline_asm.sol`: a `layout at 42` contract with inline asm now compiles, and a direct `cstore(x.slot)` on a public var is still flagged (10314).
- Full syntax suite green (4070).
- Full semantic sweep green on both pipelines (legacy + via-IR, 1921/1921).
- B2's normal-contract bare-literal detection unaffected.