### PR TITLE
3.19: give duplicated diagnostic IDs (10002, 10312) unique codes

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2383,7 +2383,7 @@ void TypeChecker::endVisit(BinaryOperation const& _operation)
 		commonType->category() != Type::Category::ShieldedInteger
 	)
 		m_errorReporter.warning(
-			10312_error,
+			10315_error,
 			_operation.location(),
 			"Shielded integer shift count can leak through the public shift result."
 		);

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -853,7 +853,7 @@ bool AsmAnalyzer::validateInstructions(evmasm::Instruction _instr, SourceLocatio
 	else if ((_instr == evmasm::Instruction::TSTORE || _instr == evmasm::Instruction::TLOAD) && !m_evmVersion.supportsTransientStorage())
 		errorForVM(6243_error, "only available for Cancun-compatible");
 	else if ((_instr == evmasm::Instruction::CLOAD || _instr == evmasm::Instruction::CSTORE || _instr == evmasm::Instruction::TIMESTAMPMS) && !m_evmVersion.supportShieldedStorage())
-		errorForVM(10002_error, "only available for Mercury-compatible");
+		errorForVM(10005_error, "only available for Mercury-compatible");
 	else if (_instr == evmasm::Instruction::PC)
 		m_errorReporter.error(
 			2450_error,

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_shift_leak.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_shift_leak.sol
@@ -10,6 +10,6 @@ contract C {
 }
 // ----
 // Warning 10312: (89-101): Shielded integer shift count can leak through the public shift result.
-// Warning 10312: (115-126): Shielded integer shift count can leak through the public shift result.
+// Warning 10315: (115-126): Shielded integer shift count can leak through the public shift result.
 // Warning 10312: (136-148): Shielded integer shift count can leak through the public shift result.
-// Warning 10312: (162-173): Shielded integer shift count can leak through the public shift result.
+// Warning 10315: (162-173): Shielded integer shift count can leak through the public shift result.

--- a/test/libsolidity/syntaxTests/types/magic_block_timestamp_ms_error.sol
+++ b/test/libsolidity/syntaxTests/types/magic_block_timestamp_ms_error.sol
@@ -12,5 +12,5 @@ contract C {
 // EVMVersion: =cancun
 // ----
 // TypeError 10004: (74-92): "timestamp_ms" is not supported by the VM version.
-// TypeError 10002: (188-199): The "timestampms" instruction is only available for Mercury-compatible VMs (you are currently compiling for "cancun").
+// TypeError 10005: (188-199): The "timestampms" instruction is only available for Mercury-compatible VMs (you are currently compiling for "cancun").
 // DeclarationError 8678: (181-201): Variable count for assignment to "ret" does not match number of values (1 vs. 0)

--- a/test/libsolidity/syntaxTests/types/version_test_mercury_instructions.sol
+++ b/test/libsolidity/syntaxTests/types/version_test_mercury_instructions.sol
@@ -10,4 +10,4 @@ contract C {
 // ====
 // EVMVersion: <mercury
 // ----
-// TypeError 10002: (103-109): The "cstore" instruction is only available for Mercury-compatible VMs (you are currently compiling for "cancun").
+// TypeError 10005: (103-109): The "cstore" instruction is only available for Mercury-compatible VMs (you are currently compiling for "cancun").

--- a/test/libyul/yulSyntaxTests/timestampms_evm_version.yul
+++ b/test/libyul/yulSyntaxTests/timestampms_evm_version.yul
@@ -4,4 +4,4 @@
 // ====
 // EVMVersion: <mercury
 // ----
-// TypeError 10002: (15-26): The "timestampms" instruction is only available for Mercury-compatible VMs (you are currently compiling for "cancun").
+// TypeError 10005: (15-26): The "timestampms" instruction is only available for Mercury-compatible VMs (you are currently compiling for "cancun").


### PR DESCRIPTION
Fixes #360

10002 (shielded-type-keyword vs asm-opcode Mercury errors) and 10312 (compound vs binary shift-leak) were each used at two sites. Reassigned the asm-opcode site to 10005 and the binary-shift site to 10315; kept the others. `error_codes.py --check` exits 0. Syntax suite 3998/0-fail, yul tests 0-fail. Pure diagnostic renumbering — no codegen/control-flow change, so semantic outcomes are unaffected.