### PR TITLE
3.13: warn on msg.value into shielded tuple member/index targets and helper launders

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1931,18 +1931,14 @@ bool TypeChecker::visit(Assignment const& _assignment)
 
 		checkImplicitConversion(_assignment.rightHandSide(), *tupleType);
 
-		// Per-component msg.value/msg.data leak check, for simple variable targets paired with a
-		// literal-tuple RHS. Mirrors the preserve loop above: only Identifier LHS components, so
-		// non-lvalue components like x.push() are skipped (they can't receive msg.value anyway).
+		// Per-component msg.value/msg.data leak check against a literal-tuple RHS. Fires for any
+		// LHS component whose resolved type is shielded (member/index targets included);
+		// checkMsgValueToShielded self-guards on the target type.
 		if (auto const* lhsTuple = dynamic_cast<TupleExpression const*>(&_assignment.leftHandSide()))
 			if (auto const* rhsTuple = dynamic_cast<TupleExpression const*>(&_assignment.rightHandSide()))
 				for (size_t i = 0; i < std::min(lhsTuple->components().size(), rhsTuple->components().size()); ++i)
-				{
-					if (!lhsTuple->components()[i] || !rhsTuple->components()[i])
-						continue;
-					if (dynamic_cast<Identifier const*>(lhsTuple->components()[i].get()))
+					if (lhsTuple->components()[i] && rhsTuple->components()[i])
 						checkMsgValueToShielded(*rhsTuple->components()[i], *type(*lhsTuple->components()[i]));
-				}
 	}
 	else if (_assignment.assignmentOperator() == Token::Assign)
 	{
@@ -4959,6 +4955,11 @@ void TypeChecker::checkMsgValueToShielded(
 	Type const& _targetType
 )
 {
+	// A tuple target (nested tuple LHS component) is decomposed and its components are checked
+	// individually; TupleType::containsShieldedType() is unimplemented, so skip it here.
+	if (dynamic_cast<TupleType const*>(&_targetType))
+		return;
+
 	// Only warn if target type is or contains a shielded type
 	if (!_targetType.isShielded() && !_targetType.containsShieldedType())
 		return;
@@ -5002,6 +5003,21 @@ void TypeChecker::checkMsgValueToShielded(
 			for (auto const& arg : funcCall->arguments())
 				if (arg)
 					checkMsgValueToShielded(*arg, _targetType);
+
+	// A real helper call can launder msg.value/msg.data into a shielded target, e.g.
+	// secret = wrap(msg.value). Recurse into positional arguments whose parameter is public;
+	// shielded-parameter arguments are already covered by the call-site check.
+	if (auto funcCall = dynamic_cast<FunctionCall const*>(&_expression))
+		if (funcCall->annotation().kind.set() && *funcCall->annotation().kind == FunctionCallKind::FunctionCall)
+			if (funcCall->names().empty())
+				if (auto const* funcType = dynamic_cast<FunctionType const*>(type(funcCall->expression())))
+				{
+					TypePointers const params = funcType->parameterTypes();
+					auto const& args = funcCall->arguments();
+					for (size_t i = 0; i < args.size() && i < params.size(); ++i)
+						if (args[i] && params[i] && !params[i]->isShielded() && !params[i]->containsShieldedType())
+							checkMsgValueToShielded(*args[i], _targetType);
+				}
 }
 
 void TypeChecker::checkShieldedLeakInPublicSink(Expression const& _expression)

--- a/test/libsolidity/syntaxTests/shieldedTypes/msg_value_helper_launder.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/msg_value_helper_launder.sol
@@ -1,0 +1,12 @@
+contract C {
+    suint256 secret;
+    function wrap(uint256 v) internal pure returns (suint256) { return suint256(v); }
+    function launderThroughHelper() external payable { secret = wrap(msg.value); }
+    function direct() external payable { secret = suint256(msg.value); }
+    function sinkShielded(suint256 _v) internal { secret = _v; }
+    function throughShieldedParam() external payable { sinkShielded(suint256(msg.value)); }
+}
+// ----
+// Warning 10306: (189-198): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.
+// Warning 10306: (262-271): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.
+// Warning 10306: (418-427): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.

--- a/test/libsolidity/syntaxTests/shieldedTypes/msg_value_tuple_shielded_target.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/msg_value_tuple_shielded_target.sol
@@ -1,0 +1,22 @@
+contract C {
+    struct S { suint256 priv; }
+    S s;
+    suint256[3] arr;
+    function tupleStructMember() external payable {
+        uint256 dummy;
+        (s.priv, dummy) = (suint256(msg.value), 0);
+    }
+    function tupleArrayIndex() external payable {
+        uint256 dummy;
+        (arr[0], dummy) = (suint256(msg.value), 0);
+    }
+    function tupleIdentifierLHS() external payable {
+        suint256 localSecret;
+        uint256 dummy;
+        (localSecret, dummy) = (suint256(msg.value), 0);
+    }
+}
+// ----
+// Warning 10306: (186-195): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.
+// Warning 10306: (317-326): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.
+// Warning 10306: (486-495): msg.value is always publicly visible on-chain. Assigning it to a shielded type does not hide the transaction value from observers.


### PR DESCRIPTION
Fixes #370

Two gaps in the msg.value/msg.data -> shielded safety-net warnings (10306/10307):

**Tuple member/index targets.** The tuple branch of `visit(Assignment)` gated the check on an `Identifier` LHS component, so `(s.priv, x) = (suint256(msg.value), 0)` and `(arr[0], x) = ...` produced no warning. Dropped the gate; the check now fires for every component whose resolved type is shielded (`checkMsgValueToShielded` self-guards on the target type).

**Helper launder.** `checkMsgValueToShielded` recursed only through `TypeConversion` nodes, so `secret = wrap(msg.value)` (real call, public `uint256` param) was silent at both the assignment and — because the param is public — the call site. It now also recurses into a real call's positional arguments whose parameter is public. Shielded-parameter arguments remain the call-site check's responsibility, so there is no double warning (verified: the launder PoC goes 2 -> 3 warnings, not 4).

**Robustness.** Guards `TupleType` targets up front — nested-tuple LHS components resolve to a `TupleType` whose `containsShieldedType()` is unimplemented (would throw `UnimplementedFeatureError 1834`); those are decomposed and checked component-wise anyway.

## Tests
- `msg_value_tuple_shielded_target.sol`: 10306 x3 (struct member, array index, identifier baseline).
- `msg_value_helper_launder.sol`: 10306 x3 (helper launder, direct, shielded-param).
- Full syntax suite: no regressions (caught and fixed the TupleType crash on non-shielded push-tuple tests mid-review).
- Warning-only, analysis phase — semantic output unaffected.