### PR TITLE
3.7 follow-up: stop duplicating error codes 4426/2326/7407 (re-fixes 3.19 regression)

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -5368,48 +5368,9 @@ bool TypeChecker::expectBoolOrShieldedBool(Expression const& _expression) {
 			);
 		return true;
 	}
-	// expectType would accept() a second time (SetOnce reassign -> crash); inline its check.
-	Type const& expectedType = *TypeProvider::boolean();
-	BoolResult result = condType->isImplicitlyConvertibleTo(expectedType);
-	if (!result)
-	{
-		auto errorMsg = "Type " +
-			condType->humanReadableName() +
-			" is not implicitly convertible to expected type " +
-			expectedType.humanReadableName();
-		if (
-			condType->category() == Type::Category::RationalNumber &&
-			dynamic_cast<RationalNumberType const*>(condType)->isFractional() &&
-			condType->mobileType()
-		)
-		{
-			if (expectedType.operator==(*condType->mobileType()))
-				m_errorReporter.typeError(
-					4426_error,
-					_expression.location(),
-					errorMsg + ", but it can be explicitly converted."
-				);
-			else
-				m_errorReporter.typeErrorConcatenateDescriptions(
-					2326_error,
-					_expression.location(),
-					errorMsg +
-					". Try converting to type " +
-					condType->mobileType()->humanReadableName() +
-					" or use an explicit conversion.",
-					result.message()
-				);
-		}
-		else
-			m_errorReporter.typeErrorConcatenateDescriptions(
-				7407_error,
-				_expression.location(),
-				errorMsg + ".",
-				result.message()
-			);
-		return false;
-	}
-	return true;
+	// Already accepted above; checkImplicitConversion does not accept, so calling it directly
+	// avoids the double-visit crash without duplicating its 4426/2326/7407 error sites.
+	return checkImplicitConversion(_expression, *TypeProvider::boolean());
 }
 
 


### PR DESCRIPTION
Auditor follow-up on 3.7. The 3.7 ICE fix (89f5c943d) inlined the body of `checkImplicitConversion` into `expectBoolOrShieldedBool` to avoid a second `accept()`. But that copied error codes 4426/2326/7407 to a second source site, so `scripts/error_codes.py --check` fails again — exactly the duplicate-ID problem 3.19 fixed.

At the time, `checkImplicitConversion` did not yet exist as a standalone method; it has since been split out of `expectType` and, crucially, does **not** call `accept()`. So the clean fix is to call it directly:

```cpp
return checkImplicitConversion(_expression, *TypeProvider::boolean());
```

`expectBoolOrShieldedBool` already does the single `accept()` at the top, so this keeps the ICE fixed (no double-visit) while removing the duplicate code sites.

## Verification
- `error_codes.py --check`: 4426/2326/7407 no longer duplicated (the 10002/10312 dups are separately handled by 3.19, already merged).
- `non_bool_condition_no_crash.sol` still passes (ICE stays fixed; correct 7407 diagnostic).
- Full syntax suite green.

No new .sol test: the invariant is enforced by `error_codes.py --check`, not the .sol suites (which is why the original regression slipped past functional tests). Recommend wiring that check into CI.