### PR TITLE
3.7: fix compiler crash on non-bool condition (double-visit in expectBoolOrShieldedBool)

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -4935,7 +4935,6 @@ bool TypeChecker::expectBoolOrShieldedBool(Expression const& _expression) {
 	Type const* condType = type(_expression);
 	if (condType->category() == Type::Category::Bool || condType->category() == Type::Category::ShieldedBool)
 	{
-		// Warn about information leakage when shielded types are used in branching conditions
 		if (condType->category() == Type::Category::ShieldedBool)
 			m_errorReporter.warning(
 				10311_error,
@@ -4945,8 +4944,48 @@ bool TypeChecker::expectBoolOrShieldedBool(Expression const& _expression) {
 			);
 		return true;
 	}
-	else
-		return expectType(_expression, *TypeProvider::boolean());
+	// expectType would accept() a second time (SetOnce reassign -> crash); inline its check.
+	Type const& expectedType = *TypeProvider::boolean();
+	BoolResult result = condType->isImplicitlyConvertibleTo(expectedType);
+	if (!result)
+	{
+		auto errorMsg = "Type " +
+			condType->humanReadableName() +
+			" is not implicitly convertible to expected type " +
+			expectedType.humanReadableName();
+		if (
+			condType->category() == Type::Category::RationalNumber &&
+			dynamic_cast<RationalNumberType const*>(condType)->isFractional() &&
+			condType->mobileType()
+		)
+		{
+			if (expectedType.operator==(*condType->mobileType()))
+				m_errorReporter.typeError(
+					4426_error,
+					_expression.location(),
+					errorMsg + ", but it can be explicitly converted."
+				);
+			else
+				m_errorReporter.typeErrorConcatenateDescriptions(
+					2326_error,
+					_expression.location(),
+					errorMsg +
+					". Try converting to type " +
+					condType->mobileType()->humanReadableName() +
+					" or use an explicit conversion.",
+					result.message()
+				);
+		}
+		else
+			m_errorReporter.typeErrorConcatenateDescriptions(
+				7407_error,
+				_expression.location(),
+				errorMsg + ".",
+				result.message()
+			);
+		return false;
+	}
+	return true;
 }
 
 

--- a/test/libsolidity/syntaxTests/shieldedTypes/non_bool_condition_no_crash.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/non_bool_condition_no_crash.sol
@@ -1,0 +1,14 @@
+// Non-bool conditions must produce a TypeError, not a crash.
+contract C {
+    function f() public pure {
+        if (1) {}
+        while (2) {}
+        for (; 3; ) {}
+        uint x = 1 ? 0 : 1;
+    }
+}
+// ----
+// TypeError 7407: (118-119): Type int_const 1 is not implicitly convertible to expected type bool.
+// TypeError 7407: (139-140): Type int_const 2 is not implicitly convertible to expected type bool.
+// TypeError 7407: (160-161): Type int_const 3 is not implicitly convertible to expected type bool.
+// TypeError 7407: (185-186): Type int_const 1 is not implicitly convertible to expected type bool.


### PR DESCRIPTION
Fixes #364

The non-bool fallback delegated to `expectType`, which `accept()`s the already-visited condition again, reassigning a SetOnce annotation -> `BadSetOnceReassignment` crash on `if`/`while`/`for`/ternary with a non-bool condition. Inline the conversion check without the second accept -> normal 7407 TypeError.

Test: `non_bool_condition_no_crash.sol` (all four call sites, 7407). Crash PoC exit 2 -> 1. Syntax 3979/0-fail; semantic sweeps legacy + via-IR all-pass.