### PR TITLE
Backport Zellic fixes: P1/P4/3.10 onto seismic

### DIFF
--- a/libsolidity/analysis/DeclarationTypeChecker.cpp
+++ b/libsolidity/analysis/DeclarationTypeChecker.cpp
@@ -282,8 +282,8 @@ void DeclarationTypeChecker::endVisit(Mapping const& _mapping)
 	Type const* keyType = _mapping.keyType().annotation().type;
 	ASTString keyName = _mapping.keyName();
 
-	// Reject shielded types as mapping keys
-	if (keyType->isShielded())
+	// containsShieldedType also covers sbytes, whose ArrayType::isShielded() is false.
+	if (keyType->isShielded() || keyType->containsShieldedType())
 	{
 		m_errorReporter.fatalTypeError(
 			10109_error,

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -111,6 +111,22 @@ bool canPreserveShieldedStorageMarkerInAssignment(VariableDeclaration const& _va
 		_variable.referenceLocation() == VariableDeclaration::Location::Storage;
 }
 
+// 0 = not a byte-array/string storage ref, 1 = public, 2 = shielded.
+int byteStorageRefDomain(Type const& _type)
+{
+	auto const* arrayType = dynamic_cast<ArrayType const*>(&_type);
+	if (!arrayType || arrayType->location() != DataLocation::Storage || !arrayType->isByteArrayOrString())
+		return 0;
+	return arrayType->usesShieldedStorage() ? 2 : 1;
+}
+
+// The bytes(sbytesRef) alias form: shielded via the side-marker, not an intrinsic sbytes element.
+bool isShieldedByteStorageAlias(Type const& _type)
+{
+	auto const* arrayType = dynamic_cast<ArrayType const*>(&_type);
+	return arrayType && arrayType->location() == DataLocation::Storage && arrayType->hasShieldedStorageMarker();
+}
+
 FunctionDefinition const* internalFunctionDefinition(FunctionType const& _functionType)
 {
 	if (_functionType.kind() != FunctionType::Kind::Internal || !_functionType.hasDeclaration())
@@ -912,6 +928,27 @@ bool TypeChecker::visit(ErrorDefinition const& _errorDef)
 	return true;
 }
 
+void TypeChecker::checkByteStorageRefDomain(
+	VariableDeclaration const& _variable,
+	Type const& _sourceType,
+	SourceLocation const& _location
+)
+{
+	int const domain = byteStorageRefDomain(_sourceType);
+	if (domain == 0)
+		return;
+	auto& [seenShielded, seenPublic] = m_byteStorageRefDomains[&_variable];
+	(domain == 2 ? seenShielded : seenPublic) = true;
+	if (seenShielded && seenPublic)
+		m_errorReporter.typeError(
+			10112_error,
+			_location,
+			"This bytes/string storage reference aliases both shielded and non-shielded storage "
+			"on different paths. A storage reference must have a single confidentiality domain, "
+			"since the compiler selects cstore/cload or sstore/sload for it at compile time."
+		);
+}
+
 void TypeChecker::endVisit(FunctionTypeName const& _funType)
 {
 	FunctionType const& fun = dynamic_cast<FunctionType const&>(*_funType.annotation().type);
@@ -1502,15 +1539,34 @@ void TypeChecker::endVisit(Return const& _return)
 		m_errorReporter.typeError(7552_error, _return.location(), "Return arguments not allowed.");
 		return;
 	}
+	static std::string const shieldedAliasReturnError =
+		"A bytes/string storage reference aliasing shielded storage cannot be returned. "
+		"Return the shielded type (sbytes storage) or a memory copy (bytes memory) instead.";
 	TypePointers returnTypes;
 	if (auto tupleType = dynamic_cast<TupleType const*>(type(*_return.expression())))
 	{
 		for (size_t i = 0; i < std::min(tupleType->components().size(), params->parameters().size()); ++i)
 			if (tupleType->components()[i])
+			{
+				if (
+					params->parameters()[i]->referenceLocation() == VariableDeclaration::Location::Storage &&
+					isShieldedByteStorageAlias(*tupleType->components()[i])
+				)
+					m_errorReporter.typeError(10113_error, _return.location(), shieldedAliasReturnError);
 				preserveShieldedStorageMarkerInDeclaration(*params->parameters()[i], *tupleType->components()[i]);
+				checkByteStorageRefDomain(*params->parameters()[i], *tupleType->components()[i], _return.location());
+			}
 	}
 	else if (params->parameters().size() == 1)
+	{
+		if (
+			params->parameters().front()->referenceLocation() == VariableDeclaration::Location::Storage &&
+			isShieldedByteStorageAlias(*type(*_return.expression()))
+		)
+			m_errorReporter.typeError(10113_error, _return.location(), shieldedAliasReturnError);
 		preserveShieldedStorageMarkerInDeclaration(*params->parameters().front(), *type(*_return.expression()));
+		checkByteStorageRefDomain(*params->parameters().front(), *type(*_return.expression()), _return.location());
+	}
 
 	for (auto const& var: params->parameters())
 		returnTypes.push_back(type(*var));
@@ -1644,6 +1700,7 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 		Type const* valueComponentType = valueTypes[i];
 		solAssert(!!valueComponentType, "");
 		preserveShieldedStorageMarkerInDeclaration(var, *valueComponentType);
+		checkByteStorageRefDomain(var, *valueComponentType, var.location());
 		var.accept(*this);
 		BoolResult result = valueComponentType->isImplicitlyConvertibleTo(*var.annotation().type);
 		if (!result)
@@ -1843,6 +1900,27 @@ bool TypeChecker::visit(Assignment const& _assignment)
 		_assignment.annotation().type = TypeProvider::emptyTuple();
 
 		expectType(_assignment.rightHandSide(), *tupleType);
+		// Best-effort domain tracking for tuple component storage refs (seismic-compatible).
+		if (auto const* lhsTuple = dynamic_cast<TupleExpression const*>(&_assignment.leftHandSide()))
+		{
+			auto const& lhsComponents = lhsTuple->components();
+			auto const& rhsComponents = tupleType->components();
+			for (size_t i = 0; i < std::min(lhsComponents.size(), rhsComponents.size()); ++i)
+			{
+				if (!lhsComponents[i] || !rhsComponents[i])
+					continue;
+				auto const* identifier = dynamic_cast<Identifier const*>(lhsComponents[i].get());
+				if (!identifier)
+					continue;
+				auto const* variable = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration);
+				if (variable && canPreserveShieldedStorageMarkerInAssignment(*variable))
+				{
+					preserveShieldedStorageMarkerInDeclaration(*variable, *rhsComponents[i]);
+					checkByteStorageRefDomain(*variable, *rhsComponents[i], _assignment.location());
+					identifier->annotation().type = variable->annotation().type;
+				}
+			}
+		}
 	}
 	else if (_assignment.assignmentOperator() == Token::Assign)
 	{
@@ -1850,7 +1928,14 @@ bool TypeChecker::visit(Assignment const& _assignment)
 		if (auto const* identifier = dynamic_cast<Identifier const*>(&_assignment.leftHandSide()))
 			if (auto const* variable = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration))
 				if (canPreserveShieldedStorageMarkerInAssignment(*variable))
