### PR TITLE
3.8: guard shielded-push check so fixed-size array .push doesn't crash

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3673,7 +3673,7 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 				"after argument-dependent lookup in " + exprType->humanReadableName() + ".";
 
 			if (auto const* arrayType = dynamic_cast<ArrayType const*>(exprType)) {
-				if (memberName == "push") {
+				if (memberName == "push" && annotation.arguments.has_value() && !annotation.arguments.value().types.empty()) {
 					if (arrayType->containsShieldedType() && !annotation.arguments.value().types.front()->isShielded()) {
 						return { 10205_error, "Cannot push a non-shielded type to a shielded array" };
 					}

--- a/test/libsolidity/syntaxTests/shieldedTypes/fixed_array_push_bare_no_crash.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/fixed_array_push_bare_no_crash.sol
@@ -1,0 +1,6 @@
+contract C {
+    uint[3] arr;
+    function f() external { arr.push; }
+}
+// ----
+// TypeError 9582: (58-66): Member "push" not found or not visible after argument-dependent lookup in uint256[3] storage ref.

--- a/test/libsolidity/syntaxTests/shieldedTypes/fixed_array_push_no_crash.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/fixed_array_push_no_crash.sol
@@ -1,0 +1,6 @@
+contract C {
+    uint[3] arr;
+    function f() external { arr.push(); }
+}
+// ----
+// TypeError 9582: (58-66): Member "push" not found or not visible after argument-dependent lookup in uint256[3] storage ref.


### PR DESCRIPTION
Fixes #362

The push-member block in `visit(MemberAccess)` dereferenced `annotation.arguments` (and its `types` vector) unguarded, crashing on any fixed-size array `.push` (SIGSEGV for `arr.push()`, `bad_optional_access` for bare `arr.push`). Guard on `has_value() && !types.empty()` -> falls through to the generic 9582. The 10205/10206 dynamic-array push-mismatch checks are unchanged (confirmed still firing).

Tests: `fixed_array_push_no_crash.sol`, `fixed_array_push_bare_no_crash.sol`. Syntax 3980/0-fail; semantic sweeps legacy + via-IR all-pass.