### PR TITLE
3.12: make the 10313 declassification warning value-based (all sinks)

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1554,6 +1554,9 @@ void TypeChecker::endVisit(Return const& _return)
 	else if (params->parameters().size() == 1)
 		checkMsgValueToShielded(*_return.expression(), *type(*params->parameters().front()));
 
+	// A shielded-to-public cast in a return expression leaks into returndata.
+	checkShieldedLeakInPublicSink(*_return.expression());
+
 	for (auto const& var: params->parameters())
 		returnTypes.push_back(type(*var));
 	if (auto tupleType = dynamic_cast<TupleType const*>(type(*_return.expression())))
@@ -1992,6 +1995,21 @@ bool TypeChecker::visit(Assignment const& _assignment)
 				"Shielded integer shift count can leak through the public shift result."
 			);
 	}
+
+	// A cast to a public target leaks into public storage; a shielded target (reshield) does not.
+	auto targetIsPublicSink = [&](Type const* _t) -> bool {
+		return _t && !dynamic_cast<TupleType const*>(_t) && !_t->isShielded() && !_t->containsShieldedType();
+	};
+	if (auto const* lhsTuple = dynamic_cast<TupleExpression const*>(&_assignment.leftHandSide()))
+	{
+		if (auto const* rhsTuple = dynamic_cast<TupleExpression const*>(&_assignment.rightHandSide()))
+			for (size_t i = 0; i < std::min(lhsTuple->components().size(), rhsTuple->components().size()); ++i)
+				if (lhsTuple->components()[i] && rhsTuple->components()[i] && targetIsPublicSink(type(*lhsTuple->components()[i])))
+					checkShieldedLeakInPublicSink(*rhsTuple->components()[i]);
+	}
+	else if (targetIsPublicSink(type(_assignment.leftHandSide())))
+		checkShieldedLeakInPublicSink(_assignment.rightHandSide());
+
 	return false;
 }
 
