### PR TITLE
3.5 follow-up: shift by a shielded amount yields a shielded result (mirror exp)

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2135,17 +2135,6 @@ bool TypeChecker::visit(Assignment const& _assignment)
 				type(_assignment.rightHandSide())->humanReadableName() +
 				"."
 			);
-		if (
-			resultType && *resultType == *t &&
-			TokenTraits::isShiftOp(binaryOp) &&
-			rhsType->category() == Type::Category::ShieldedInteger &&
-			t->category() != Type::Category::ShieldedInteger
-		)
-			m_errorReporter.warning(
-				10312_error,
-				_assignment.location(),
-				"Shielded integer shift count can leak through the public shift result."
-			);
 	}
 
 	// A cast to a public target leaks into public storage; a shielded target (reshield) does not.
@@ -2547,16 +2536,6 @@ void TypeChecker::endVisit(BinaryOperation const& _operation)
 		);
 	}
 
-	if (
-		TokenTraits::isShiftOp(_operation.getOperator()) &&
-		rightType->category() == Type::Category::ShieldedInteger &&
-		commonType->category() != Type::Category::ShieldedInteger
-	)
-		m_errorReporter.warning(
-			10315_error,
-			_operation.location(),
-			"Shielded integer shift count can leak through the public shift result."
-		);
 
 	if (
 		(_operation.getOperator() == Token::And || _operation.getOperator() == Token::Or) &&

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -752,10 +752,15 @@ TypeResult IntegerType::binaryOperatorResult(Token _operator, Type const* _other
 	if (TokenTraits::isShiftOp(_operator))
 	{
 		// Shifts are not symmetric with respect to the type
-		if (isValidShiftAndAmountType(_operator, *_other))
-			return this;
-		else
+		if (!isValidShiftAndAmountType(_operator, *_other))
 			return nullptr;
+		// Shielded shift amount -> shielded result, so a public return errors (mirrors exp).
+		if (dynamic_cast<ShieldedIntegerType const*>(_other))
+			return TypeProvider::shieldedInteger(
+				numBits(),
+				isSigned() ? ShieldedIntegerType::Modifier::Signed : ShieldedIntegerType::Modifier::Unsigned
+			);
+		return this;
 	}
 	else if (Token::Exp == _operator)
 	{

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_shift_leak.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_shift_leak.sol
@@ -1,3 +1,5 @@
+// Shifting a public value by a shielded amount yields a shielded result, so it cannot flow to a
+// public destination (mirrors public ** shielded). The prior warning-only leak is now an error.
 contract C {
     suint8 private secret;
     uint256 a;
@@ -9,7 +11,7 @@ contract C {
     }
 }
 // ----
-// Warning 10312: (89-101): Shielded integer shift count can leak through the public shift result.
-// Warning 10315: (115-126): Shielded integer shift count can leak through the public shift result.
-// Warning 10312: (136-148): Shielded integer shift count can leak through the public shift result.
-// Warning 10315: (162-173): Shielded integer shift count can leak through the public shift result.
+// TypeError 7366: (283-295): Operator <<= not compatible with types uint256 and suint8.
+// TypeError 7407: (309-320): Type suint256 is not implicitly convertible to expected type uint256.
+// TypeError 7366: (330-342): Operator >>= not compatible with types uint256 and suint8.
+// TypeError 7407: (356-367): Type suint256 is not implicitly convertible to expected type uint256.

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_shift_public_result_rejected.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_shift_public_result_rejected.sol
@@ -1,0 +1,19 @@
+contract C {
+    suint8 private secret;
+    suint256 stored;
+    // public value shifted by a shielded amount -> shielded result -> cannot be returned publicly
+    function leakReturn(uint256 base) external view returns (uint256) {
+        return base << secret;
+    }
+    function leakAssign(uint256 base) external view returns (uint256 r) {
+        r = base << secret;
+    }
+    // shifting in a shielded context stays legal
+    function shieldedOk() external {
+        suint256 x;
+        stored = x << secret;
+    }
+}
+// ----
+// TypeError 6359: (247-261): Return argument type suint256 is not implicitly convertible to expected type (type of first return variable) uint256.
+// TypeError 7407: (355-369): Type suint256 is not implicitly convertible to expected type uint256.

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_shift_public_result_rejected.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_shift_public_result_rejected.sol
@@ -13,6 +13,10 @@ contract C {
         suint256 x;
         stored = x << secret;
     }
+    // public base shifted by a shielded amount -> shielded result, legal into a shielded sink
+    function publicBaseIntoShielded(uint256 base) external {
+        stored = base << secret;
+    }
 }
 // ----
 // TypeError 6359: (247-261): Return argument type suint256 is not implicitly convertible to expected type (type of first return variable) uint256.


### PR DESCRIPTION
Fixes #386

After 3.5, `public ** shielded` hard-errors (shielded exponent -> shielded result), but `public << shielded` stayed warning-only and still compiled — the same recoverable leak (attacker reads `1 << secret`, log2 recovers the count).

## Change
- `IntegerType::binaryOperatorResult` shift branch: a `ShieldedIntegerType` shift amount now yields a shielded result (base width/signedness preserved), so `public << shielded` is `suintN` and errors on a public return/assignment — symmetric with exp.
- Removed the now-unreachable shift-leak warnings **10315** (binary) and **10312** (compound): once the result is shielded, the "public result with shielded amount" scenario they warned about is impossible. Verified nothing in the suite triggers them anymore.

## Verification
- New `shielded_shift_public_result_rejected.sol`: public return (6359) and public assign (7407) rejected; a shielded-context shift still compiles.
- `shielded_shift_leak.sol` updated to the type-error behavior.
- Full syntax suite green. **Full semantic suite (1922 files) green** — no shielded shift test regressed (a result-type change doesn't alter the emitted shift; it only blocks flow to a public sink).
- `error_codes.py --check`: 10312/10315 removed with no orphan. (The 2326/4426/7407 dups it currently reports are the separate pending 3.7 fix #385, not this PR.)

Verified in an isolated worktree, not the shared checkout.