### PR TITLE
3.10: reject sbytes as a mapping key

### DIFF
--- a/libsolidity/analysis/DeclarationTypeChecker.cpp
+++ b/libsolidity/analysis/DeclarationTypeChecker.cpp
@@ -282,8 +282,8 @@ void DeclarationTypeChecker::endVisit(Mapping const& _mapping)
 	Type const* keyType = _mapping.keyType().annotation().type;
 	ASTString keyName = _mapping.keyName();
 
-	// Reject shielded types as mapping keys
-	if (keyType->isShielded())
+	// containsShieldedType also covers sbytes, whose ArrayType::isShielded() is false.
+	if (keyType->isShielded() || keyType->containsShieldedType())
 	{
 		m_errorReporter.fatalTypeError(
 			10109_error,

--- a/test/libsolidity/syntaxTests/shieldedTypes/mapping_sbytes_key_rejected.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/mapping_sbytes_key_rejected.sol
@@ -1,0 +1,6 @@
+// sbytes as a mapping key must be rejected (key would be hashed in plaintext for slot derivation).
+contract C {
+    mapping(sbytes => uint256) m;
+}
+// ----
+// TypeError 10109: (125-131): Shielded types are not allowed as mapping keys.


### PR DESCRIPTION
Fixes #358

`mapping(sbytes => ...)` compiled without 10109 because `ArrayType::isShielded()` is false for sbytes, so the confidential key was hashed in plaintext for slot derivation. Guard now uses `isShielded() || containsShieldedType()` (matching the sibling shielded-variable guard).

Test: `mapping_sbytes_key_rejected.sol` (10109). Syntax suite 3999/0-fail; semantic sweeps legacy 1920 / via-IR 1920.