### PR TITLE
3.11: resolve inline-asm slot operand by value, not surface syntax

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1151,7 +1151,9 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 
 	// yul locals that currently alias a non-shielded state variable's .slot (let s := pub.slot),
 	// so cstore(s, v) is flagged too. Reassigning the local to anything else clears the alias.
+	// shieldedSlotAliases mirrors it for shielded .slot references (let s := secret.slot).
 	std::set<std::string> slotAliases;
+	std::set<std::string> shieldedSlotAliases;
 
 	// Track storage operations: slot key -> (isShielded, location, funcName)
 	struct StorageOp {
@@ -1175,10 +1177,41 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 		return std::nullopt;
 	};
 
-	// Whether a slot operand resolves to a non-shielded state variable's slot, through any of the
-	// statically-visible spellings: a direct .slot reference, a yul local aliasing one, or a bare
-	// literal slot number. Runtime-computed slots (keccak256, arithmetic) are not classifiable.
-	auto slotTargetsPublicStateVar = [&](yul::Expression const& _slot) -> bool {
+	auto typeIsShielded = [](VariableDeclaration const* _var) -> bool {
+		return _var && _var->annotation().type &&
+			(_var->annotation().type->isShielded() || _var->annotation().type->containsShieldedType());
+	};
+
+	// Classify a slot operand's domain by the value it computes (identifier, yul alias, literal,
+	// local storage pointer, or arithmetic/hash wrapper), not its surface syntax.
+	std::function<bool(yul::Expression const&)> slotIsShielded;
+	std::function<bool(yul::Expression const&)> slotIsPublic;
+	slotIsShielded = [&](yul::Expression const& _slot) -> bool {
+		if (auto const* ident = std::get_if<yul::Identifier>(&_slot))
+		{
+			auto it = externalRefs.find(ident);
+			if (it != externalRefs.end())
+			{
+				if (it->second.suffix == "slot")
+				{
+					if (it->second.isShieldedStorage)
+						return true;
+					// local storage pointer into shielded storage (S storage ptr, S contains shielded)
+					if (auto const* var = dynamic_cast<VariableDeclaration const*>(it->second.declaration))
+						if (!var->isStateVariable() && typeIsShielded(var))
+							return true;
+				}
+				return false;
+			}
+			return shieldedSlotAliases.count(ident->name.str()) > 0;
+		}
+		if (auto const* funCall = std::get_if<yul::FunctionCall>(&_slot))
+			for (auto const& arg: funCall->arguments)
+				if (slotIsShielded(arg))
+					return true;
+		return false;
+	};
+	slotIsPublic = [&](yul::Expression const& _slot) -> bool {
 		if (auto const* lit = std::get_if<yul::Literal>(&_slot))
 			return lit->kind == yul::LiteralKind::Number && publicSlots.count(lit->value.value()) > 0;
 		if (auto const* ident = std::get_if<yul::Identifier>(&_slot))
@@ -1186,13 +1219,19 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 			auto it = externalRefs.find(ident);
 			if (it != externalRefs.end())
 			{
+				// Public only when the type is non-shielded; keying on isStateVariable alone would
+				// misflag cstore(keccak(sbytes.slot, i)) on a shielded dynamic array's element.
 				if (it->second.suffix == "slot" && !it->second.isShieldedStorage)
 					if (auto const* var = dynamic_cast<VariableDeclaration const*>(it->second.declaration))
-						return var->isStateVariable();
+						return !typeIsShielded(var);
 				return false;
 			}
 			return slotAliases.count(ident->name.str()) > 0;
 		}
+		if (auto const* funCall = std::get_if<yul::FunctionCall>(&_slot))
+			for (auto const& arg: funCall->arguments)
+				if (slotIsPublic(arg))
+					return true;
 		return false;
 	};
 
