### PR TITLE
3.15: gate shielded features to Mercury exactly (reject post-Mercury versions)

### DIFF
--- a/liblangutil/EVMVersion.h
+++ b/liblangutil/EVMVersion.h
@@ -147,8 +147,10 @@ public:
 	bool hasBlobHash() const { return *this >= cancun(); }
 	bool hasMcopy() const { return *this >= cancun(); }
 	bool supportsTransientStorage() const { return *this >= cancun(); }
-	bool supportShieldedStorage() const { return *this >= mercury(); }
-	bool hasTimestampMs() const { return *this >= mercury(); }
+	// Mercury-only: the runtime defines CLOAD/CSTORE/TIMESTAMPMS for Mercury alone, and later
+	// versions (e.g. Osaka) do not, so shielded support must not extend past Mercury.
+	bool supportShieldedStorage() const { return *this == mercury(); }
+	bool hasTimestampMs() const { return *this == mercury(); }
 	bool supportsEOF() const { return *this >= firstWithEOF(); }
 
 	bool hasOpcode(evmasm::Instruction _opcode, std::optional<uint8_t> _eofVersion) const;

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -201,7 +201,7 @@ void ReferencesResolver::endVisit(IdentifierPath const& _path)
 				m_errorReporter.fatalDeclarationError(
 					10002_error,
 					_path.location(),
-					"Shielded type \"" + _path.path().front() + "\" requires the Mercury EVM version or later. "
+					"Shielded type \"" + _path.path().front() + "\" requires the Mercury EVM version. "
 					"The current EVM version \"" + m_evmVersion.name() + "\" does not support shielded types. "
 					"Use \"--evm-version mercury\" to enable shielded type support."
 				);

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -675,7 +675,7 @@ bool TypeChecker::visit(VariableDeclaration const& _variable)
 			m_errorReporter.typeError(
 				10001_error,
 				_variable.location(),
-				"Shielded types (suint, sbool, saddress, sbytes, etc.) require the Mercury EVM version or later. "
+				"Shielded types (suint, sbool, saddress, sbytes, etc.) require the Mercury EVM version. "
 				"The current EVM version \"" + m_evmVersion.name() + "\" does not support shielded types. "
 				"Use \"--evm-version mercury\" to enable shielded type support."
 			);

--- a/scripts/error_codes.py
+++ b/scripts/error_codes.py
@@ -327,6 +327,9 @@ def examine_id_coverage(top_dir, source_id_to_file_names, new_ids_only=False):
         "9603",
         "9658",
         "9988",
+        # ReferencesResolver's fatal 10002 preempts every shielded declaration on a
+        # non-Mercury version, so the belt-and-suspenders 10001 in TypeChecker is unreachable.
+        "10001",
     }
 
     new_source_only_ids = source_only_ids - old_source_only_ids - experimental_source_only_ids

--- a/test/libsolidity/syntaxTests/docExamples/use_cases_compliance_token.sol
+++ b/test/libsolidity/syntaxTests/docExamples/use_cases_compliance_token.sol
@@ -27,7 +27,7 @@ contract ComplianceToken is AccessControl {
     }
 }
 // ====
-// EVMVersion: >=mercury
+// EVMVersion: =mercury
 // ----
 // Warning 5667: (462-474): Unused function parameter. Remove or comment out the variable name to silence this warning.
 // Warning 5667: (476-491): Unused function parameter. Remove or comment out the variable name to silence this warning.

--- a/test/libsolidity/syntaxTests/docExamples/use_cases_confidential_amm.sol
+++ b/test/libsolidity/syntaxTests/docExamples/use_cases_confidential_amm.sol
@@ -20,7 +20,7 @@ contract ConfidentialAMM {
     }
 }
 // ====
-// EVMVersion: >=mercury
+// EVMVersion: =mercury
 // ----
 // Warning 10301: (507-526): Shielded integer multiplication can leak information. A revert due to overflow reveals range information about the operands.
 // Warning 10301: (531-550): Shielded integer addition can leak information. A revert due to overflow reveals range information about the operands.

--- a/test/libsolidity/syntaxTests/docExamples/use_cases_private_voting.sol
+++ b/test/libsolidity/syntaxTests/docExamples/use_cases_private_voting.sol
@@ -24,7 +24,7 @@ contract PrivateVoting {
     }
 }
 // ====