@@ -5006,10 +5024,6 @@ void TypeChecker::checkMsgValueToShielded(
 
 void TypeChecker::checkShieldedLeakInPublicSink(Expression const& _expression)
 {
-	auto funcCall = dynamic_cast<FunctionCall const*>(&_expression);
-	if (!funcCall)
-		return;
-
 	// Structural shielding check that ignores the array storage marker, since
 	// bytes(sbytesRef) carries it through but the value is semantically public.
 	std::function<bool(Type const&)> structurallyShielded = [&](Type const& t) -> bool {
@@ -5020,22 +5034,44 @@ void TypeChecker::checkShieldedLeakInPublicSink(Expression const& _expression)
 		return t.containsShieldedType();
 	};
 
-	if (
-		*funcCall->annotation().kind == FunctionCallKind::TypeConversion &&
-		!funcCall->arguments().empty() &&
-		funcCall->arguments().front() &&
-		structurallyShielded(*type(*funcCall->arguments().front())) &&
-		!structurallyShielded(*type(_expression))
-	)
-		m_errorReporter.warning(
-			10313_error,
-			_expression.location(),
-			"Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata."
-		);
+	// Value-based: descend the expression tree so a shielded-to-public cast is caught wherever it
+	// sits (ternary, binary operand, tuple component, call arg), not only as a direct call argument.
+	if (auto const* funcCall = dynamic_cast<FunctionCall const*>(&_expression))
+	{
+		if (
+			funcCall->annotation().kind.set() &&
+			*funcCall->annotation().kind == FunctionCallKind::TypeConversion &&
+			!funcCall->arguments().empty() &&
+			funcCall->arguments().front() &&
+			structurallyShielded(*type(*funcCall->arguments().front())) &&
+			!structurallyShielded(*type(_expression))
+		)
+			m_errorReporter.warning(
+				10313_error,
+				_expression.location(),
+				"Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage."
+			);
 
-	for (auto const& arg: funcCall->arguments())
-		if (arg)
-			checkShieldedLeakInPublicSink(*arg);
+		for (auto const& arg: funcCall->arguments())
+			if (arg)
+				checkShieldedLeakInPublicSink(*arg);
+	}
+	else if (auto const* conditional = dynamic_cast<Conditional const*>(&_expression))
+	{
+		checkShieldedLeakInPublicSink(conditional->trueExpression());
+		checkShieldedLeakInPublicSink(conditional->falseExpression());
+	}
+	else if (auto const* binaryOperation = dynamic_cast<BinaryOperation const*>(&_expression))
+	{
+		checkShieldedLeakInPublicSink(binaryOperation->leftExpression());
+		checkShieldedLeakInPublicSink(binaryOperation->rightExpression());
+	}
+	else if (auto const* tuple = dynamic_cast<TupleExpression const*>(&_expression))
+	{
+		for (auto const& component: tuple->components())
+			if (component)
+				checkShieldedLeakInPublicSink(*component);
+	}
 }
 
 void TypeChecker::checkErrorAndEventParameters(CallableDeclaration const& _callable)

--- a/test/libsolidity/syntaxTests/docExamples/use_cases_compliance_token.sol
+++ b/test/libsolidity/syntaxTests/docExamples/use_cases_compliance_token.sol
@@ -29,6 +29,7 @@ contract ComplianceToken is AccessControl {
 // ====
 // EVMVersion: >=mercury
 // ----
+// Warning 10313: (780-807): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
 // Warning 5667: (462-474): Unused function parameter. Remove or comment out the variable name to silence this warning.
 // Warning 5667: (476-491): Unused function parameter. Remove or comment out the variable name to silence this warning.
 // Warning 2018: (445-558): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/docExamples/use_cases_private_voting.sol
+++ b/test/libsolidity/syntaxTests/docExamples/use_cases_private_voting.sol
@@ -29,3 +29,5 @@ contract PrivateVoting {
 // Warning 10406: (389-400): Bool Literals converted to shielded bools will leak during contract deployment.
 // Warning 10403: (455-466): Literals converted to shielded integers will leak during contract deployment.
 // Warning 10403: (508-519): Literals converted to shielded integers will leak during contract deployment.
+// Warning 10313: (694-711): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (726-742): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/docExamples/use_cases_sealed_bid_auction.sol
+++ b/test/libsolidity/syntaxTests/docExamples/use_cases_sealed_bid_auction.sol
@@ -24,3 +24,5 @@ contract SealedBidAuction {
 // ====
 // EVMVersion: >=mercury
 // ----
+// Warning 10313: (669-691): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (710-729): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_113_exp_warn_literal_base_1.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_113_exp_warn_literal_base_1.sol
@@ -7,3 +7,4 @@ contract test {
 // ----
 // Warning 10403: (80-91): Literals converted to shielded integers will leak during contract deployment.
 // Warning 10304: (113-118): Shielded integer exponentiation will leak the exponent value through gas cost.
+// Warning 10313: (108-119): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_114_exp_warn_literal_base_2.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_114_exp_warn_literal_base_2.sol
@@ -8,3 +8,4 @@ contract test {
 // Warning 10403: (80-91): Literals converted to shielded integers will leak during contract deployment.
 // Warning 10403: (113-123): Literals converted to shielded integers will leak during contract deployment.
 // Warning 10304: (113-126): Shielded integer exponentiation will leak the exponent value through gas cost.
+// Warning 10313: (108-127): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_116_shift_warn_literal_base_1.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_116_shift_warn_literal_base_1.sol
@@ -6,3 +6,4 @@ contract test {
 }
 // ----
 // Warning 10403: (80-91): Literals converted to shielded integers will leak during contract deployment.
+// Warning 10313: (108-121): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_117_shift_warn_literal_base_2.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_117_shift_warn_literal_base_2.sol
@@ -7,3 +7,4 @@ contract test {
 // ----
 // Warning 10403: (80-91): Literals converted to shielded integers will leak during contract deployment.
 // Warning 10403: (113-123): Literals converted to shielded integers will leak during contract deployment.
+// Warning 10313: (108-129): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_119_shift_warn_literal_base_4.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_119_shift_warn_literal_base_4.sol
@@ -6,3 +6,4 @@ contract test {
 }
 // ----
 // Warning 10403: (81-92): Literals converted to shielded integers will leak during contract deployment.
+// Warning 10313: (110-123): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_129_int_to_enum_explicit_conversion_is_not_okay.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_129_int_to_enum_explicit_conversion_is_not_okay.sol
@@ -10,3 +10,4 @@ contract test {
 // ----
 // Warning 10403: (108-116): Literals converted to shielded integers will leak during contract deployment.
 // TypeError 9640: (130-146): Explicit type conversion not allowed from "suint256" to "enum test.ActionChoices".
+// Warning 10313: (130-146): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_133_saddress_to_enum_conversion_not_allowed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_133_saddress_to_enum_conversion_not_allowed.sol
@@ -6,3 +6,4 @@ contract test {
 }
 // ----
 // TypeError 9640: (156-172): Explicit type conversion not allowed from "saddress" to "enum test.ActionChoices".
+// Warning 10313: (156-172): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_instantiation.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_instantiation.sol
@@ -11,3 +11,4 @@ contract InstantiationFail {
 }
 // ----
 // TypeError 10204: (234-266): Instantiating a contract with a saddress is not yet supported
+// Warning 10313: (234-266): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_integer_to_enum_explicit_rejected.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/shielded_integer_to_enum_explicit_rejected.sol
@@ -7,3 +7,4 @@ contract C {
 }
 // ----
 // TypeError 9640: (126-135): Explicit type conversion not allowed from "suint8" to "enum C.E".
+// Warning 10313: (126-135): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_address_literal.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_address_literal.sol
@@ -6,3 +6,4 @@ contract test {
 }
 // ----
 // Warning 10409: (85-137): Address Literals converted to shielded addresses will leak during contract deployment.
+// Warning 10313: (154-164): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_bool_literal.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/warn_shielded_bool_literal.sol
@@ -6,3 +6,4 @@ contract test {
 }
 // ----
 // Warning 10406: (79-90): Bool Literals converted to shielded bools will leak during contract deployment.
+// Warning 10313: (107-114): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/parsing/shielded_address_nonpayable.sol
+++ b/test/libsolidity/syntaxTests/parsing/shielded_address_nonpayable.sol
@@ -6,3 +6,4 @@ contract C {
     }
 }
 // ----
+// Warning 10313: (129-139): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/parsing/shielded_address_payable.sol
+++ b/test/libsolidity/syntaxTests/parsing/shielded_address_payable.sol
@@ -6,3 +6,4 @@ contract C {
     }
 }
 // ----
+// Warning 10313: (169-179): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/parsing/shielded_for_loop.sol
+++ b/test/libsolidity/syntaxTests/parsing/shielded_for_loop.sol
@@ -13,3 +13,4 @@ contract TestForSbool {
 // Warning 10311: (128-137): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
 // Warning 10302: (155-164): Shielded integer increment can leak information. A revert due to overflow reveals range information about the operand.
 // Warning 10311: (182-198): Using shielded types in branching conditions can leak information through observable execution patterns such as gas costs, state changes, and execution traces.
+// Warning 10313: (264-277): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_bytes_copy_public_warns.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_bytes_copy_public_warns.sol
@@ -1,0 +1,8 @@
+contract C {
+    sbytes private secret;
+    bytes public pub;
+    function copyLeak() external { pub = bytes(secret); }
+}
+// ----
+// Warning 10305: (17-38): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// Warning 10313: (103-116): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_bytes_leak_via_emit_revert.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_bytes_leak_via_emit_revert.sol
@@ -41,10 +41,10 @@ contract C {
 }
 // ----
 // Warning 10305: (17-38): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
-// Warning 10313: (264-277): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
-// Warning 10313: (346-359): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
-// Warning 10313: (433-446): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
-// Warning 10313: (543-556): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
+// Warning 10313: (264-277): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (346-359): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (433-446): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (543-556): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
 // TypeError 10202: (635-648): Shielded types cannot be ABI encoded.
-// Warning 10313: (635-648): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
-// Warning 10313: (725-738): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
+// Warning 10313: (635-648): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (725-738): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_declassify_sinks.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_declassify_sinks.sol
@@ -1,0 +1,14 @@
+contract C {
+    suint256 private secret;
+    uint256 public pub;
+    function returnLeak() external view returns (uint256) { return uint256(secret); }
+    function storageLeak() external { pub = uint256(secret); }
+    function ternaryLeak(bool c) external view returns (uint256) { return c ? uint256(secret) : 0; }
+    function arithLeak() external view returns (uint256) { return uint256(secret) + 0; }
+    function reshieldNoLeak() external { secret = suint256(uint256(secret)); }
+}
+// ----
+// Warning 10313: (133-148): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (196-211): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (293-308): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (382-397): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_require_condition_no_leak_warning.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_require_condition_no_leak_warning.sol
@@ -17,5 +17,5 @@ contract C {
 }
 // ----
 // Warning 10305: (41-62): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
-// Warning 10313: (363-376): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
-// Warning 10313: (456-469): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
+// Warning 10313: (363-376): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (456-469): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/structs/shielded_struct_mixed_event_param_fail.sol
+++ b/test/libsolidity/syntaxTests/structs/shielded_struct_mixed_event_param_fail.sol
@@ -13,4 +13,4 @@ contract C {
 }
 // ----
 // Warning 10403: (264-276): Literals converted to shielded integers will leak during contract deployment.
-// Warning 10313: (308-325): Converting a shielded value to a public type within an emit or revert leaks the value to public logs or returndata.
+// Warning 10313: (308-325): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/types/address/shielded_address_abi_decode.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_address_abi_decode.sol
@@ -6,3 +6,4 @@ contract C {
 }
 // ----
 // TypeError 10201: (130-138): Shielded types cannot be ABI encoded.
+// Warning 10313: (165-175): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/types/address/shielded_address_to_payable_address_double.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_address_to_payable_address_double.sol
@@ -4,4 +4,5 @@ contract C {
     }
 }
 // ----
+// Warning 10313: (95-125): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
 // TypeError 6359: (95-125): Return argument type address is not implicitly convertible to expected type (type of first return variable) address payable.

--- a/test/libsolidity/syntaxTests/types/address/shielded_address_tuple_fail.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_address_tuple_fail.sol
@@ -5,3 +5,5 @@ contract C {
     }
 }
 // ----
+// Warning 10313: (191-201): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (203-213): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/types/address/shielded_address_tuple_fine.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_address_tuple_fine.sol
@@ -5,3 +5,5 @@ contract C {
     }
 }
 // ----
+// Warning 10313: (191-201): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (203-213): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/types/address/shielded_bytes_long_to_payable_address.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_bytes_long_to_payable_address.sol
@@ -5,4 +5,5 @@ contract C {
 }
 // ----
 // TypeError 9640: (102-113): Explicit type conversion not allowed from "bytes32" to "saddress".
+// Warning 10313: (94-114): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
 // TypeError 6359: (94-114): Return argument type address is not implicitly convertible to expected type (type of first return variable) address payable.

--- a/test/libsolidity/syntaxTests/types/address/shielded_bytes_short_to_payable_address.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_bytes_short_to_payable_address.sol
@@ -5,4 +5,5 @@ contract C {
 }
 // ----
 // TypeError 9640: (102-113): Explicit type conversion not allowed from "bytes10" to "saddress".
+// Warning 10313: (94-114): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
 // TypeError 6359: (94-114): Return argument type address is not implicitly convertible to expected type (type of first return variable) address payable.

--- a/test/libsolidity/syntaxTests/types/address/shielded_bytes_to_payable_address.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_bytes_to_payable_address.sol
@@ -5,3 +5,4 @@ contract C {
     }
 }
 // ----
+// Warning 10313: (153-163): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/types/address/shielded_conversion.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_conversion.sol
@@ -7,3 +7,5 @@ contract C {
     }
 }
 // ----
+// Warning 10313: (77-105): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (177-213): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/types/address/shielded_conversion_error.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_conversion_error.sol
@@ -11,5 +11,7 @@ contract C {
 }
 // ----
 // TypeError 9640: (85-97): Explicit type conversion not allowed from "int_const -1" to "saddress".
+// Warning 10313: (77-98): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
 // TypeError 6359: (170-172): Return argument type int_const -1 is not implicitly convertible to expected type (type of first return variable) address.
 // TypeError 9640: (243-259): Explicit type conversion not allowed from "int_const 1461...(41 digits omitted)...2976" to "saddress".
+// Warning 10313: (235-260): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/types/address/shielded_nonpayable_address_to_contract_payable_fallback.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_nonpayable_address_to_contract_payable_fallback.sol
@@ -9,3 +9,4 @@ contract C {
 // ----
 // Warning 3628: (0-141): This contract has a payable fallback function, but no receive ether function. Consider adding a receive ether function.
 // TypeError 7398: (94-98): Explicit type conversion not allowed from non-payable "saddress" to "contract C", which has a payable fallback function.
+// Warning 10313: (94-98): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/types/address/shielded_nonpayable_address_to_contract_receive.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_nonpayable_address_to_contract_receive.sol
@@ -8,3 +8,4 @@ contract C {
 }
 // ----
 // TypeError 7398: (94-98): Explicit type conversion not allowed from non-payable "saddress" to "contract C", which has a payable fallback function.
+// Warning 10313: (94-98): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/types/address/shielded_uint_to_address.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_uint_to_address.sol
@@ -4,3 +4,4 @@ contract C {
     }
 }
 // ----
+// Warning 10313: (87-97): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/types/address/shielded_uint_to_payable_address.sol
+++ b/test/libsolidity/syntaxTests/types/address/shielded_uint_to_payable_address.sol
@@ -4,3 +4,4 @@ contract C {
     }
 }
 // ----
+// Warning 10313: (99-137): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/types/sbytes_explicit_conversions.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_explicit_conversions.sol
@@ -24,3 +24,6 @@ contract C {
 // Warning 10412: (72-85): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
 // Warning 10412: (109-136): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
 // Warning 10412: (162-238): FixedBytes Literals converted to shielded fixed bytes will leak during contract deployment.
+// Warning 10313: (531-542): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (557-568): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
+// Warning 10313: (584-597): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/types/shielded_alias_internal_param_rejected.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_alias_internal_param_rejected.sol
@@ -24,4 +24,5 @@ contract C {
 // ----
 // Warning 10305: (17-30): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 9553: (502-515): Invalid type for argument in function call. Invalid implicit conversion from bytes storage pointer to bytes storage pointer requested. Cannot mix shielded and non-shielded storage byte arrays: a reference into shielded storage is not interchangeable with a plain bytes/string storage reference.
+// Warning 10313: (502-515): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
 // TypeError 9553: (651-652): Invalid type for argument in function call. Invalid implicit conversion from bytes storage pointer to bytes storage pointer requested. Cannot mix shielded and non-shielded storage byte arrays: a reference into shielded storage is not interchangeable with a plain bytes/string storage reference.

--- a/test/libsolidity/syntaxTests/types/shielded_literal_return_cast.sol
+++ b/test/libsolidity/syntaxTests/types/shielded_literal_return_cast.sol
@@ -12,5 +12,6 @@ contract C {
 // ----
 // Warning 10416: (168-171): Shielded number literals will leak during contract deployment.
 // TypeError 9640: (160-172): Explicit type conversion not allowed from "shielded_int_const 42" to "uint256".
+// Warning 10313: (160-172): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
 // Warning 10416: (319-322): Shielded number literals will leak during contract deployment.
 // TypeError 6359: (319-322): Return argument type shielded_int_const 42 is not implicitly convertible to expected type (type of first return variable) uint256. Shielded number literal cannot be implicitly converted to non-shielded type.


### PR DESCRIPTION
Fixes #376

Warning 10313 only fired when a shielded-to-public cast was a direct argument of `emit`/`revert`/`require`. It was silent for returns, assignments, ternary branches, arithmetic identities (`uint256(secret) + 0`), and non-pointer byte-array copies — every other declassification form.

## Change
`checkShieldedLeakInPublicSink` is now value-based: it descends through `Conditional`, `BinaryOperation`, `TupleExpression`, and `FunctionCall` subtrees, and is invoked at returns and public-target assignments in addition to emit/revert/require. The message names all three sinks (logs, returndata, public storage). Reshielding (`sSecret = suint256(uint256(secret))`) stays silent — a shielded target is not a public sink. `pub = bytes(secret)` now warns, closing the silent byte-array declassification gap.

## Scope
- **Part 2 (reject the non-pointer sbytes->bytes copy in the type system) is intentionally not included.** It overturns a deliberate, runtime-tested feature (`copies stay allowed`, `shielded_inline_cast_sbytes_dynamic_edge_cases.sol`) and diverges from scalar declassification, which is allowed+warned. The auditor's own impact statement says this is a diagnostic gap "without affecting the correctness of the emitted opcodes" — so the warning (part 1) is the right-sized fix. Part 2 is a design question for the auditor.
- **Local-variable launder** (`uint x = uint(secret); emit Log(x)`) is not caught: at the declaration it false-positives on transient declassify-then-reshield locals; at the sink it needs def-use taint (shared with 3.14). Documented limitation.

## Tests
- New: `shielded_declassify_sinks.sol` (return/storage/ternary/arithmetic warn; reshield silent), `shielded_bytes_copy_public_warns.sol`.
- 36 existing shielded tests updated for the new/relocated 10313 (each a verified clean addition or message update; no masked regressions).
- Full syntax suite green. Warning-only, analysis phase — no codegen change, semantic output unaffected.