### PR TITLE
P4: reject shielded types in external function type signatures

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -893,6 +893,13 @@ void TypeChecker::endVisit(FunctionTypeName const& _funType)
 			solAssert(t->annotation().type, "Type not set for parameter.");
 			if (!t->annotation().type->interfaceType(false).get())
 				m_errorReporter.fatalTypeError(2582_error, t->location(), "Internal type cannot be used for external function type.");
+			if (t->annotation().type->containsShieldedType())
+				m_errorReporter.typeError(
+					10111_error,
+					t->location(),
+					"Shielded types cannot appear in the parameters or return values of an external function type. "
+					"The ABI encodes a function value as (address, selector) only and cannot enforce the shielded boundary across it."
+				);
 		}
 		solAssert(fun.interfaceType(false), "External function type uses internal types.");
 	}

--- a/test/libsolidity/syntaxTests/parsing/shielded_address_payable_function_type.sol
+++ b/test/libsolidity/syntaxTests/parsing/shielded_address_payable_function_type.sol
@@ -5,4 +5,6 @@ contract C {
     }
 }
 // ----
-// Warning 6321: (199-270): Unnamed return variable can remain unassigned. Add an explicit return with value to all non-reverting code paths or name the variable.
+// TypeError 10111: (113-129): Shielded types cannot appear in the parameters or return values of an external function type. The ABI encodes a function value as (address, selector) only and cannot enforce the shielded boundary across it.
+// TypeError 10111: (209-225): Shielded types cannot appear in the parameters or return values of an external function type. The ABI encodes a function value as (address, selector) only and cannot enforce the shielded boundary across it.
+// TypeError 10111: (291-307): Shielded types cannot appear in the parameters or return values of an external function type. The ABI encodes a function value as (address, selector) only and cannot enforce the shielded boundary across it.

--- a/test/libsolidity/syntaxTests/shieldedTypes/external_function_type_shielded_return.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/external_function_type_shielded_return.sol
@@ -1,0 +1,19 @@
+// An external function type cannot carry shielded types in its parameter or return list.
+// The ABI encodes a function value as (address, selector) only, so the shielded boundary
+// cannot be enforced across it: ordinary returndata could be decoded as a shielded value
+// and cstored, or a shielded value passed out as a public callback argument.
+contract C {
+    sbool private opened;
+
+    function open(function() external returns (sbool) policy) external {
+        opened = policy();
+    }
+
+    function takesShieldedArg(function(suint256) external cb) external {}
+
+    function() external returns (saddress) stored;
+}
+// ----
+// TypeError 10111: (435-440): Shielded types cannot appear in the parameters or return values of an external function type. The ABI encodes a function value as (address, selector) only and cannot enforce the shielded boundary across it.
+// TypeError 10111: (534-542): Shielded types cannot appear in the parameters or return values of an external function type. The ABI encodes a function value as (address, selector) only and cannot enforce the shielded boundary across it.
+// TypeError 10111: (603-611): Shielded types cannot appear in the parameters or return values of an external function type. The ABI encodes a function value as (address, selector) only and cannot enforce the shielded boundary across it.


### PR DESCRIPTION
Fixes #354

## Problem

`FunctionType::interfaceType()` returns the external function type itself without recursing into its parameter/return lists, and the shielded value types return themselves from `interfaceType()`. So `function() external returns (sbool)` / `(suint256)` / `(saddress)` passed the public ABI boundary check. Downstream codegen decoded ordinary external returndata as the shielded type and `cstore`d it (an unauditable public-to-shielded conversion), or passed a shielded value out as a public callback argument. The ABI cannot enforce this boundary — a function value only encodes `(address, selector)`.

## Fix

Reject shielded types in the parameter/return lists of external function types in `endVisit(FunctionTypeName)` (new error 10111). That node is visited for every syntactic function type (parameter, return, state variable, nested), so all occurrences are caught. The check keys on `containsShieldedType()` at the analysis layer only, leaving codegen's CSTORE/SSTORE decision for function-pointer values unchanged.

## Scope / non-regression

- Internal function types are untouched (gated on `External`); they never cross the ABI, so `function(suint256) internal` still compiles.
- External function types without shielded types still compile.
- A function-pointer state variable's stored bytes (the public `(address, selector)`) are unaffected.

## Tests

- New `shieldedTypes/external_function_type_shielded_return.sol`: shielded return / shielded param / shielded-return state var all rejected (10111).
- Updated existing `parsing/shielded_address_payable_function_type.sol`: its external function types using `saddress payable` now correctly report 10111 (the internal one is left alone).

## Verification

- Full syntax suite green (3999, 0 failures).
- Full semantic sweeps green: legacy 1920/1920, via-IR 1920/1920.