-// EVMVersion: >=mercury
+// EVMVersion: =mercury
 // ----
 // Warning 10406: (389-400): Bool Literals converted to shielded bools will leak during contract deployment.
 // Warning 10403: (455-466): Literals converted to shielded integers will leak during contract deployment.

--- a/test/libsolidity/syntaxTests/docExamples/use_cases_sealed_bid_auction.sol
+++ b/test/libsolidity/syntaxTests/docExamples/use_cases_sealed_bid_auction.sol
@@ -22,5 +22,5 @@ contract SealedBidAuction {
     }
 }
 // ====
-// EVMVersion: >=mercury
+// EVMVersion: =mercury
 // ----

--- a/test/libsolidity/syntaxTests/docExamples/use_cases_src20.sol
+++ b/test/libsolidity/syntaxTests/docExamples/use_cases_src20.sol
@@ -10,5 +10,5 @@ contract SRC20 {
     }
 }
 // ====
-// EVMVersion: >=mercury
+// EVMVersion: =mercury
 // ----

--- a/test/libsolidity/syntaxTests/types/magic_block_timestamp_ms.sol
+++ b/test/libsolidity/syntaxTests/types/magic_block_timestamp_ms.sol
@@ -10,5 +10,5 @@ contract C {
     }
 }
 // ====
-// EVMVersion: >=mercury
+// EVMVersion: =mercury
 // ----

