### PR TITLE
3.9: support sbytes -> sbytesN from memory/calldata, reject from storage

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1985,7 +1985,17 @@ BoolResult ArrayType::isExplicitlyConvertibleTo(Type const& _convertTo) const
 		if (_convertTo.category() == Type::Category::FixedBytes)
 			return !baseType()->isShielded();
 		if (_convertTo.category() == Type::Category::ShieldedFixedBytes)
-			return baseType()->isShielded();
+		{
+			if (!baseType()->isShielded())
+				return false;
+			// Storage source needs an unimplemented shielded read; memory/calldata is a plain copy.
+			if (location() == DataLocation::Storage)
+				return BoolResult::err(
+					"Conversion of a shielded byte array in storage to a fixed shielded-bytes type "
+					"is not supported; copy it to memory first (e.g. sbytesN(sbytes memory))."
+				);
+			return true;
+		}
 		return false;
 	}
 	auto& convertTo = dynamic_cast<ArrayType const&>(_convertTo);

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -1035,7 +1035,11 @@ void CompilerUtils::convertType(
 	case Type::Category::Array:
 	{
 		auto const& typeOnStack = dynamic_cast<ArrayType const&>(_typeOnStack);
-		if (_targetType.category() == Type::Category::FixedBytes)
+		// sbytes -> sbytesN shares the bytes -> bytesN path (ShieldedFixedBytesType derives from FixedBytesType).
+		if (
+			_targetType.category() == Type::Category::FixedBytes ||
+			_targetType.category() == Type::Category::ShieldedFixedBytes
+		)
 		{
 			solAssert(
 				typeOnStack.isByteArray(),
@@ -1165,7 +1169,10 @@ void CompilerUtils::convertType(
 	case Type::Category::ArraySlice:
 	{
 		auto& typeOnStack = dynamic_cast<ArraySliceType const&>(_typeOnStack);
-		if (_targetType.category() == Type::Category::FixedBytes)
+		if (
+			_targetType.category() == Type::Category::FixedBytes ||
+			_targetType.category() == Type::Category::ShieldedFixedBytes
+		)
 		{
 			solAssert(
 				typeOnStack.arrayType().isByteArray(),

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -3604,7 +3604,7 @@ std::string YulUtilFunctions::conversionFunction(Type const& _from, Type const& 
 	else if (_from.category() == Type::Category::ArraySlice)
 	{
 		auto const& fromType = dynamic_cast<ArraySliceType const&>(_from);
-		if (_to.category() == Type::Category::FixedBytes)
+		if (_to.category() == Type::Category::FixedBytes || _to.category() == Type::Category::ShieldedFixedBytes)
 		{
 			solAssert(fromType.arrayType().isByteArray(), "Array types other than bytes not convertible to bytesNN.");
 			return bytesToFixedBytesConversionFunction(fromType.arrayType(), dynamic_cast<FixedBytesType const &>(_to));
@@ -3644,7 +3644,7 @@ std::string YulUtilFunctions::conversionFunction(Type const& _from, Type const& 
 	else if (_from.category() == Type::Category::Array)
 	{
 		auto const& fromArrayType =  dynamic_cast<ArrayType const&>(_from);
-		if (_to.category() == Type::Category::FixedBytes)
+		if (_to.category() == Type::Category::FixedBytes || _to.category() == Type::Category::ShieldedFixedBytes)
 		{
 			solAssert(fromArrayType.isByteArray(), "Array types other than bytes not convertible to bytesNN.");
 			return bytesToFixedBytesConversionFunction(fromArrayType, dynamic_cast<FixedBytesType const &>(_to));

--- a/test/libsolidity/semanticTests/types/shielded_sbytes_memory_to_fixed.sol
+++ b/test/libsolidity/semanticTests/types/shielded_sbytes_memory_to_fixed.sol
@@ -1,0 +1,28 @@
+contract C {
+    function full() public pure returns (bytes4) {
+        bytes memory b = hex"AABBCCDDEE";
+        sbytes memory sb = sbytes(b);
+        return bytes4(sbytes4(sb));
+    }
+    function shortInput() public pure returns (bytes4) {
+        bytes memory b = hex"AABB";
+        sbytes memory sb = sbytes(b);
+        return bytes4(sbytes4(sb));
+    }
+    // must match the public bytes -> bytesN result exactly
+    function publicBaseline() public pure returns (bytes4) {
+        bytes memory b = hex"AABBCCDDEE";
+        return bytes4(b);
+    }
+    // calldata slice source (ArraySlice path)
+    function fromCalldataSlice(sbytes calldata s) external pure returns (bytes4) {
+        return bytes4(sbytes4(s[0:4]));
+    }
+}
+// ====
+// EVMVersion: >=mercury
+// ----
+// full() -> 0xAABBCCDD00000000000000000000000000000000000000000000000000000000
+// shortInput() -> 0xAABB000000000000000000000000000000000000000000000000000000000000
+// publicBaseline() -> 0xAABBCCDD00000000000000000000000000000000000000000000000000000000
+// fromCalldataSlice(sbytes): 0x20, 5, 0xAABBCCDDEE000000000000000000000000000000000000000000000000000000 -> 0xAABBCCDD00000000000000000000000000000000000000000000000000000000

--- a/test/libsolidity/syntaxTests/types/sbytes_dynamic_conversions.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_dynamic_conversions.sol
@@ -14,9 +14,11 @@ contract C {
         sbytes memory s = sbytes(bdata);
     }
 
-    function testSbytesToSbytesNN() internal view {
-        // sbytes -> sbytesNN should be allowed (like bytes -> bytesNN)
+    function testSbytesToSbytesNN(sbytes memory m) internal view {
+        // sbytes -> sbytesNN allowed from memory, rejected from storage (needs a shielded read)
+        sbytes32 ok = sbytes32(m);
         sbytes32 x = sbytes32(sdata);
+        ok; x;
     }
 
     function testSbytesToBytesNN() internal view {
@@ -28,4 +30,5 @@ contract C {
 // Warning 10305: (17-29): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
 // TypeError 9574: (184-210): Type sbytes storage ref is not implicitly convertible to expected type bytes storage pointer. Cannot mix shielded and non-shielded storage byte arrays: a reference into shielded storage is not interchangeable with a plain bytes/string storage reference.
 // TypeError 9574: (220-247): Type bytes storage ref is not implicitly convertible to expected type sbytes storage pointer.
-// TypeError 9640: (776-790): Explicit type conversion not allowed from "sbytes storage ref" to "bytes32".
+// TypeError 9640: (687-702): Explicit type conversion not allowed from "sbytes storage ref" to "sbytes32". Conversion of a shielded byte array in storage to a fixed shielded-bytes type is not supported; copy it to memory first (e.g. sbytesN(sbytes memory)).
+// TypeError 9640: (866-880): Explicit type conversion not allowed from "sbytes storage ref" to "bytes32".

--- a/test/libsolidity/syntaxTests/types/sbytes_dynamic_to_fixed.sol
+++ b/test/libsolidity/syntaxTests/types/sbytes_dynamic_to_fixed.sol
@@ -1,17 +1,17 @@
-// Tests sbytes to sbytesN explicit conversion compiles
-// Adapted from array/bytes_to_fixed_bytes.sol
+// sbytes -> sbytesN: allowed from a memory/calldata source (plain byte copy),
+// rejected from storage (needs a shielded-layout read that is not implemented).
 contract C {
     sbytes s;
-    function f() internal view {
-        sbytes3 a = sbytes3(s);
-        sbytes8 b = sbytes8(s);
-        sbytes16 c = sbytes16(s);
-        sbytes32 d = sbytes32(s);
+    function fromMemory(sbytes memory m) internal pure {
+        sbytes3 a = sbytes3(m);
+        sbytes32 b = sbytes32(m);
+        a; b;
+    }
+    function fromStorage() internal view {
+        sbytes8 c = sbytes8(s);
+        c;
     }
 }
 // ----
-// Warning 10305: (120-128): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
-// Warning 2072: (171-180): Unused local variable.
-// Warning 2072: (203-212): Unused local variable.
-// Warning 2072: (235-245): Unused local variable.
-// Warning 2072: (269-279): Unused local variable.
+// Warning 10305: (177-185): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// TypeError 9640: (393-403): Explicit type conversion not allowed from "sbytes storage ref" to "sbytes8". Conversion of a shielded byte array in storage to a fixed shielded-bytes type is not supported; copy it to memory first (e.g. sbytesN(sbytes memory)).


### PR DESCRIPTION
Fixes #382

`sbytesN(sb)` type-checked but had no codegen branch in either backend, so it aborted with an InternalCompilerError — any contract using the pattern was uncompilable.

## Change
- **Memory/calldata source**: routed through the existing `bytesToFixedBytesConversionFunction` (mirrors `bytes -> bytesN`). Guards broadened for a `ShieldedFixedBytes` target in `CompilerUtils::convertType` (legacy) and `YulUtilFunctions::conversionFunction` (via-IR), for both `Array` and `ArraySlice` sources.
- **Storage source**: rejected in `ArrayType::isExplicitlyConvertibleTo` with a user-facing error. The public conversion machinery assumes the public bytes storage layout and returns `0` for a shielded storage source, so routing it there would turn the ICE into silent data corruption. A correct storage read needs a shielded-layout-aware `cload` (a real codegen feature); rejecting with a clear message and steering to the memory form is Zellic's sanctioned alternative.

## Verification
- New semantic test `shielded_sbytes_memory_to_fixed.sol`: memory + calldata-slice sources, checked against the public `bytesN` baseline across **all four** configs (legacy/via-IR × optimizer).
- `semanticTests/types` (135 files) + `conversions` (3) regression-swept clean.
- Full syntax suite green. The two updated syntax tests previously asserted the storage cast type-checks (syntax tests don't run codegen, so they never caught the crash); they now cover memory-allowed + storage-rejected.

## Scope note
This delivers the memory/calldata case (the finding's PoC) correctly and removes the crash for all forms. Direct-from-storage `sbytesN(storageSbytes)` is intentionally left as a follow-up feature (shielded storage-read codegen); it currently errors cleanly rather than crashing.