@@ -1206,26 +1245,20 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 		{
 			auto const& slotExpr = funCall->arguments.front();
 
-			// Check for external identifier referencing shielded variable with wrong op
+			// Reject sstore/sload against a shielded slot (resolved by value, not just a bare identifier).
 			if (isNonShieldedOp)
 			{
-				if (auto const* slotIdent = std::get_if<yul::Identifier>(&slotExpr))
-				{
-					auto it = externalRefs.find(slotIdent);
-					if (it != externalRefs.end() && it->second.isShieldedStorage)
-					{
-						m_errorReporter.typeError(
-							10308_error,
-							nativeLocationOf(*funCall),
-							std::string("Cannot use ") + std::string(funcName) + "() on shielded storage variable. Use " +
-							(funcName == "sstore" ? "cstore" : "cload") + "() instead."
-						);
-					}
-				}
+				if (slotIsShielded(slotExpr))
+					m_errorReporter.typeError(
+						10308_error,
+						nativeLocationOf(*funCall),
+						std::string("Cannot use ") + std::string(funcName) + "() on shielded storage variable. Use " +
+						(funcName == "sstore" ? "cstore" : "cload") + "() instead."
+					);
 			}
 			// cload only reads — it never claims a slot for the confidential domain, so it is safe
 			// on a public slot. Only cstore bricks a public slot, so 10314 is cstore-only.
-			else if (funcName == "cstore" && slotTargetsPublicStateVar(slotExpr))
+			else if (funcName == "cstore" && slotIsPublic(slotExpr))
 				m_errorReporter.typeError(
 					10314_error,
 					nativeLocationOf(*funCall),
@@ -1261,22 +1294,29 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 				[&](yul::VariableDeclaration const& _varDecl) {
 					if (_varDecl.value)
 						walkExpression(*_varDecl.value);
-					// let s := pub.slot  -> s now aliases a public slot.
-					if (_varDecl.value && _varDecl.variables.size() == 1 && slotTargetsPublicStateVar(*_varDecl.value))
-						slotAliases.insert(_varDecl.variables.front().name.str());
+					// let s := pub.slot / secret.slot  -> s now aliases that slot's domain.
+					if (_varDecl.value && _varDecl.variables.size() == 1)
+					{
+						std::string const name = _varDecl.variables.front().name.str();
+						if (slotIsShielded(*_varDecl.value))
+							shieldedSlotAliases.insert(name);
+						else if (slotIsPublic(*_varDecl.value))
+							slotAliases.insert(name);
+					}
 				},
 				[&](yul::Assignment const& _assignment) {
 					if (_assignment.value)
 						walkExpression(*_assignment.value);
-					// Reassignment updates the alias: track it if the new value is a public slot,
-					// otherwise the local no longer aliases one.
+					// Reassignment retracks the alias to the new value's domain (or clears it).
 					if (_assignment.variableNames.size() == 1)
 					{
 						std::string const name = _assignment.variableNames.front().name.str();
-						if (_assignment.value && slotTargetsPublicStateVar(*_assignment.value))
+						shieldedSlotAliases.erase(name);
+						slotAliases.erase(name);
+						if (_assignment.value && slotIsShielded(*_assignment.value))
+							shieldedSlotAliases.insert(name);
+						else if (_assignment.value && slotIsPublic(*_assignment.value))
 							slotAliases.insert(name);
-						else
-							slotAliases.erase(name);
 					}
 				},
 				[&](yul::If const& _if) {

--- a/test/libsolidity/syntaxTests/inlineAssembly/cstore_public_via_local_storage_pointer.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/cstore_public_via_local_storage_pointer.sol
@@ -1,0 +1,10 @@
+contract Q {
+    struct S { uint256 v; }
+    S public x;
+    function test() public {
+        S storage ptr = x;
+        assembly { cstore(ptr.slot, 99) }
+    }
+}
+// ----
+// TypeError 10314: (132-152): Cannot use cstore() on non-shielded storage variable. Use sstore() instead.

--- a/test/libsolidity/syntaxTests/inlineAssembly/shielded_slot_arithmetic_and_alias.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/shielded_slot_arithmetic_and_alias.sol
@@ -1,0 +1,12 @@
+contract C {
+    suint256 secret;
+    function viaComputedSlot() external view returns (uint256 r) {
+        assembly { r := sload(add(secret.slot, 0)) }
+    }
+    function viaAlias() external view returns (uint256 r) {
+        assembly { let s := secret.slot r := sload(s) }
+    }
+}
+// ----
+// TypeError 10308: (125-151): Cannot use sload() on shielded storage variable. Use cload() instead.
+// TypeError 10308: (265-273): Cannot use sload() on shielded storage variable. Use cload() instead.


### PR DESCRIPTION
Fixes #378

The inline-assembly storage-domain checks (10308 sstore/sload on a shielded slot; 10314 cstore on a public slot) matched the slot operand only as a bare identifier or literal, so three spellings of the same slot bypassed them: a computed slot `add(secret.slot, 0)`, a yul alias `let s := secret.slot`, and a Solidity local storage pointer `S storage ptr = x; cstore(ptr.slot, ...)`.

## Change
`slotTargetsPublicStateVar` is replaced by recursive `slotIsShielded`/`slotIsPublic` resolvers that classify by the value the operand computes:
- recurse through arithmetic/hash wrappers (`add`, `keccak256`, …);
- `shieldedSlotAliases` mirrors the existing public `slotAliases` (both maintained in the yul var-decl/assignment walk);
- a local storage pointer's `.slot` is classified by its storage type (its domain is its type; `VariableDeclaration::value()` is null for locals, so following the initializer isn't viable).

The public classification now keys on the variable's type rather than `isStateVariable()`, so a computed element slot on a shielded dynamic array (`cstore(keccak(sbytes.slot, i))`) is not mis-flagged as public.

## Tests
- `shielded_slot_arithmetic_and_alias.sol` — computed slot + yul alias, 10308 x2.
- `cstore_public_via_local_storage_pointer.sol` — local storage pointer, 10314.
- All three finding PoCs now diagnosed; full syntax suite green (0 fail); no inline-asm semantic test newly rejected.