### PR TITLE
P2: keep cross-domain storage conflicts on literal slots in UnusedStoreEliminator

### DIFF
--- a/libyul/optimiser/UnusedStoreEliminator.cpp
+++ b/libyul/optimiser/UnusedStoreEliminator.cpp
@@ -137,6 +137,7 @@ void UnusedStoreEliminator::visit(Statement const& _statement)
 {
 	using evmasm::Instruction;
 
+	m_currentStatementHasDomainConflict = false;
 	UnusedStoreBase::visit(_statement);
 
 	auto const* exprStatement = std::get_if<ExpressionStatement>(&_statement);
@@ -211,6 +212,10 @@ void UnusedStoreEliminator::visit(Statement const& _statement)
 			activeMemoryStores().insert(&_statement);
 		}
 		m_storeOperations[&_statement] = std::move(operations.front());
+		// A store that itself triggers a cross-domain revert must be kept: its revert is
+		// observable, so it cannot be eliminated as dead-before-revert.
+		if (m_currentStatementHasDomainConflict)
+			m_usedStores.insert(&_statement);
 	}
 }
 
@@ -235,9 +240,9 @@ std::vector<UnusedStoreEliminator::Operation> UnusedStoreEliminator::operationsF
 		std::vector<Operation> result;
 		// Unknown read is worse than unknown write.
 		if (sideEffects.memory != SideEffects::Effect::None)
-			result.emplace_back(Operation{Location::Memory, Effect::Read, {}, {}, false});
+			result.emplace_back(Operation{Location::Memory, Effect::Read, {}, {}, {}, false});
 		if (sideEffects.storage != SideEffects::Effect::None)
-			result.emplace_back(Operation{Location::Storage, Effect::Read, {}, {}, false});
+			result.emplace_back(Operation{Location::Storage, Effect::Read, {}, {}, {}, false});
 		return result;
 	}
 
