### PR TITLE
3.5 follow-up (regression): FixedBytes shift by a shielded amount must yield a shielded result

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1599,10 +1599,12 @@ TypeResult FixedBytesType::binaryOperatorResult(Token _operator, Type const* _ot
 {
 	if (TokenTraits::isShiftOp(_operator))
 	{
-		if (isValidShiftAndAmountType(_operator, *_other))
-			return this;
-		else
+		if (!isValidShiftAndAmountType(_operator, *_other))
 			return nullptr;
+		// Shielded shift amount -> shielded result, so a public sink errors (mirrors IntegerType).
+		if (dynamic_cast<ShieldedIntegerType const*>(_other))
+			return TypeProvider::shieldedFixedBytes(numBytes());
+		return this;
 	}
 
 	auto commonType = dynamic_cast<FixedBytesType const*>(Type::commonType(this, _other));

--- a/test/libsolidity/semanticTests/types/shielded_fixed_bytes_shift.sol
+++ b/test/libsolidity/semanticTests/types/shielded_fixed_bytes_shift.sol
@@ -1,0 +1,15 @@
+contract C {
+    suint8 amount;
+    bytes32 base;
+    sbytes32 stored;
+    function run() public returns (bytes32) {
+        amount = suint8(4);
+        base = bytes32(uint256(0x11));
+        stored = base << amount;
+        return bytes32(stored);
+    }
+}
+// ====
+// EVMVersion: >=mercury
+// ----
+// run() -> 0x0000000000000000000000000000000000000000000000000000000000000110

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_fixed_bytes_shift_leak.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_fixed_bytes_shift_leak.sol
@@ -4,16 +4,26 @@ contract C {
     bytes32 public pub;
     sbytes32 private stored;
     event E(bytes32 v);
-    // bytesN shifted by a shielded amount yields a shielded fixed-bytes result: public sinks error
-    function ret() external view returns (bytes32) { return bs << secret; }
-    function store() external { pub = bs << secret; }
-    function ev() external { emit E(bs << secret); }
-    // shielded fixed-bytes sink is fine
+    error Err(bytes32 v);
+    function sink(bytes32 v) external {}
+    // bytesN << shielded yields sbytesN, so every public sink rejects it:
+    function retSink() external view returns (bytes32) { return bs << secret; }
+    function storeSink() external { pub = bs << secret; }
+    function compoundSink() external { pub <<= secret; }
+    function eventSink() external { emit E(bs << secret); }
+    function callSink() external { this.sink(bs << secret); }
+    function revertSink() external view { revert Err(bs << secret); }
+    // shielded fixed-bytes sink is legal; public shift amount is unaffected
     function shieldedOk() external { stored = bs << secret; }
-    // public shift amount is unaffected
     function publicOk(uint8 n) external view returns (bytes32) { return bs << n; }
+    // narrow width and right shift promote the same way
+    function narrowRightSink() external view returns (bytes1) { bytes1 b; return b >> secret; }
 }
 // ----
-// TypeError 6359: (301-313): Return argument type sbytes32 is not implicitly convertible to expected type (type of first return variable) bytes32.
-// TypeError 7407: (355-367): Type sbytes32 is not implicitly convertible to expected type bytes32.
-// TypeError 9553: (407-419): Invalid type for argument in function call. Invalid implicit conversion from sbytes32 to bytes32 requested.
+// TypeError 6359: (347-359): Return argument type sbytes32 is not implicitly convertible to expected type (type of first return variable) bytes32.
+// TypeError 7407: (405-417): Type sbytes32 is not implicitly convertible to expected type bytes32.
+// TypeError 7366: (460-474): Operator <<= not compatible with types bytes32 and suint8.
+// TypeError 9553: (521-533): Invalid type for argument in function call. Invalid implicit conversion from sbytes32 to bytes32 requested.
+// TypeError 9553: (583-595): Invalid type for argument in function call. Invalid implicit conversion from sbytes32 to bytes32 requested.
+// TypeError 9553: (653-665): Invalid type for argument in function call. Invalid implicit conversion from sbytes32 to bytes32 requested.
+// TypeError 6359: (1030-1041): Return argument type sbytes1 is not implicitly convertible to expected type (type of first return variable) bytes1.

--- a/test/libsolidity/syntaxTests/shieldedTypes/shielded_fixed_bytes_shift_leak.sol
+++ b/test/libsolidity/syntaxTests/shieldedTypes/shielded_fixed_bytes_shift_leak.sol
@@ -1,0 +1,19 @@
+contract C {
+    suint8 private secret;
+    bytes32 private bs;
+    bytes32 public pub;
+    sbytes32 private stored;
+    event E(bytes32 v);
+    // bytesN shifted by a shielded amount yields a shielded fixed-bytes result: public sinks error
+    function ret() external view returns (bytes32) { return bs << secret; }
+    function store() external { pub = bs << secret; }
+    function ev() external { emit E(bs << secret); }
+    // shielded fixed-bytes sink is fine
+    function shieldedOk() external { stored = bs << secret; }
+    // public shift amount is unaffected
+    function publicOk(uint8 n) external view returns (bytes32) { return bs << n; }
+}
+// ----
+// TypeError 6359: (301-313): Return argument type sbytes32 is not implicitly convertible to expected type (type of first return variable) bytes32.
+// TypeError 7407: (355-367): Type sbytes32 is not implicitly convertible to expected type bytes32.
+// TypeError 9553: (407-419): Invalid type for argument in function call. Invalid implicit conversion from sbytes32 to bytes32 requested.


### PR DESCRIPTION
Fixes #393

The 3.5 fix (#387) promoted `IntegerType` shift results and removed the 10312/10315 shift-leak warnings as unreachable. That held for `IntegerType` and `RationalNumberType`, but `FixedBytesType::binaryOperatorResult` still returned the public `bytesN` for a shielded shift amount — so with the warning gone, `bytes32 << suint8` into a public sink became a **silent leak** (reproduced on the merged base: cload -> shl -> return, no diagnostic).

## Change
`FixedBytesType` shift branch now returns `TypeProvider::shieldedFixedBytes(numBytes())` when the amount is a `ShieldedIntegerType`, matching Integer/Rational. So `bytesN << shielded` is `sbytesN` and hard-errors on a public return/assignment/event/call-arg/revert. All three shift-capable types now promote, so 10312/10315 are genuinely unreachable (the #387 removal is now correct).

## Verification
- `shielded_fixed_bytes_shift_leak.sol` (syntax): sinks error (6359/7407/9553); shielded fixed-bytes sink and public shift amount compile.
- `shielded_fixed_bytes_shift.sol` (semantic): shielded-context shift round-trips correctly (0x11 << 4 = 0x110).
- Full syntax suite green; **full semantic suite (1923) green**; both pipelines compile the shielded path with no ICE; `error_codes.py --check` clean; public paths unaffected.

Verified in an isolated worktree.