+				{
 					preserveShieldedStorageMarkerInDeclaration(*variable, *type(_assignment.rightHandSide()));
+					checkByteStorageRefDomain(*variable, *type(_assignment.rightHandSide()), _assignment.location());
+					// Sync the cached Identifier and Assignment types to the variable's post-preserve type.
+					identifier->annotation().type = variable->annotation().type;
+					t = variable->annotation().type;
+					_assignment.annotation().type = t;
+				}
 	}
 	else
 	{

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1525,6 +1525,23 @@ bool TypeChecker::visit(ForStatement const& _forStatement)
 	return false;
 }
 
+void TypeChecker::endVisit(FunctionDefinition const& _function)
+{
+	// Checked after the body so every assignment/return to a named return parameter has resolved.
+	for (ASTPointer<VariableDeclaration> const& param: _function.returnParameters())
+		if (
+			param->referenceLocation() == VariableDeclaration::Location::Storage &&
+			param->annotation().type &&
+			isShieldedByteStorageAlias(*param->annotation().type)
+		)
+			m_errorReporter.typeError(
+				10113_error,
+				param->location(),
+				"A bytes/string storage reference aliasing shielded storage cannot be returned. "
+				"Return the shielded type (sbytes storage) or a memory copy (bytes memory) instead."
+			);
+}
+
 void TypeChecker::endVisit(Return const& _return)
 {
 	ParameterList const* params = _return.annotation().functionReturnParameters;
@@ -1539,31 +1556,18 @@ void TypeChecker::endVisit(Return const& _return)
 		m_errorReporter.typeError(7552_error, _return.location(), "Return arguments not allowed.");
 		return;
 	}
