### PR TITLE
P3: convert sbytes length to slot count in convertLengthToSize

### DIFF
--- a/libsolidity/codegen/ArrayUtils.cpp
+++ b/libsolidity/codegen/ArrayUtils.cpp
@@ -1017,7 +1017,13 @@ void ArrayUtils::convertLengthToSize(ArrayType const& _arrayType, bool _pad) con
 {
 	if (_arrayType.location() == DataLocation::Storage)
 	{
-		if (_arrayType.baseType()->storageSize() <= 1)
+		if (_arrayType.isByteArrayOrString())
+			// Byte/string arrays pack 32 bytes per slot, including shielded sbytes whose
+			// element reports a full-slot storageBytes(). Slot count = ceil(len / 32).
+			m_context
+				<< u256(31) << Instruction::ADD
+				<< u256(32) << Instruction::SWAP1 << Instruction::DIV;
+		else if (_arrayType.baseType()->storageSize() <= 1)
 		{
 			unsigned baseBytes = _arrayType.baseType()->storageBytes();
 			if (baseBytes == 0)

--- a/test/libsolidity/semanticTests/types/sbytes_dynamic_delete_slot_count.sol
+++ b/test/libsolidity/semanticTests/types/sbytes_dynamic_delete_slot_count.sol
@@ -1,0 +1,42 @@
+// delete on a dynamic sbytes must clear only ceil(len/32) data slots, like a plain
+// bytes array (sbytes packs 32 bytes per confidential slot). The legacy clear loop
+// derived no element->slot count for the shielded byte element (storageBytes() == 32
+// falls through every branch of ArrayUtils::convertLengthToSize), so it iterated once
+// per byte and cstore-claimed ~32x as many slots as the array occupies. Every slot
+// past the array then becomes confidential, and a later public sstore to it reverts.
+//
+// `data` lives at slot 0; its long-array payload starts at keccak256(bytes32(0)):
+//   keccak256(bytes32(0))      = 18569430475105882587588266137607568536673111973893317399460219858819262702947
+//   keccak256(bytes32(0)) + 32 = 18569430475105882587588266137607568536673111973893317399460219858819262702979
+// 64 bytes occupy 2 data slots (offsets 0 and 1); offset 32 is well past the array.
+// publicWritable() probes whether a slot is still public by attempting a public sstore
+// through an external call and catching the cross-domain revert.
+contract C {
+    sbytes data;
+
+    function setup() external {
+        for (uint256 i = 0; i < 64; i++)
+            data.push(sbytes1(0xAB));
+    }
+
+    function del() external {
+        delete data;
+    }
+
+    function publicWritable(uint256 slot) external returns (bool) {
+        try this.pubWrite(slot) {
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    function pubWrite(uint256 slot) external {
+        assembly { sstore(slot, 1) }
+    }
+}
+// ----
+// setup() ->
+// del() ->
+// publicWritable(uint256): 18569430475105882587588266137607568536673111973893317399460219858819262702947 -> false
+// publicWritable(uint256): 18569430475105882587588266137607568536673111973893317399460219858819262702979 -> true


### PR DESCRIPTION
Fixes #348

## Problem

`ArrayUtils::convertLengthToSize` (legacy codegen) derives a storage array's slot count by dispatching on the element's `storageBytes()`. A shielded byte element reports a full slot (32), so it matches neither the `<= 16` pack branch nor the `storageSize() > 1` multiply, and emits nothing — the byte length is consumed by `clearStorageLoop` as if it were a slot count. `delete` on a dynamic `sbytes` (and assignment-shrink) then iterates one `CSTORE` per byte instead of per 32-byte slot, ~32x the work: large arrays exhaust gas, and the extra `CSTORE`s claim slots past the array as confidential.

## Fix

Handle byte/string arrays explicitly in the storage branch: they pack 32 bytes per slot regardless of element slot width, so slot count = `ceil(len / 32)`. The emitted opcodes are identical to the prior path for plain `bytes`/`string` (element `storageBytes()==1`); only `sbytes` changes. The via-IR path already used `div32Ceil` and was unaffected.

## Test

New semantic test `sbytes_dynamic_delete_slot_count.sol`: after `delete` on a 64-byte `sbytes`, a slot past the array's 2 data slots must stay public (probed via a public `sstore` through an external call, catching the cross-domain revert). A control probe on a real data slot confirms the mechanism detects confidential slots. Fails on legacy pre-fix, passes on via-IR pre-fix.

## Verification

- Target test green on all 4 configs (legacy +/- opt, via-IR +/- opt).
- Full semantic sweeps green: legacy 1921/1921, via-IR 1921/1921 — no regression in normal bytes/string/array handling.