### PR TITLE
3.17: warn on shielded-bool short-circuit branch leak

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2388,6 +2388,17 @@ void TypeChecker::endVisit(BinaryOperation const& _operation)
 			"Shielded integer shift count can leak through the public shift result."
 		);
 
+	if (
+		(_operation.getOperator() == Token::And || _operation.getOperator() == Token::Or) &&
+		(leftType->category() == Type::Category::ShieldedBool || rightType->category() == Type::Category::ShieldedBool)
+	)
+		m_errorReporter.warning(
+			10316_error,
+			_operation.location(),
+			"Using shielded types in branching conditions can leak information through "
+			"observable execution patterns such as gas costs, state changes, and execution traces."
+		);
+
 	if (_operation.getOperator() == Token::Exp || _operation.getOperator() == Token::SHL)
 	{
 		std::string operation = _operation.getOperator() == Token::Exp ? "exponentiation" : "shift";

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_short_circuit_leak.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_short_circuit_leak.sol
@@ -1,0 +1,12 @@
+contract C {
+    sbool sa;
+    sbool sb;
+    sbool sc;
+    function f() internal {
+        sc = sa && sb;
+        sc = sa || sb;
+    }
+}
+// ----
+// Warning 10316: (96-104): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
+// Warning 10316: (119-127): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.

--- a/test/libsolidity/syntaxTests/types/sbool_ops.sol
+++ b/test/libsolidity/syntaxTests/types/sbool_ops.sol
@@ -32,6 +32,8 @@ contract C {
     }
 }
 // ----
+// Warning 10316: (175-181): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
+// Warning 10316: (195-201): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
 // TypeError 2271: (234-239): Built-in binary operator > cannot be applied to types sbool and sbool.
 // TypeError 2271: (253-258): Built-in binary operator < cannot be applied to types sbool and sbool.
 // TypeError 2271: (272-278): Built-in binary operator >= cannot be applied to types sbool and sbool.

--- a/test/libsolidity/syntaxTests/types/shielded_bool_ops.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_bool_ops.sol
@@ -32,6 +32,8 @@ contract C {
     }
 }
 // ----
+// Warning 10316: (175-181): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
+// Warning 10316: (195-201): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
 // TypeError 2271: (234-239): Built-in binary operator > cannot be applied to types sbool and sbool.
 // TypeError 2271: (253-258): Built-in binary operator < cannot be applied to types sbool and sbool.
 // TypeError 2271: (272-278): Built-in binary operator >= cannot be applied to types sbool and sbool.


### PR DESCRIPTION
Fixes #368

`sbool && sbool` and `sbool || sbool` are branching constructs — the RHS is evaluated conditionally on the LHS — but emitted no leak warning, unlike `if`/`while`/`require`/ternary conditions on `sbool` (10310/10311).

## Change
`TypeChecker::endVisit(BinaryOperation)` now emits warning **10316** when the operator is `&&`/`||` and either operand is `sbool`. A dedicated code (group 103__, info-leak) rather than reusing 10311: the codebase enforces one-ID-one-site (cf. 3.19), so a second 10311 site would fail `error_codes.py --check`. 10316 avoids 10315, which 3.19's PR claims. Mixed `sbool && bool` is already rejected by `BoolType::binaryOperatorResult`, so the warning fires only on genuine shielded short-circuits.

## Tests
- `shielded_short_circuit_leak.sol` (new): 10316 x2.
- `types/sbool_ops.sol`, `types/shielded_bool_ops.sol`: expectations updated for the `a || b` / `a && b` lines.
- Full syntax suite: no regressions. `error_codes.py --check` shows 10316 unique (the 10002/10312 dups are pre-existing, addressed by 3.19).
- Warning-only, analysis phase, no codegen change — semantic output unaffected.