### PR TITLE
3.16 follow-up: correct for-loop pre/condition scoping in 10309 detector

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1397,11 +1397,13 @@ void TypeChecker::validateShieldedStorageOps(InlineAssembly const& _inlineAssemb
 					}
 				},
 				[&](yul::ForLoop const& _forLoop) {
-					if (_forLoop.condition)
-						walkExpression(*_forLoop.condition);
+					// pre runs once before the loop (straight-line); condition/body/post run each
+					// iteration, so only they carry the loop id for cross-iteration conflicts.
+					collectStorageOps(_forLoop.pre);
 					unsigned const loopId = scopeCounter++;
 					currentLoops.insert(loopId);
-					collectStorageOps(_forLoop.pre);
+					if (_forLoop.condition)
+						walkExpression(*_forLoop.condition);
 					collectStorageOps(_forLoop.body);
 					collectStorageOps(_forLoop.post);
 					currentLoops.erase(loopId);

--- a/test/libsolidity/syntaxTests/inlineAssembly/cstore_sload_loop_condition_and_pre.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/cstore_sload_loop_condition_and_pre.sol
@@ -1,0 +1,12 @@
+contract C {
+    // loop-condition sload conflicts with a body cstore across iterations (was a false negative)
+    function conditionConflict(uint256 x) external {
+        assembly { for {} gt(sload(0), 5) {} { cstore(0, x) } }
+    }
+    // pre-block runs once, so its sload does not conflict with a body cstore (was a false positive)
+    function preNoConflict(uint256 n, uint256 x) external returns (uint256 r) {
+        assembly { for { r := sload(1) } lt(r, n) {} { cstore(1, x) } }
+    }
+}
+// ----
+// TypeError 10309: (193-201): Cannot use sload() on a slot that was previously written with cstore(). cstore() makes the slot private, and sload() cannot access private storage. Use cload() instead.


### PR DESCRIPTION
Fixes #388

My 3.16 loop-scoping mis-tagged the for-loop parts:
- **FP (rejected valid code):** `pre` runs once but was tagged in-loop, so `for { r := sload(0) } … { cstore(0, x) }` wrongly errored 10309.
- **FN:** `condition` runs each iteration but was walked outside the loop scope, so `for {} gt(sload(0), 5) {} { cstore(0, x) }` (a real cross-iteration conflict) was silent.

## Change
`pre` is collected before the loop id is pushed (straight-line, runs once); `condition`/`body`/`post` are collected inside the loop scope (per-iteration).

## Verification
- New `cstore_sload_loop_condition_and_pre.sol`: condition-sload flagged, pre-block sload clean.
- Existing 3.16 tests still pass; full syntax suite green; `error_codes.py --check` clean for 10309; no inline-asm semantic test newly errors on 10309.

Verified in an isolated worktree.