### PR TITLE
P5: propagate shielded marker through exponentiation result

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -763,6 +763,11 @@ TypeResult IntegerType::binaryOperatorResult(Token _operator, Type const* _other
 		{
 			if (otherIntType->isSigned())
 				return TypeResult::err("Exponentiation power is not allowed to be a signed shielded integer type.");
+			// Shielded exponent -> shielded result, preserving the base's width/signedness.
+			return TypeProvider::shieldedInteger(
+				numBits(),
+				isSigned() ? ShieldedIntegerType::Modifier::Signed : ShieldedIntegerType::Modifier::Unsigned
+			);
 		}
 		else if (auto otherIntType = dynamic_cast<IntegerType const*>(_other))
 		{

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_exp_public_base_shielded_exponent.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_exp_public_base_shielded_exponent.sol
@@ -1,0 +1,14 @@
+// A public integer base raised to a shielded exponent must be a shielded result, so it
+// cannot cross a public ABI boundary. Previously IntegerType::binaryOperatorResult dropped
+// the shielded marker on the Exp branch (returned the public base type), letting the
+// exponent be returned through a public function and recovered in invertible ranges.
+contract C {
+    suint8 private secretExponent;
+
+    function leak(uint256 base) external view returns (uint256) {
+        return base ** secretExponent;
+    }
+}
+// ----
+// Warning 10304: (482-504): Shielded integer exponentiation will leak the exponent value through gas cost.
+// TypeError 6359: (482-504): Return argument type suint256 is not implicitly convertible to expected type (type of first return variable) uint256.


### PR DESCRIPTION
Fixes #352

## Problem

`IntegerType::binaryOperatorResult` returned the public base type for the `**` (Exp) branch even when the exponent was a shielded unsigned integer. So `base ** secret` (variable `base: uint256`, `secret: suintN`) was typed `uint256` and could be returned from a public `view` function, recovering the exponent in invertible ranges (e.g. `2 ** suint8`). The literal-base path (`RationalNumberType`) already propagated, so `2 ** secret` was rejected but `base ** secret` was not.

## Fix

When the exponent is an unsigned shielded integer, return the shielded counterpart of the base's width/signedness. When the base is already shielded this yields the canonical same type, so existing shielded-base behavior is unchanged. The shielded result is then blocked at the public return (10102 / 6359) but remains usable internally and assignable to shielded variables.

## Tests

New syntax test `shielded_exp_public_base_shielded_exponent.sol`: `uint256 base ** suint8` returned publicly now emits 10304 + the conversion error (6359). Fails pre-fix (compiles clean).

## Verification

- Full syntax suite green (3999, 0 failures); the 60 shielded `nameAndTypeResolution` tests unchanged (shielded-base cases intact).
- Full semantic sweeps green: legacy 1920/1920, via-IR 1920/1920.
- Confirmed the shielded result still compiles when assigned to a shielded state var or returned from an `internal` function.