@@ -249,9 +254,13 @@ std::vector<UnusedStoreEliminator::Operation> UnusedStoreEliminator::operationsF
 		{
 			yulAssert(!(_op.lengthParameter && _op.lengthConstant));
 			yulAssert(_op.effect != Effect::None);
-			Operation ourOp{_op.location, _op.effect, {}, {}, false};
+			Operation ourOp{_op.location, _op.effect, {}, {}, {}, false};
 			if (_op.startParameter)
-				ourOp.start = identifierNameIfSSA(_functionCall.arguments.at(*_op.startParameter));
+			{
+				Expression const& startArg = _functionCall.arguments.at(*_op.startParameter);
+				ourOp.start = identifierNameIfSSA(startArg);
+				ourOp.startValue = m_knowledgeBase.valueIfKnownConstant(startArg);
+			}
 			if (_op.lengthParameter)
 				ourOp.length = identifierNameIfSSA(_functionCall.arguments.at(*_op.lengthParameter));
 			if (_op.lengthConstant)
@@ -292,8 +301,11 @@ void UnusedStoreEliminator::applyOperation(UnusedStoreEliminator::Operation cons
 			it = active.erase(it);
 		else if (_operation.effect == Effect::Write && hasStorageDomainConflict(storeOperation, _operation))
 		{
-			// Storage domain conflict: mark the first store as used since the second will cause runtime error.
+			// Storage domain conflict: the incoming write reverts at runtime against the slot
+			// the prior store claimed for the other domain. Keep the prior store, and flag the
+			// incoming one so visit() keeps it too (it is the op that actually reverts).
 			m_usedStores.insert(statement);
+			m_currentStatementHasDomainConflict = true;
 			it = active.erase(it);
 		}
 		else
@@ -325,10 +337,8 @@ bool UnusedStoreEliminator::knownUnrelated(
 		{
 			bool op2ReadsBothDomains =
 				(_op2.effect == Effect::Read && _op2.isShieldedStorage) ||
-				!_op2.start;
-			bool sameSlotCrossDomain =
-				_op1.start && _op2.start &&
-				!m_knowledgeBase.knownToBeDifferent(*_op1.start, *_op2.start);
+				(!_op2.start && !_op2.startValue);
+			bool sameSlotCrossDomain = !knownToBeDifferentStorageSlots(_op1, _op2);
 			if (!op2ReadsBothDomains && !sameSlotCrossDomain)
 				return true;
 		}
@@ -459,6 +469,21 @@ bool UnusedStoreEliminator::knownCovered(
 /// @param _op1 First operation to check
 /// @param _op2 Second operation to check
 /// @return true if the operations target the same slot in different storage domains
+bool UnusedStoreEliminator::knownToBeDifferentStorageSlots(
+	UnusedStoreEliminator::Operation const& _op1,
+	UnusedStoreEliminator::Operation const& _op2
+) const
+{
+	// Prefer known constant slot values; this is the only handle for literal operands,
+	// whose `start` (an SSA name) is empty.
+	if (_op1.startValue && _op2.startValue)
+		return *_op1.startValue != *_op2.startValue;
+	if (_op1.start && _op2.start)
+		return m_knowledgeBase.knownToBeDifferent(*_op1.start, *_op2.start);
+	// Cannot prove the slots differ; treat them as possibly the same.
+	return false;
+}
+
 bool UnusedStoreEliminator::hasStorageDomainConflict(
 	UnusedStoreEliminator::Operation const& _op1,
 	UnusedStoreEliminator::Operation const& _op2
@@ -472,11 +497,11 @@ bool UnusedStoreEliminator::hasStorageDomainConflict(
 	if (_op1.isShieldedStorage == _op2.isShieldedStorage)
 		return false;
 
-	// Check if they target the same slot (or we can't prove they're different)
-	if (!_op1.start || !_op2.start)
-		return false;
-
-	return !m_knowledgeBase.knownToBeDifferent(*_op1.start, *_op2.start);
+	// Conflict unless we can prove the two slots are different. Literal slots
+	// (e.g. cstore(0, ...) / sstore(0, ...)) are compared by value here; previously
+	// their empty `start` short-circuited to "no conflict" and the reverting store
+	// was eliminated.
+	return !knownToBeDifferentStorageSlots(_op1, _op2);
 }
 
 void UnusedStoreEliminator::markActiveAsUsed(

--- a/libyul/optimiser/UnusedStoreEliminator.h
+++ b/libyul/optimiser/UnusedStoreEliminator.h
@@ -85,6 +85,9 @@ public:
 		Effect effect;
 		/// Start of affected area. Unknown if not provided.
 		std::optional<YulName> start;
+		/// Constant value of the start operand, if known (covers literal operands,
+		/// for which `start` is empty). Used to compare storage slots across domains.
+		std::optional<u256> startValue;
 		/// Length of affected area, unknown if not provided.
 		/// Unused for storage.
 		std::optional<OperationLength> length;
@@ -118,6 +121,10 @@ private:
 	void applyOperation(Operation const& _operation);
 	bool knownUnrelated(Operation const& _op1, Operation const& _op2) const;
 	bool knownCovered(Operation const& _covered, Operation const& _covering) const;
+	/// Returns true if two storage operations are provably on different slots, comparing
+	/// known constant slot values (incl. literals) or, failing that, SSA slot identifiers.
+	/// When neither can prove a difference, returns false (slots may coincide).
+	bool knownToBeDifferentStorageSlots(Operation const& _op1, Operation const& _op2) const;
 	/// Returns true if two operations target the same storage slot but different domains (public vs shielded).
 	/// This will cause a runtime error, so both operations must be preserved.
 	bool hasStorageDomainConflict(Operation const& _op1, Operation const& _op2) const;
@@ -133,6 +140,10 @@ private:
 	std::map<YulName, AssignedValue> const& m_ssaValues;
 
 	std::map<Statement const*, Operation> m_storeOperations;
+
+	/// Set while visiting a store statement if it has a cross-domain conflict with an
+	/// active store; the incoming store then itself reverts at runtime and must be kept.
+	bool m_currentStatementHasDomainConflict = false;
 
 	KnowledgeBase mutable m_knowledgeBase;
 };

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/cstore_sstore_crossdomain_literal.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/cstore_sstore_crossdomain_literal.yul
@@ -1,0 +1,22 @@
+{
+    // cstore claims slot 0 confidential; the sstore to the same slot reverts at runtime
+    // (cross-domain). Both must be kept even though they precede an explicit revert, so the
+    // runtime revert fires. Slot operands are literals (Operation.start is empty for them).
+    cstore(0, 1)
+    sstore(0, 2)
+    mstore(0, 0x1234)
+    revert(0, 32)
+}
+// ====
+// EVMVersion: >=mercury
+// ----
+// step: unusedStoreEliminator
+//
+// {
+//     {
+//         cstore(0, 1)
+//         sstore(0, 2)
+//         mstore(0, 0x1234)
+//         revert(0, 32)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/cstore_sstore_different_literal_slots.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/cstore_sstore_different_literal_slots.yul
@@ -1,0 +1,23 @@
+{
+    // Different literal slots: no cross-domain conflict, so both stores are dead before the
+    // revert (which rolls back storage) and may be eliminated.
+    cstore(0, 1)
+    sstore(1, 2)
+    mstore(0, 0x1234)
+    revert(0, 32)
+}
+// ====
+// EVMVersion: >=mercury
+// ----
+// step: unusedStoreEliminator
+//
+// {
+//     {
+//         let _1 := 1
+//         let _2 := 0
+//         let _3 := 2
+//         let _4 := 1
+//         mstore(0, 0x1234)
+//         revert(0, 32)
+//     }
+// }


### PR DESCRIPTION
Fixes #350

## Problem

`cstore(0,1)` claims slot 0 confidential; the following `sstore(0,2)` is a public write to a private slot and reverts at runtime (cross-domain). The optimizer must keep both ops so the revert fires. But `hasStorageDomainConflict` compared slots only via `Operation.start` (an SSA name), which is empty for literal operands, so any `cstore(N,..)`/`sstore(N,..)` pair with literal slots short-circuited to "no conflict". Under `--optimize` the `sstore` was eliminated as dead-before-revert; control then reached a later explicit `revert`, changing observable returndata.

## Fix

- Capture the slot's known constant value (`Operation.startValue`), covering literal operands; compare slots by value, falling back to the SSA knowledge base. A pair conflicts unless provably on different slots, so `cstore(0)`/`sstore(1)` is still freely eliminated.
- Keep the incoming reverting store live, not just the prior store (it is the op that actually reverts).
- Apply the same slot comparison to the read-side `sameSlotCrossDomain` check.

## Tests

New `unusedStoreEliminator/` Yul tests: positive (`cstore(0,1)`/`sstore(0,2)` — both kept; fails pre-fix) and negative control (`cstore(0,1)`/`sstore(1,2)` — different slots, both eliminated).

## Verification

- Test-first confirmed: positive test drops the sstore pre-fix, passes post-fix.
- PoC bytecode: both ops preserved under `--optimize` and `:S`; different-slot control still eliminated.
- Full `unusedStoreEliminator` suite (59) and full Yul optimizer suite (639/650, no failures) green.
- Full semantic sweeps green on both optimize configs: legacy+opt 1920/1920, via-IR+opt 1920/1920.