### PR TITLE
3.6: resolve layout-at baseSlot on-demand so cstore-on-public (10314) fires

### DIFF
--- a/libsolidity/analysis/PostTypeContractLevelChecker.cpp
+++ b/libsolidity/analysis/PostTypeContractLevelChecker.cpp
@@ -138,7 +138,9 @@ void PostTypeContractLevelChecker::checkStorageLayoutSpecifier(ContractDefinitio
 	}
 
 	solAssert(baseSlotExpressionType->isImplicitlyConvertibleTo(*TypeProvider::uint256()));
-	storageLayoutSpecifier->annotation().baseSlot = u256(baseSlot);
+	// May already be resolved on-demand during type checking (validateShieldedStorageOps).
+	if (!storageLayoutSpecifier->annotation().baseSlot.set())
+		storageLayoutSpecifier->annotation().baseSlot = u256(baseSlot);
 
 	bigint size = contractStorageSizeUpperBound(_contract, VariableDeclaration::Location::Unspecified);
 	solAssert(size < bigint(1) << 256);

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1143,6 +1143,16 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 	if (m_currentContract)
 	{
 		auto const* layoutSpecifier = m_currentContract->storageLayoutSpecifier();
+		// baseSlot is normally set in a later pass (PostTypeContractLevelChecker); resolve it here so
+		// the literal/alias 10314 arm is not dead for `layout at` contracts. PostType's set is guarded.
+		if (layoutSpecifier && !layoutSpecifier->annotation().baseSlot.set())
+			if (auto const* rational = dynamic_cast<RationalNumberType const*>(type(layoutSpecifier->baseSlotExpression())))
+				if (!rational->isFractional())
+				{
+					bigint base = rational->value().numerator();
+					if (0 <= base && base <= std::numeric_limits<u256>::max())
+						layoutSpecifier->annotation().baseSlot = u256(base);
+				}
 		if (!layoutSpecifier || layoutSpecifier->annotation().baseSlot.set())
 			for (auto const& [var, slot, byteOffset]: ContractType(*m_currentContract).linearizedStateVariables(DataLocation::Storage))
 				if (var->annotation().type && !var->annotation().type->isShielded() && !var->annotation().type->containsShieldedType())

--- a/test/libsolidity/syntaxTests/inlineAssembly/layout_at_cstore_public_slot.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/layout_at_cstore_public_slot.sol
@@ -1,0 +1,16 @@
+// cstore on a public slot must be flagged (10314) even in a `layout at` contract, via a bare
+// literal, a literal alias, or a .slot reference. baseSlot is resolved on-demand so the map is built.
+contract C layout at 42 {
+    uint256 public x;   // slot 42
+    suint256 secret;    // slot 43
+    function bypassLiteral() public { assembly { cstore(42, 1) } }
+    function bypassAlias() public { assembly { let s := 42  cstore(s, 1) } }
+    function viaSlot() public { assembly { cstore(x.slot, 1) } }
+    function shieldedOk() public { assembly { cstore(secret.slot, 1) } }
+}
+// ====
+// EVMVersion: >=mercury
+// ----
+// TypeError 10314: (342-355): Cannot use cstore() on non-shielded storage variable. Use sstore() instead.
+// TypeError 10314: (420-432): Cannot use cstore() on non-shielded storage variable. Use sstore() instead.
+// TypeError 10314: (480-497): Cannot use cstore() on non-shielded storage variable. Use sstore() instead.


### PR DESCRIPTION
Fixes #366

The B2.1 ICE guard skipped the public-slot map whenever `baseSlot` was unset, but `baseSlot` is set in a later pass (PostTypeContractLevelChecker) — so for every `layout at` contract the literal / literal-alias 10314 arm was silently dead. Resolve `baseSlot` on-demand from the already-type-checked base expression before building the map; guard PostType's assignment to stay idempotent. Still ICE-safe (unresolvable base -> map skipped as before).

Test: `layout_at_cstore_public_slot.sol` (literal + alias + .slot cstore-on-public all 10314; shielded control clean). Full layout-at compile doesn't double-set-crash; edge cases (`layout at 0`, non-constant base) clean. Syntax 3999/0-fail; sweeps legacy 1920 / via-IR 1920.