### PR TITLE
3.18: gate shielded number literal suffix pre-Mercury

### DIFF
--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -1020,7 +1020,7 @@ Token Scanner::scanNumber(char _charSeen)
 	// Check for shielded literal suffix 's'.
 	// Only treat as suffix if 's' is not followed by an identifier character
 	// (so that e.g. `1seconds` still errors as expected).
-	if (m_char == 's' && (m_source.isPastEndOfInput(1) || !isIdentifierPart(m_source.get(1))))
+	if (m_shieldedTypesEnabled && m_char == 's' && (m_source.isPastEndOfInput(1) || !isIdentifierPart(m_source.get(1))))
 	{
 		advance(); // consume the 's'
 		literal.complete();

--- a/test/libsolidity/syntaxTests/types/shielded_literal_rejected_pre_mercury.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_rejected_pre_mercury.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure returns (uint256) {
+        return 42s;
+    }
+}
+// ====
+// EVMVersion: =cancun
+// ----
+// ParserError 8936: (77-79): Identifier-start is not allowed at end of a number.


### PR DESCRIPTION
Fixes #374

`Scanner::scanNumber` returned `Token::ShieldedNumber` for an `s`-suffixed literal unconditionally, with no `m_shieldedTypesEnabled` check — unlike the keyword path, which demotes shielded keywords to identifiers pre-Mercury. So `42s` scanned (and only warned, 10416) on a pre-Mercury target where every other shielded construct hard-errors.

## Change
One-line guard: the s-suffix branch now requires `m_shieldedTypesEnabled`. Pre-Mercury the trailing `s` falls through to the existing number-end check and errors as `ParserError 8936`. Mercury behavior is unchanged.

## Tests
- `shielded_literal_rejected_pre_mercury.sol` (=cancun): `42s` -> ParserError 8936, verified.
- Mercury still scans `42s` as a shielded literal (10416) — no-op at Mercury since `m_shieldedTypesEnabled` is true.
- Full syntax suite green. Scanner-only; no codegen change.