-	static std::string const shieldedAliasReturnError =
-		"A bytes/string storage reference aliasing shielded storage cannot be returned. "
-		"Return the shielded type (sbytes storage) or a memory copy (bytes memory) instead.";
 	TypePointers returnTypes;
 	if (auto tupleType = dynamic_cast<TupleType const*>(type(*_return.expression())))
 	{
 		for (size_t i = 0; i < std::min(tupleType->components().size(), params->parameters().size()); ++i)
 			if (tupleType->components()[i])
 			{
-				if (
-					params->parameters()[i]->referenceLocation() == VariableDeclaration::Location::Storage &&
-					isShieldedByteStorageAlias(*tupleType->components()[i])
-				)
-					m_errorReporter.typeError(10113_error, _return.location(), shieldedAliasReturnError);
 				preserveShieldedStorageMarkerInDeclaration(*params->parameters()[i], *tupleType->components()[i]);
 				checkByteStorageRefDomain(*params->parameters()[i], *tupleType->components()[i], _return.location());
 			}
 	}
 	else if (params->parameters().size() == 1)
 	{
-		if (
-			params->parameters().front()->referenceLocation() == VariableDeclaration::Location::Storage &&
-			isShieldedByteStorageAlias(*type(*_return.expression()))
-		)
-			m_errorReporter.typeError(10113_error, _return.location(), shieldedAliasReturnError);
 		preserveShieldedStorageMarkerInDeclaration(*params->parameters().front(), *type(*_return.expression()));
 		checkByteStorageRefDomain(*params->parameters().front(), *type(*_return.expression()), _return.location());
 	}

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -922,6 +922,13 @@ void TypeChecker::endVisit(FunctionTypeName const& _funType)
 			solAssert(t->annotation().type, "Type not set for parameter.");
 			if (!t->annotation().type->interfaceType(false).get())
 				m_errorReporter.fatalTypeError(2582_error, t->location(), "Internal type cannot be used for external function type.");
+			if (t->annotation().type->containsShieldedType())
+				m_errorReporter.typeError(
+					10111_error,
+					t->location(),
+					"Shielded types cannot appear in the parameters or return values of an external function type. "
+					"The ABI encodes a function value as (address, selector) only and cannot enforce the shielded boundary across it."
+				);
 		}
 		solAssert(fun.interfaceType(false), "External function type uses internal types.");
 	}

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -137,6 +137,11 @@ private:
 	/// - sstore/sload is used on a shielded variable reference
 	/// - sstore/sload is used on a slot that was previously written with cstore
 	void validateShieldedStorageOps(InlineAssembly const& _inlineAssembly);
+	void checkByteStorageRefDomain(
+		VariableDeclaration const& _variable,
+		Type const& _sourceType,
+		langutil::SourceLocation const& _location
+	);
 	bool visit(IfStatement const& _ifStatement) override;
 	void endVisit(TryStatement const& _tryStatement) override;
 	bool visit(WhileStatement const& _whileStatement) override;
