### PR TITLE
3.12 follow-up: walk UnaryOperation in the 10313 declassification check

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -5249,6 +5249,8 @@ void TypeChecker::checkShieldedLeakInPublicSink(Expression const& _expression)
 		checkShieldedLeakInPublicSink(binaryOperation->leftExpression());
 		checkShieldedLeakInPublicSink(binaryOperation->rightExpression());
 	}
+	else if (auto const* unaryOperation = dynamic_cast<UnaryOperation const*>(&_expression))
+		checkShieldedLeakInPublicSink(unaryOperation->subExpression());
 	else if (auto const* tuple = dynamic_cast<TupleExpression const*>(&_expression))
 	{
 		for (auto const& component: tuple->components())

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_declassify_unary.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_declassify_unary.sol
@@ -1,0 +1,8 @@
+contract C {
+    suint256 secret;
+    function f() external view returns (uint256) {
+        return ~uint256(secret);
+    }
+}
+// ----
+// Warning 10313: (101-116): Converting a shielded value to a public type declassifies it; the public value can leak through logs, returndata, or public storage.


### PR DESCRIPTION
Fixes #390

The value-based 10313 walk covered `FunctionCall`/`Conditional`/`BinaryOperation`/`TupleExpression` but not `UnaryOperation`, so `return ~uint256(secret)` was silent. One `else if` recurses into the unary sub-expression.

## Verification
- `shielded_declassify_unary.sol` (new): `~uint256(secret)` warns 10313.
- Full syntax suite green; `error_codes.py --check` clean. Warning-only, no codegen change.

The remaining 3.12 sub-cases (local-variable launder, call arg, statement condition) stay ACK/documented — def-use taint / 10311 overlap (shared with 3.14). Verified in an isolated worktree.