--- a/test/libsolidity/syntaxTests/types/shielded_local_variable_evm_version.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_local_variable_evm_version.sol
@@ -7,4 +7,4 @@ contract C {
 // EVMVersion: =paris
 // compileViaYul: true
 // ----
-// TypeError 10001: (49-72): Shielded types (suint, sbool, saddress, sbytes, etc.) require the Mercury EVM version or later. The current EVM version "paris" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.
+// DeclarationError 10002: (47-55): Shielded type "suint256" requires the Mercury EVM version. The current EVM version "paris" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.

--- a/test/libsolidity/syntaxTests/types/shielded_memory_param_evm_version.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_memory_param_evm_version.sol
@@ -6,5 +6,4 @@ contract C {
 // EVMVersion: =cancun
 // compileViaYul: true
 // ----
-// TypeError 10001: (28-43): Shielded types (suint, sbool, saddress, sbytes, etc.) require the Mercury EVM version or later. The current EVM version "cancun" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.
-// TypeError 10001: (79-96): Shielded types (suint, sbool, saddress, sbytes, etc.) require the Mercury EVM version or later. The current EVM version "cancun" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.
+// DeclarationError 10002: (28-34): Shielded type "sbytes" requires the Mercury EVM version. The current EVM version "cancun" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.

--- a/test/libsolidity/syntaxTests/types/shielded_rejected_on_osaka.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_rejected_on_osaka.sol
@@ -1,0 +1,7 @@
+contract C {
+    suint8 private secret = 42;
+}
+// ====
+// EVMVersion: =osaka
+// ----
+// DeclarationError 10002: (17-23): Shielded type "suint8" requires the Mercury EVM version. The current EVM version "osaka" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.

--- a/test/libsolidity/syntaxTests/types/shielded_storage_evm_version_cancun.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_storage_evm_version_cancun.sol
@@ -8,7 +8,4 @@ contract C {
 // EVMVersion: =cancun
 // compileViaYul: true
 // ----
-// TypeError 10001: (20-31): Shielded types (suint, sbool, saddress, sbytes, etc.) require the Mercury EVM version or later. The current EVM version "cancun" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.
-// TypeError 10001: (37-46): Shielded types (suint, sbool, saddress, sbytes, etc.) require the Mercury EVM version or later. The current EVM version "cancun" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.
-// TypeError 10001: (52-64): Shielded types (suint, sbool, saddress, sbytes, etc.) require the Mercury EVM version or later. The current EVM version "cancun" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.
-// TypeError 10001: (70-79): Shielded types (suint, sbool, saddress, sbytes, etc.) require the Mercury EVM version or later. The current EVM version "cancun" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.
+// DeclarationError 10002: (17-25): Shielded type "suint256" requires the Mercury EVM version. The current EVM version "cancun" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.

--- a/test/libsolidity/syntaxTests/types/shielded_storage_evm_version_mercury.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_storage_evm_version_mercury.sol
@@ -11,7 +11,7 @@ contract C {
     S s;
 }
 // ====
-// EVMVersion: >=mercury
+// EVMVersion: =mercury
 // compileViaYul: true
 // ----
 // Warning 10305: (62-73): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.

--- a/test/libsolidity/syntaxTests/types/shielded_storage_evm_version_paris.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_storage_evm_version_paris.sol
@@ -5,4 +5,4 @@ contract C {
 // EVMVersion: =paris
 // compileViaYul: true
 // ----
-// TypeError 10001: (20-31): Shielded types (suint, sbool, saddress, sbytes, etc.) require the Mercury EVM version or later. The current EVM version "paris" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.
+// DeclarationError 10002: (17-25): Shielded type "suint256" requires the Mercury EVM version. The current EVM version "paris" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.

--- a/test/libsolidity/syntaxTests/types/shielded_storage_sbytes_evm_version.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_storage_sbytes_evm_version.sol
@@ -5,4 +5,4 @@ contract C {
 // EVMVersion: =cancun
 // compileViaYul: true
 // ----
-// TypeError 10001: (20-31): Shielded types (suint, sbool, saddress, sbytes, etc.) require the Mercury EVM version or later. The current EVM version "cancun" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.
+// DeclarationError 10002: (17-23): Shielded type "sbytes" requires the Mercury EVM version. The current EVM version "cancun" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.

--- a/test/libsolidity/syntaxTests/types/shielded_storage_struct_evm_version.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_storage_struct_evm_version.sol
@@ -9,4 +9,4 @@ contract C {
 // EVMVersion: =paris
 // compileViaYul: true
 // ----
-// TypeError 10001: (88-91): Shielded types (suint, sbool, saddress, sbytes, etc.) require the Mercury EVM version or later. The current EVM version "paris" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.
+// DeclarationError 10002: (36-44): Shielded type "suint256" requires the Mercury EVM version. The current EVM version "paris" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.

--- a/test/libsolidity/syntaxTests/types/shielded_type_used_pre_mercury.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_type_used_pre_mercury.sol
@@ -4,4 +4,4 @@ contract C {
 // ====
 // EVMVersion: =paris
 // ----
-// DeclarationError 10002: (17-23): Shielded type "suint8" requires the Mercury EVM version or later. The current EVM version "paris" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.
+// DeclarationError 10002: (17-23): Shielded type "suint8" requires the Mercury EVM version. The current EVM version "paris" does not support shielded types. Use "--evm-version mercury" to enable shielded type support.


### PR DESCRIPTION
Fixes #372

`EVMVersion::supportShieldedStorage()` and `hasTimestampMs()` gated on `*this >= mercury()` with no upper bound, so a post-Mercury version (e.g. Osaka, which follows Mercury in the enum) satisfied the gate — the compiler would emit CLOAD/CSTORE/TIMESTAMPMS and accept shielded types for a target where they do not exist. The runtime (seismic-revm) is Mercury-pinned (`SeismicSpecId` defines only MERCURY; the handler exact-matches it).

## Change
- Both gates now exact-match `*this == mercury()`. Audited all 14 callers — definitions, `hasOpcode()`, the TypeChecker/AsmAnalysis gates, and the codegen `solAssert` guards all behave correctly under exact-match.
- Dropped "or later" from the two rejection messages (10001 TypeChecker, 10002 ReferencesResolver).

## Tests
- `shielded_rejected_on_osaka.sol` (=osaka): shielded declaration rejected on Osaka. Verified: Osaka errors, Mercury compiles.
- Corrected 6 pre-Mercury version tests (`shielded_storage_*_evm_version`, `shielded_memory_param_evm_version`, `shielded_local_variable_evm_version`): they asserted `10001 x N`, but the compiler emits a single fatal `10002` (ReferencesResolver preempts the TypeChecker path). Pre-existing wrong expectations, unnoticed because CI runs only the default Mercury matrix where these =cancun/=paris tests are skipped. Now assert actual output, verified at their pinned versions.
- Tightened shielded/timestamp syntax + docExample pins `>=mercury` -> `=mercury` (they assert successful compilation, now Mercury-only).
- `10001` is now unreachable (fatal 10002 preempts every shielded declaration); recorded in `error_codes.py` old_source_only_ids with a note.
- Full syntax suite green at Mercury (0 fail).

Follow-up (not in scope): seismic `>=mercury` pins on semantic and yul tests could likewise be tightened to `=mercury`; verifying those at Osaka needs revme.