@@ -226,6 +231,9 @@ private:
 
 	langutil::EVMVersion m_evmVersion;
 	std::optional<uint8_t> m_eofVersion;
+
+	/// Per byte-array storage ref: {seenShielded, seenPublic}. Seeing both is a domain conflict.
+	std::map<VariableDeclaration const*, std::pair<bool, bool>> m_byteStorageRefDomains;
 
 	langutil::ErrorReporter& m_errorReporter;
 };

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -122,6 +122,7 @@ private:
 	void endVisit(InheritanceSpecifier const& _inheritance) override;
 	void endVisit(ModifierDefinition const& _modifier) override;
 	bool visit(FunctionDefinition const& _function) override;
+	void endVisit(FunctionDefinition const& _function) override;
 	void endVisit(ArrayTypeName const& _typeName) override;
 	bool visit(VariableDeclaration const& _variable) override;
 	void endVisit(StructDefinition const& _struct) override;

--- a/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_internal_returns.sol
+++ b/test/libsolidity/semanticTests/types/shielded_inline_cast_sbytes_dynamic_internal_returns.sol
@@ -1,4 +1,5 @@
-// Internal functions that return bytes storage aliases must preserve shielded storage ops.
+// Internal functions returning a shielded storage ref (sbytes storage) preserve shielded ops
+// regardless of definition order; the boundary reveal goes through bytes()/bytes memory.
 contract C {
     sbytes private left;
     sbytes private right;
@@ -20,33 +21,33 @@ contract C {
             longRight.push(sbytes1(bytes1(uint8(i + 0x31))));
     }
 
-    function pick(bool which) internal view returns (bytes storage ref) {
+    function pick(bool which) internal view returns (sbytes storage ref) {
         if (which)
-            ref = bytes(left);
+            ref = left;
         else
-            ref = bytes(right);
+            ref = right;
     }
 
-    function pickTagged(bool which) internal view returns (uint256, bytes storage ref) {
+    function pickTagged(bool which) internal view returns (uint256, sbytes storage ref) {
         if (which)
-            return (1, bytes(left));
-        return (2, bytes(right));
+            return (1, left);
+        return (2, right);
     }
 
-    function pickLong(bool which) internal view returns (bytes storage ref) {
+    function pickLong(bool which) internal view returns (sbytes storage ref) {
         if (which)
-            ref = bytes(longLeft);
+            ref = longLeft;
         else
-            ref = bytes(longRight);
+            ref = longRight;
     }
 
     function readPick(bool which) public view returns (bytes memory) {
-        bytes storage ref = pick(which);
-        return ref;
+        sbytes storage ref = pick(which);
+        return bytes(ref);
     }
 
     function readPickDirect(bool which) public view returns (bytes memory) {
-        return pick(which);
+        return bytes(pick(which));
     }
 
     function readViaTernary(bool which) public view returns (bytes memory) {
@@ -60,8 +61,8 @@ contract C {
     }
 
     function pushPick(bool which, bytes1 value) public {
-        bytes storage ref = pick(which);
-        ref.push(value);
+        sbytes storage ref = pick(which);
+        ref.push(sbytes1(value));
     }
 
     function pushViaTernary(bool which, bytes1 value) public {
@@ -89,22 +90,22 @@ contract C {
     }
 
     function readTaggedBytes(bool which) public view returns (bytes memory) {
-        (, bytes storage ref) = pickTagged(which);
-        return ref;
+        (, sbytes storage ref) = pickTagged(which);
+        return bytes(ref);
     }
 
     function readPickLong(bool which) public view returns (bytes memory) {
-        return pickLong(which);
+        return bytes(pickLong(which));
     }
 
     function readPickLongAt(bool which, uint256 i) public view returns (bytes1) {
-        bytes storage ref = pickLong(which);
-        return ref[i];
+        sbytes storage ref = pickLong(which);
+        return bytes1(ref[i]);
     }
 
     function pushPickLong(bool which, bytes1 value) public {
-        bytes storage ref = pickLong(which);
-        ref.push(value);
+        sbytes storage ref = pickLong(which);
+        ref.push(sbytes1(value));
     }
 
     function readDirectLongLeft() public view returns (bytes memory) {

--- a/test/libsolidity/syntaxTests/parsing/shielded_address_payable_function_type.sol
+++ b/test/libsolidity/syntaxTests/parsing/shielded_address_payable_function_type.sol
@@ -5,4 +5,6 @@ contract C {
     }
 }
 // ----
-// Warning 6321: (199-270): Unnamed return variable can remain unassigned. Add an explicit return with value to all non-reverting code paths or name the variable.
+// TypeError 10111: (113-129): Shielded types cannot appear in the parameters or return values of an external function type. The ABI encodes a function value as (address, selector) only and cannot enforce the shielded boundary across it.
+// TypeError 10111: (209-225): Shielded types cannot appear in the parameters or return values of an external function type. The ABI encodes a function value as (address, selector) only and cannot enforce the shielded boundary across it.
+// TypeError 10111: (291-307): Shielded types cannot appear in the parameters or return values of an external function type. The ABI encodes a function value as (address, selector) only and cannot enforce the shielded boundary across it.

--- a/test/libsolidity/syntaxTests/shieldedTypes/bytes_storage_ref_conflicting_domain.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/bytes_storage_ref_conflicting_domain.sol
@@ -1,0 +1,26 @@
+// A bytes/string storage reference must have one consistent storage domain. If it can alias
+// public storage on one path and shielded storage on another, codegen can only pick one
+// opcode (cstore/cload vs sstore/sload), so one path is silently wrong. Reject the mix.
+contract C {
+    bytes public pub;
+    sbytes private secret;
+
+    // if/else merge: public on one branch, shielded on the other.
+    function mixedBranch(bool which) external {
+        bytes storage r;
+        if (which) { r = pub; }
+        else { r = bytes(secret); }
+        r.push(0x42);
+    }
+
+    // straight-line reassignment across domains: same unsoundness.
+    function mixedReassign() external {
+        bytes storage r = pub;
+        r = bytes(secret);
+        r.push(0x42);
+    }
+}
+// ----
+// Warning 10305: (310-331): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// TypeError 10112: (521-538): This bytes/string storage reference aliases both shielded and non-shielded storage on different paths. A storage reference must have a single confidentiality domain, since the compiler selects cstore/cload or sstore/sload for it at compile time.
+// TypeError 10112: (718-735): This bytes/string storage reference aliases both shielded and non-shielded storage on different paths. A storage reference must have a single confidentiality domain, since the compiler selects cstore/cload or sstore/sload for it at compile time.

--- a/test/libsolidity/syntaxTests/shieldedTypes/bytes_storage_ref_single_domain_ok.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/bytes_storage_ref_single_domain_ok.sol
@@ -1,0 +1,24 @@
+// Negative control: single-domain storage references must keep compiling. Only a mix of
+// public and shielded sources is rejected (see bytes_storage_ref_conflicting_domain.sol).
+contract C {
+    bytes public pubA;
+    bytes public pubB;
+    sbytes private secretA;
+    sbytes private secretB;
+
+    function allPublicBranch(bool which) external {
+        bytes storage r;
+        if (which) { r = pubA; }
+        else { r = pubB; }
+        r.push(0x42);
+    }
+
+    function allShieldedReassign() external {
+        bytes storage r = bytes(secretA);
+        r = bytes(secretB);
+        r.push(0x42);
+    }
+}
+// ----
+// Warning 10305: (243-265): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// Warning 10305: (271-293): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.

--- a/test/libsolidity/syntaxTests/shieldedTypes/external_function_type_shielded_return.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/external_function_type_shielded_return.sol
@@ -1,0 +1,19 @@
+// An external function type cannot carry shielded types in its parameter or return list.
+// The ABI encodes a function value as (address, selector) only, so the shielded boundary
+// cannot be enforced across it: ordinary returndata could be decoded as a shielded value
+// and cstored, or a shielded value passed out as a public callback argument.
+contract C {
+    sbool private opened;
+
+    function open(function() external returns (sbool) policy) external {
+        opened = policy();
+    }
+
+    function takesShieldedArg(function(suint256) external cb) external {}
+
+    function() external returns (saddress) stored;
+}
+// ----
+// TypeError 10111: (435-440): Shielded types cannot appear in the parameters or return values of an external function type. The ABI encodes a function value as (address, selector) only and cannot enforce the shielded boundary across it.
+// TypeError 10111: (534-542): Shielded types cannot appear in the parameters or return values of an external function type. The ABI encodes a function value as (address, selector) only and cannot enforce the shielded boundary across it.
+// TypeError 10111: (603-611): Shielded types cannot appear in the parameters or return values of an external function type. The ABI encodes a function value as (address, selector) only and cannot enforce the shielded boundary across it.

--- a/test/libsolidity/syntaxTests/shieldedTypes/mapping_sbytes_key_rejected.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/mapping_sbytes_key_rejected.sol
@@ -1,0 +1,6 @@
+// sbytes as a mapping key must be rejected (key would be hashed in plaintext for slot derivation).
+contract C {
+    mapping(sbytes => uint256) m;
+}
+// ----
+// TypeError 10109: (125-131): Shielded types are not allowed as mapping keys.

--- a/test/libsolidity/syntaxTests/shieldedTypes/return_shielded_bytes_storage_alias.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/return_shielded_bytes_storage_alias.sol
@@ -37,5 +37,7 @@ contract C {
 }
 // ----
 // Warning 10305: (294-315): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// Warning 10313: (628-641): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
 // TypeError 10113: (596-609): A bytes/string storage reference aliasing shielded storage cannot be returned. Return the shielded type (sbytes storage) or a memory copy (bytes memory) instead.
 // TypeError 10113: (852-867): A bytes/string storage reference aliasing shielded storage cannot be returned. Return the shielded type (sbytes storage) or a memory copy (bytes memory) instead.
+// Warning 10313: (1303-1316): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/shieldedTypes/return_shielded_bytes_storage_alias.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/return_shielded_bytes_storage_alias.sol
@@ -37,7 +37,5 @@ contract C {
 }
 // ----
 // Warning 10305: (294-315): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
-// Warning 10313: (628-641): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.
 // TypeError 10113: (596-609): A bytes/string storage reference aliasing shielded storage cannot be returned. Return the shielded type (sbytes storage) or a memory copy (bytes memory) instead.
 // TypeError 10113: (852-867): A bytes/string storage reference aliasing shielded storage cannot be returned. Return the shielded type (sbytes storage) or a memory copy (bytes memory) instead.
-// Warning 10313: (1303-1316): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.

--- a/test/libsolidity/syntaxTests/shieldedTypes/return_shielded_bytes_storage_alias.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/return_shielded_bytes_storage_alias.sol
@@ -15,6 +15,11 @@ contract C {
         return bytes(secret); // rejected: shielded bytes-storage alias return
     }
 
+    // implicit return via named return parameter (no `return` statement) must also be rejected.
+    function getSecretImplicit() internal view returns (bytes storage r) {
+        r = bytes(secret);
+    }
+
     // sound: intrinsic shielded type, order-independent.
     function getSecretShielded() internal view returns (sbytes storage) {
         return secret;
@@ -32,4 +37,5 @@ contract C {
 }
 // ----
 // Warning 10305: (294-315): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
-// TypeError 10113: (621-641): A bytes/string storage reference aliasing shielded storage cannot be returned. Return the shielded type (sbytes storage) or a memory copy (bytes memory) instead.
+// TypeError 10113: (596-609): A bytes/string storage reference aliasing shielded storage cannot be returned. Return the shielded type (sbytes storage) or a memory copy (bytes memory) instead.
+// TypeError 10113: (852-867): A bytes/string storage reference aliasing shielded storage cannot be returned. Return the shielded type (sbytes storage) or a memory copy (bytes memory) instead.

--- a/test/libsolidity/syntaxTests/shieldedTypes/return_shielded_bytes_storage_alias.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/return_shielded_bytes_storage_alias.sol
@@ -1,0 +1,35 @@
+// A bytes(sbytesRef) alias relies on a side-marker to stay shielded; carrying it across a
+// function return is order-dependent and miscompiles when the callee is defined below its
+// caller. Reject it; the sound forms are sbytes storage (intrinsic) or bytes memory (a copy).
+contract C {
+    sbytes private secret;
+    bytes private pub;
+
+    // caller above callee (the forward-reference miscompile shape).
+    function exploit() external view returns (uint256) {
+        bytes storage r = getSecretAlias();
+        return r.length;
+    }
+
+    function getSecretAlias() internal view returns (bytes storage) {
+        return bytes(secret); // rejected: shielded bytes-storage alias return
+    }
+
+    // sound: intrinsic shielded type, order-independent.
+    function getSecretShielded() internal view returns (sbytes storage) {
+        return secret;
+    }
+
+    // sound: public storage ref.
+    function getPublic() internal view returns (bytes storage) {
+        return pub;
+    }
+
+    // sound: memory copy reveal.
+    function reveal() internal view returns (bytes memory) {
+        return bytes(secret);
+    }
+}
+// ----
+// Warning 10305: (294-315): Dynamic arrays with shielded element types store their length confidentially, but an upper bound on the length may still be observable through gas cost analysis.
+// TypeError 10113: (621-641): A bytes/string storage reference aliasing shielded storage cannot be returned. Return the shielded type (sbytes storage) or a memory copy (bytes memory) instead.


### PR DESCRIPTION
## Summary
Backports the already-merged Zellic audit-branch fixes for **P1**, **P4**, and **3.10** onto the public `seismic` branch.

These fixes currently live on `zellic-audit-april-2026` (PRs #355 / #357 / 3.10 commit) but are **not** on `seismic`. Public `ssolc` release `cd9163d` and `seismic@fd5f389` still accept the vulnerable patterns.

### Fixes included
| Finding | Error | Source commits (audit branch) |
|---------|-------|-------------------------------|
| **P4** external fn type with shielded params/returns | `10111` | `20dac6d2`, `07793730` (#355) |
| **3.10** `mapping(sbytes => …)` key | `10109` via `containsShieldedType()` | `bd09d19c`, `0b5da53f` |
| **P1** mixed-domain `bytes/string storage` refs + shielded alias return | `10112` / `10113` | `3c7b48b1`, `562d2a88`, `90e8e618` (#357) |

### Seismic-specific adjustments
- Dropped `sbytes_tuple_assignment_marker.sol` conversion (file not on `seismic` tip).
- Assignment visitor keeps `seismic`'s `expectType` shape; wires in `checkByteStorageRefDomain` without pulling later audit-only assignment rewrites.
- Stripped `10313` declassification expectations (warning not present on `seismic` tip yet).

### Independent verification (pre-fix, public release)
Against `ssolc 0.8.31-develop.2026.4.29+commit.cd9163d8` + `seismic-revm` revme:
- P1 empty public `bytes` → CSTORE claims slot → `sload`/getter **FAILURE**
- P4 `function() external returns (sbool)` launders public `bool` → **cstore**, `cload==1`
- 3.10 `mapping(sbytes => uint256)` still **compiles** on unfixed release

### Test plan
- [ ] CI syntax tests under `test/libsolidity/syntaxTests/shieldedTypes/`:
  - `external_function_type_shielded_return.sol`
  - `mapping_sbytes_key_rejected.sol`
  - `bytes_storage_ref_conflicting_domain.sol`
  - `bytes_storage_ref_single_domain_ok.sol`
  - `return_shielded_bytes_storage_alias.sol`
- [ ] Confirm unfixed patterns now reject with 10111 / 10109 / 10112 / 10113

Refs: #354 #356 #358, #355 #357